### PR TITLE
feat(collections): add app-layer delete endpoint

### DIFF
--- a/backend/controllers/collections.py
+++ b/backend/controllers/collections.py
@@ -8,6 +8,7 @@ from fastapi.responses import Response
 
 from controllers.schemas.collection import (
     CollectionCreateRequest,
+    CollectionDeleteResponse,
     CollectionFileListResponse,
     CollectionFileResponse,
     CollectionListResponse,
@@ -96,6 +97,21 @@ async def get_collection(collection_id: str) -> CollectionResponse:
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     return CollectionResponse(**record)
+
+
+@router.delete(
+    "/{collection_id}",
+    response_model=CollectionDeleteResponse,
+    summary="删除论文集合",
+)
+async def delete_collection(collection_id: str) -> CollectionDeleteResponse:
+    try:
+        result = collection_service.delete_collection(collection_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return CollectionDeleteResponse(**result)
 
 
 @router.post(

--- a/backend/controllers/schemas/collection.py
+++ b/backend/controllers/schemas/collection.py
@@ -30,6 +30,13 @@ class CollectionListResponse(BaseModel):
     items: list[CollectionResponse] = Field(default_factory=list, description="集合列表")
 
 
+class CollectionDeleteResponse(BaseModel):
+    """Collection deletion result."""
+
+    collection_id: str = Field(..., description="已删除的集合 ID")
+    deleted_at: str = Field(..., description="删除时间")
+
+
 class CollectionFileResponse(BaseModel):
     """Stored collection file metadata."""
 

--- a/backend/docs/api.md
+++ b/backend/docs/api.md
@@ -110,6 +110,13 @@
   curl http://localhost:8010/collections/<collection_id>
   ```
 
+- **DELETE** `/collections/{collection_id}` — 删除论文集合
+  - 返回：`collection_id`、`deleted_at`
+  - 说明：删除集合目录及其 app-layer 元数据、输入文件、输出产物
+  ```bash
+  curl -X DELETE http://localhost:8010/collections/<collection_id>
+  ```
+
 - **POST** `/collections/{collection_id}/files` — 上传论文到集合
   - 表单字段：`file`
   - 说明：当前是单文件上传接口；PDF 会自动转为文本后写入集合输入目录

--- a/backend/services/collection_service.py
+++ b/backend/services/collection_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -152,6 +153,27 @@ class CollectionService:
         record["updated_at"] = _now_iso()
         self._write_json(paths.meta_path, record)
         return record
+
+    def delete_collection(self, collection_id: str) -> dict:
+        paths = self.get_paths(collection_id)
+        target_dir = paths.collection_dir
+        if not paths.meta_path.exists():
+            raise FileNotFoundError(f"collection not found: {collection_id}")
+
+        resolved_root = self.root_dir.resolve()
+        resolved_target = target_dir.resolve()
+        try:
+            resolved_target.relative_to(resolved_root)
+        except ValueError as exc:
+            raise ValueError("invalid collection path") from exc
+        if target_dir.is_symlink():
+            raise ValueError("collection path cannot be a symlink")
+
+        shutil.rmtree(target_dir)
+        return {
+            "collection_id": collection_id,
+            "deleted_at": _now_iso(),
+        }
 
     def list_files(self, collection_id: str) -> list[dict]:
         paths = self.get_paths(collection_id)

--- a/backend/tests/test_units/test_app_layer_api.py
+++ b/backend/tests/test_units/test_app_layer_api.py
@@ -257,6 +257,28 @@ def test_collection_task_and_query_flow(app_client):
     assert workspace_body["latest_task"]["task_id"] == task_id
 
 
+def test_delete_collection_removes_app_layer_collection(app_client):
+    create_resp = app_client.post("/collections", json={"name": "Delete Me"})
+    assert create_resp.status_code == 200
+    collection_id = create_resp.json()["collection_id"]
+
+    get_resp = app_client.get(f"/collections/{collection_id}")
+    assert get_resp.status_code == 200
+
+    delete_resp = app_client.delete(f"/collections/{collection_id}")
+    assert delete_resp.status_code == 200
+    assert delete_resp.json()["collection_id"] == collection_id
+
+    missing_resp = app_client.get(f"/collections/{collection_id}")
+    assert missing_resp.status_code == 404
+
+    list_resp = app_client.get("/collections")
+    assert list_resp.status_code == 200
+    assert all(
+        item["collection_id"] != collection_id for item in list_resp.json()["items"]
+    )
+
+
 def test_collection_protocol_endpoints_return_readiness_error_until_artifacts_exist(app_client):
     create_resp = app_client.post("/collections", json={"name": "Pending Collection"})
     assert create_resp.status_code == 200

--- a/backend/tests/test_units/test_collection_service.py
+++ b/backend/tests/test_units/test_collection_service.py
@@ -35,3 +35,32 @@ def test_collection_service_normalizes_legacy_meta(tmp_path):
     saved = json.loads(paths.meta_path.read_text(encoding="utf-8"))
     assert saved["collection_id"] == "default"
     assert "id" not in saved
+
+
+def test_delete_collection_removes_collection_directory(tmp_path):
+    service = CollectionService(tmp_path / "collections")
+    record = service.create_collection("Delete Me")
+    collection_id = record["collection_id"]
+    paths = service.get_paths(collection_id)
+
+    service.add_file(collection_id, "paper.txt", b"Experimental Section\nMix.")
+
+    assert paths.collection_dir.exists()
+    assert paths.meta_path.exists()
+    assert paths.files_path.exists()
+
+    result = service.delete_collection(collection_id)
+
+    assert result["collection_id"] == collection_id
+    assert not paths.collection_dir.exists()
+
+
+def test_delete_collection_raises_for_missing_collection(tmp_path):
+    service = CollectionService(tmp_path / "collections")
+
+    try:
+        service.delete_collection("col_missing")
+    except FileNotFoundError as exc:
+        assert "collection not found" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected FileNotFoundError")


### PR DESCRIPTION
## Summary
- add `DELETE /collections/{collection_id}` to the app-layer collections router
- add `CollectionService.delete_collection(...)` to remove the collection directory and app-layer metadata
- add service and API tests for collection deletion
- update API docs for the new app-layer endpoint

## Validation
- `pytest -q backend/tests/test_collection_service.py backend/tests/test_units/test_app_layer_api.py`
  - `3 passed, 1 skipped`

## Notes
- keeps `backend/retrieval` internals unchanged
- legacy `/retrieval/collections/{collection_id}` remains as compatibility path; this PR adds the app-layer equivalent

Refs:
- ISSUE: #34
- ISSUE: #33
