### PR TITLE
fix(app): harden index and protocol readiness guards

### DIFF
--- a/backend/controllers/collections.py
+++ b/backend/controllers/collections.py
@@ -35,6 +35,44 @@ def _payload_list(value: Any, field_name: str) -> list[str] | None:
     return [str(item) for item in value]
 
 
+def _protocol_not_ready_detail(collection_id: str, artifacts: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload = artifacts or {}
+    return {
+        "code": "protocol_artifacts_not_ready",
+        "message": "集合的 protocol 产物尚未就绪，请先完成索引任务并等待 protocol steps 生成。",
+        "collection_id": collection_id,
+        "artifacts": {
+            "documents_ready": bool(payload.get("documents_ready")),
+            "sections_ready": bool(payload.get("sections_ready")),
+            "procedure_blocks_ready": bool(payload.get("procedure_blocks_ready")),
+            "protocol_steps_ready": bool(payload.get("protocol_steps_ready")),
+        },
+    }
+
+
+def _ensure_collection_protocol_ready(collection_id: str) -> Path:
+    try:
+        collection_service.get_collection(collection_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    try:
+        artifacts = artifact_registry_service.get(collection_id)
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=409,
+            detail=_protocol_not_ready_detail(collection_id),
+        ) from None
+
+    if not artifacts.get("protocol_steps_ready"):
+        raise HTTPException(
+            status_code=409,
+            detail=_protocol_not_ready_detail(collection_id, artifacts),
+        )
+
+    return resolve_collection_output_dir(collection_id)
+
+
 @router.post("", response_model=CollectionResponse, summary="创建论文集合")
 async def create_collection(payload: CollectionCreateRequest) -> CollectionResponse:
     record = collection_service.create_collection(
@@ -158,7 +196,7 @@ async def list_collection_protocol_steps(
     limit: int = Query(default=50, ge=1, le=500, description="返回数量"),
     offset: int = Query(default=0, ge=0, description="偏移量"),
 ) -> dict[str, Any]:
-    base_dir = resolve_collection_output_dir(collection_id)
+    base_dir = _ensure_collection_protocol_ready(collection_id)
     payload = protocol_sop_service.list_protocol_steps(
         base_dir=base_dir,
         paper_id=paper_id,
@@ -177,7 +215,7 @@ async def search_collection_protocol_steps(
     paper_id: str | None = Query(default=None, description="按论文 ID 过滤"),
     limit: int = Query(default=10, ge=1, le=100, description="返回数量"),
 ) -> dict[str, Any]:
-    base_dir = resolve_collection_output_dir(collection_id)
+    base_dir = _ensure_collection_protocol_ready(collection_id)
     payload = protocol_search_service.search_protocol_steps(
         base_dir=base_dir,
         query=q,
@@ -199,7 +237,7 @@ async def build_collection_protocol_sop(
     max_steps = int(payload.get("max_steps", 12))
     if max_steps < 1 or max_steps > 50:
         raise HTTPException(status_code=400, detail="max_steps 必须在 1-50 之间")
-    base_dir = resolve_collection_output_dir(collection_id)
+    base_dir = _ensure_collection_protocol_ready(collection_id)
     response = protocol_sop_service.build_sop_draft(
         base_dir=base_dir,
         goal=goal,

--- a/backend/tests/test_units/test_app_layer_api.py
+++ b/backend/tests/test_units/test_app_layer_api.py
@@ -255,3 +255,42 @@ def test_collection_task_and_query_flow(app_client):
     assert workspace_body["capabilities"]["can_view_graph"] is True
     assert workspace_body["capabilities"]["can_generate_sop"] is True
     assert workspace_body["latest_task"]["task_id"] == task_id
+
+
+def test_collection_protocol_endpoints_return_readiness_error_until_artifacts_exist(app_client):
+    create_resp = app_client.post("/collections", json={"name": "Pending Collection"})
+    assert create_resp.status_code == 200
+    collection_id = create_resp.json()["collection_id"]
+
+    upload_resp = app_client.post(
+        f"/collections/{collection_id}/files",
+        files={"file": ("paper.txt", b"Experimental Section\nMix and anneal.", "text/plain")},
+    )
+    assert upload_resp.status_code == 200
+
+    workspace = app_client.get(f"/collections/{collection_id}/workspace")
+    assert workspace.status_code == 200
+    workspace_body = workspace.json()
+    assert workspace_body["artifacts"]["protocol_steps_ready"] is False
+    assert workspace_body["capabilities"]["can_view_protocol_steps"] is False
+
+    steps = app_client.get(f"/collections/{collection_id}/protocol/steps")
+    assert steps.status_code == 409
+    steps_detail = steps.json()["detail"]
+    assert steps_detail["code"] == "protocol_artifacts_not_ready"
+    assert steps_detail["collection_id"] == collection_id
+    assert steps_detail["artifacts"]["protocol_steps_ready"] is False
+
+    search = app_client.get(
+        f"/collections/{collection_id}/protocol/search",
+        params={"q": "anneal", "limit": 5},
+    )
+    assert search.status_code == 409
+    assert search.json()["detail"]["code"] == "protocol_artifacts_not_ready"
+
+    sop = app_client.post(
+        f"/collections/{collection_id}/protocol/sop",
+        json={"goal": "Build a draft SOP"},
+    )
+    assert sop.status_code == 409
+    assert sop.json()["detail"]["code"] == "protocol_artifacts_not_ready"

--- a/backend/tests/test_units/test_collection_protocol_readiness.py
+++ b/backend/tests/test_units/test_collection_protocol_readiness.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from controllers import collections as collections_controller
+from services.artifact_registry_service import ArtifactRegistryService
+from services.collection_service import CollectionService
+
+
+@pytest.fixture()
+def protocol_readiness_services(monkeypatch, tmp_path):
+    collection_service = CollectionService(tmp_path / "collections")
+    artifact_registry = ArtifactRegistryService(tmp_path / "collections")
+
+    monkeypatch.setattr(collections_controller, "collection_service", collection_service)
+    monkeypatch.setattr(collections_controller, "artifact_registry_service", artifact_registry)
+
+    return collection_service, artifact_registry
+
+
+def test_protocol_ready_guard_returns_409_when_registry_is_missing(protocol_readiness_services, monkeypatch, tmp_path):
+    collection_service, _ = protocol_readiness_services
+    record = collection_service.create_collection(name="Pending Collection")
+    output_dir = tmp_path / "collections" / record["collection_id"] / "output"
+    monkeypatch.setattr(collections_controller, "resolve_collection_output_dir", lambda collection_id: output_dir)
+
+    with pytest.raises(HTTPException) as exc_info:
+        collections_controller._ensure_collection_protocol_ready(record["collection_id"])
+
+    exc = exc_info.value
+    assert exc.status_code == 409
+    assert exc.detail["code"] == "protocol_artifacts_not_ready"
+    assert exc.detail["collection_id"] == record["collection_id"]
+    assert exc.detail["artifacts"]["protocol_steps_ready"] is False
+
+
+def test_protocol_ready_guard_returns_409_when_steps_are_not_ready(protocol_readiness_services, monkeypatch, tmp_path):
+    collection_service, artifact_registry = protocol_readiness_services
+    record = collection_service.create_collection(name="Pending Collection")
+    output_dir = tmp_path / "collections" / record["collection_id"] / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifact_registry.upsert(record["collection_id"], output_dir)
+    monkeypatch.setattr(collections_controller, "resolve_collection_output_dir", lambda collection_id: output_dir)
+
+    with pytest.raises(HTTPException) as exc_info:
+        collections_controller._ensure_collection_protocol_ready(record["collection_id"])
+
+    exc = exc_info.value
+    assert exc.status_code == 409
+    assert exc.detail["code"] == "protocol_artifacts_not_ready"
+    assert exc.detail["artifacts"]["documents_ready"] is False
+    assert exc.detail["artifacts"]["protocol_steps_ready"] is False
+
+
+def test_protocol_ready_guard_returns_output_dir_when_steps_exist(protocol_readiness_services, monkeypatch, tmp_path):
+    collection_service, artifact_registry = protocol_readiness_services
+    record = collection_service.create_collection(name="Ready Collection")
+    output_dir = tmp_path / "collections" / record["collection_id"] / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "documents.parquet").write_text("[]", encoding="utf-8")
+    (output_dir / "protocol_steps.parquet").write_text("[]", encoding="utf-8")
+    artifact_registry.upsert(record["collection_id"], output_dir)
+    monkeypatch.setattr(collections_controller, "resolve_collection_output_dir", lambda collection_id: output_dir)
+
+    resolved = collections_controller._ensure_collection_protocol_ready(record["collection_id"])
+
+    assert resolved == output_dir.resolve()
+
+
+def test_protocol_ready_guard_returns_404_for_missing_collection(protocol_readiness_services):
+    _collection_service, _artifact_registry = protocol_readiness_services
+
+    with pytest.raises(HTTPException) as exc_info:
+        collections_controller._ensure_collection_protocol_ready("col_missing")
+
+    exc = exc_info.value
+    assert exc.status_code == 404
+    assert "collection not found" in str(exc.detail)


### PR DESCRIPTION
## Summary
- gate collection-scoped protocol endpoints on protocol artifact readiness instead of exposing raw missing-file failures
- keep the app-layer collection flow safer when protocol artifacts are not ready yet
- add backend tests covering collection protocol readiness behavior

## Context
This follows the GraphRAG downgrade/app-layer refactor and closes the gap where the frontend could hit protocol endpoints before `protocol_steps.parquet` existed. It also complements the frontend follow-up tracked in #39.

## Testing
- `PYTHONPATH=backend pytest -q backend/tests/test_units/test_collection_protocol_readiness.py`
- `PYTHONPATH=backend pytest -q backend/tests/test_units/test_app_layer_api.py`

## Related
- #33
- #34
- #39