### PR TITLE
fix(graph): theme edges for visibility

### DIFF
--- a/frontend/src/routes/collections/[id]/graph/+page.svelte
+++ b/frontend/src/routes/collections/[id]/graph/+page.svelte
@@ -67,6 +67,7 @@
     const ink = getThemeInk();
     renderer.setSetting('labelColor', { color: ink });
     renderer.setSetting('edgeLabelColor', { color: ink });
+    renderer.setSetting('defaultEdgeColor', ink);
   }
 
   onDestroy(() => {


### PR DESCRIPTION
Why:
- Edge lines were hard to see in dark mode.

What:
- Set Sigma default edge color from the theme ink token.

Impact:
- Graph edges remain visible across light/dark themes.

Tests:
- not run (not requested)

Refs:
- N/A