### PR TITLE
fix(backend): include venv in image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -70,9 +70,12 @@ RUN set -eux; \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local /usr/local
+COPY --from=builder /app/.venv /app/.venv
 COPY . .
 
-ENV PYTHONPATH=/app
+ENV VIRTUAL_ENV=/app/.venv \
+    PATH="/app/.venv/bin:$PATH" \
+    PYTHONPATH=/app
 
 EXPOSE 8010
 


### PR DESCRIPTION
Why:
- The container failed to start because uvicorn wasn't in PATH.

What:
- Copy the uv virtualenv into the runtime image.
- Set VIRTUAL_ENV and PATH to use the venv.

Impact:
- Backend container boots reliably; no API changes.

Tests:
- not run (not requested)

Refs:
- none