### PR TITLE
feat(backend): unify public API paths

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,33 +1,46 @@
 # TsingAI-Lens Backend
 
-This directory contains the FastAPI backend for TsingAI-Lens. It manages collection-based ingestion, indexing, knowledge graph export, and structured retrieval.
+FastAPI backend for collection ingestion, indexing, graph/report browsing, protocol extraction, and query.
 
-## Capabilities
+## Public HTTP Contract
 
-- Upload PDF/TXT into collections (PDF is converted to text before indexing).
-- Manage collection input files (add/list/delete).
-- Run GraphRAG indexing pipelines (standard/fast).
-- Export GraphML for Gephi, including evidence metadata.
-- Query indexed outputs with structured retrieval.
+- Business APIs: `/api/v1/*`
+- Docs/OpenAPI/Static: `/api/*`
+  - `/api/docs`
+  - `/api/redoc`
+  - `/api/openapi.json`
+  - `/api/static/*`
 
-## Tech Stack
+Legacy public routes are removed from the main app surface:
 
-- Python, FastAPI
-- GraphRAG indexing pipeline (retrieval)
-- PyMuPDF for PDF text extraction
+- `/collections/*`
+- `/tasks/*`
+- `/retrieval/*`
+- `/docs`, `/redoc`, `/openapi.json`
+- `/static/*`
 
-## Project Layout
+## Core Endpoints
 
-```
-backend/
-├── app/          # Application layer (use cases/services)
-├── controllers/  # FastAPI routes (/retrieval)
-├── retrieval/    # GraphRAG indexing/retrieval pipelines
-├── utils/        # helpers (logging, etc.)
-├── data/         # configs, collections, outputs
-├── docs/         # API docs (docs/api.md)
-└── tests/        # unit tests
-```
+- `POST /api/v1/collections`
+- `GET /api/v1/collections`
+- `GET /api/v1/collections/{collection_id}`
+- `DELETE /api/v1/collections/{collection_id}`
+- `POST /api/v1/collections/{collection_id}/files`
+- `GET /api/v1/collections/{collection_id}/files`
+- `POST /api/v1/collections/{collection_id}/tasks/index`
+- `GET /api/v1/collections/{collection_id}/tasks`
+- `GET /api/v1/tasks/{task_id}`
+- `GET /api/v1/tasks/{task_id}/artifacts`
+- `GET /api/v1/collections/{collection_id}/workspace`
+- `GET /api/v1/collections/{collection_id}/graph`
+- `GET /api/v1/collections/{collection_id}/graphml`
+- `GET /api/v1/collections/{collection_id}/protocol/steps`
+- `GET /api/v1/collections/{collection_id}/protocol/search`
+- `POST /api/v1/collections/{collection_id}/protocol/sop`
+- `POST /api/v1/query`
+- `GET /api/v1/collections/{collection_id}/reports/communities`
+- `GET /api/v1/collections/{collection_id}/reports/communities/{community_id}`
+- `GET /api/v1/collections/{collection_id}/reports/patterns`
 
 ## Local Development
 
@@ -36,176 +49,16 @@ cd backend
 uv venv .venv && source .venv/bin/activate
 uv sync
 
-# OpenAI-compatible LLM endpoint example
 export LLM_BASE_URL=http://localhost:11434/v1
 export LLM_MODEL=qwen1.5-8b-chat
 export LLM_API_KEY=sk-local
 
 uvicorn main:app --reload --port 8010
 ```
-
-## Core API
-
-- POST `/retrieval/collections` - create collection
-- GET `/retrieval/collections` - list collections with stats
-- DELETE `/retrieval/collections/{collection_id}` - delete collection (default cannot be deleted)
-- POST `/retrieval/collections/{collection_id}/files` - upload files to a collection
-- GET `/retrieval/collections/{collection_id}/files` - list collection files
-- DELETE `/retrieval/collections/{collection_id}/files` - delete a collection file
-- POST `/retrieval/index` - run indexing on a collection
-- POST `/retrieval/index/upload` - upload a file and index immediately
-- POST `/retrieval/input/upload` - upload multiple files without indexing
-- POST `/retrieval/query` - query indexed outputs
-- GET `/retrieval/graphml` - export GraphML for Gephi
-
-## Collection Fields
-
-- `status`: `ready` (entities exist) / `empty` (not indexed)
-- `document_count`: from `documents.parquet` or `stats.json`
-- `entity_count`: from `entities.parquet`
-- `updated_at`: last output artifact timestamp (fallback to `created_at`)
-
-## Recommended Flow (MVP)
-
-1) Optional: POST `/retrieval/collections`
-2) POST `/retrieval/collections/{collection_id}/files`
-3) POST `/retrieval/index`
-4) GET `/retrieval/graphml`
-5) POST `/retrieval/query`
-
-## GraphML Export Parameters
-
-- `include_community`: attach community id to nodes for Gephi coloring
-- `community_id`: export a single community
-- `max_nodes`: limit node count
-- `min_weight`: filter relationships by weight
-
-GraphML evidence fields (nodes and edges):
-- `node_text_unit_ids`, `node_text_unit_count`
-- `node_document_ids`, `node_document_titles`, `node_document_count`
-- `edge_text_unit_ids`, `edge_text_unit_count`
-- `edge_document_ids`, `edge_document_titles`, `edge_document_count`
-
-## Model Configuration
-
-Backend uses an OpenAI-compatible endpoint. Set:
-
-- `LLM_BASE_URL`
-- `LLM_MODEL`
-- `LLM_API_KEY`
 
 ## Notes
 
-- PDF must contain selectable text (OCR is not provided).
-
-## References
-
-- `backend/docs/api.md` for detailed API docs and curl examples
-
----
-
-# 中文说明
-
-## 功能说明
-
-本目录为 TsingAI-Lens 的 FastAPI 后端，提供集合式导入、索引、知识图谱导出与结构化检索能力。
-
-## 能力清单
-
-- 上传 PDF/TXT 到集合（PDF 会先抽取为文本）。
-- 集合文件管理（添加/列表/删除）。
-- 运行 GraphRAG 索引流程（standard/fast）。
-- 导出 GraphML 供 Gephi 使用，包含证据字段。
-- 基于索引结果进行结构化检索。
-
-## 技术栈
-
-- Python、FastAPI
-- GraphRAG 索引流程（retrieval）
-- PyMuPDF 负责 PDF 文本抽取
-
-## 目录结构
-
-```
-backend/
-├── app/          # 应用层（use cases / services）
-├── controllers/  # FastAPI 路由（/retrieval）
-├── retrieval/    # GraphRAG 索引/检索流程
-├── utils/        # 工具模块（日志等）
-├── data/         # 配置、集合与输出目录
-├── docs/         # API 文档
-└── tests/        # 单元测试
-```
-
-## 本地开发
-
-```bash
-cd backend
-uv venv .venv && source .venv/bin/activate
-uv sync
-
-# OpenAI 兼容 LLM 端点示例
-export LLM_BASE_URL=http://localhost:11434/v1
-export LLM_MODEL=qwen1.5-8b-chat
-export LLM_API_KEY=sk-local
-
-uvicorn main:app --reload --port 8010
-```
-
-## 核心 API
-
-- POST `/retrieval/collections` - 创建集合
-- GET `/retrieval/collections` - 列出集合与统计
-- DELETE `/retrieval/collections/{collection_id}` - 删除集合（默认集合不可删）
-- POST `/retrieval/collections/{collection_id}/files` - 上传集合文件
-- GET `/retrieval/collections/{collection_id}/files` - 列出集合文件
-- DELETE `/retrieval/collections/{collection_id}/files` - 删除集合文件
-- POST `/retrieval/index` - 触发索引
-- POST `/retrieval/index/upload` - 上传单文件并索引
-- POST `/retrieval/input/upload` - 批量上传不索引
-- POST `/retrieval/query` - 结构化检索
-- GET `/retrieval/graphml` - 导出 GraphML
-
-## 集合字段说明
-
-- `status`：`ready`（已有实体输出）/ `empty`（未索引）
-- `document_count`：来自 `documents.parquet` 或 `stats.json`
-- `entity_count`：来自 `entities.parquet`
-- `updated_at`：输出产物最后更新时间（缺失回退 `created_at`）
-
-## 推荐流程（MVP）
-
-1) 可选：POST `/retrieval/collections`
-2) POST `/retrieval/collections/{collection_id}/files`
-3) POST `/retrieval/index`
-4) GET `/retrieval/graphml`
-5) POST `/retrieval/query`
-
-## GraphML 导出参数
-
-- `include_community`：输出社区字段用于 Gephi 着色
-- `community_id`：导出指定社区
-- `max_nodes`：限制节点数量
-- `min_weight`：按关系权重过滤
-
-GraphML 证据字段（节点/边共用）：
-- `node_text_unit_ids`、`node_text_unit_count`
-- `node_document_ids`、`node_document_titles`、`node_document_count`
-- `edge_text_unit_ids`、`edge_text_unit_count`
-- `edge_document_ids`、`edge_document_titles`、`edge_document_count`
-
-## 模型配置
-
-后端使用 OpenAI 兼容接口，需配置：
-
-- `LLM_BASE_URL`
-- `LLM_MODEL`
-- `LLM_API_KEY`
-
-## 注意事项
-
-- PDF 需可复制文本（不含 OCR）。
-
-## 参考文档
-
-- `backend/docs/api.md`
+- The `controllers/retrieval.py` file still contains legacy/engine-facing handlers.
+- The main FastAPI app no longer mounts legacy `/retrieval/*` as public browser routes.
+- Public protocol browsing is collection-scoped under `/api/v1/collections/{collection_id}/protocol/*`; raw retrieval protocol endpoints stay non-public.
+- See `backend/docs/api.md` for detailed contract notes.

--- a/backend/controllers/retrieval.py
+++ b/backend/controllers/retrieval.py
@@ -35,6 +35,8 @@ from retrieval.config.enums import IndexingMethod
 from services import protocol_search_service, protocol_sop_service
 
 router = APIRouter(prefix="/retrieval", tags=["retrieval"])
+public_query_router = APIRouter(tags=["query"])
+public_reports_router = APIRouter(tags=["reports"])
 logger = logging.getLogger(__name__)
 
 
@@ -133,6 +135,11 @@ async def delete_collection_file(
     response_model=ReportCommunityListResponse,
     summary="列出社区报告",
 )
+@public_reports_router.get(
+    "/collections/{collection_id}/reports/communities",
+    response_model=ReportCommunityListResponse,
+    summary="列出社区报告",
+)
 async def list_community_reports(
     collection_id: str,
     level: int | None = Query(default=2, description="社区层级"),
@@ -153,6 +160,11 @@ async def list_community_reports(
 
 
 @router.get(
+    "/collections/{collection_id}/reports/communities/{community_id}",
+    response_model=ReportCommunityDetailResponse,
+    summary="社区报告详情",
+)
+@public_reports_router.get(
     "/collections/{collection_id}/reports/communities/{community_id}",
     response_model=ReportCommunityDetailResponse,
     summary="社区报告详情",
@@ -179,6 +191,11 @@ async def get_community_report_detail(
 
 
 @router.get(
+    "/collections/{collection_id}/reports/patterns",
+    response_model=ReportPatternsResponse,
+    summary="社区规律概览",
+)
+@public_reports_router.get(
     "/collections/{collection_id}/reports/patterns",
     response_model=ReportPatternsResponse,
     summary="社区规律概览",
@@ -234,6 +251,11 @@ async def upload_inputs(
 
 
 @router.post(
+    "/query",
+    response_model=QueryResponse,
+    summary="基于索引结果进行检索问答",
+)
+@public_query_router.post(
     "/query",
     response_model=QueryResponse,
     summary="基于索引结果进行检索问答",

--- a/backend/docs/api.md
+++ b/backend/docs/api.md
@@ -2,429 +2,56 @@
 
 默认 Base URL：`http://localhost:8010`。当前接口未启用鉴权。
 
-## 推荐接入方式
-- 产品默认入口：`/collections`、`/tasks`、`/workspace`
-- 结果接口优先：图谱、protocol、SOP 都优先走 collection 维度接口
-- 兼容 / 调试接口：`/retrieval/*`
-- 不建议前端默认直接调用：`/retrieval/index`、`/retrieval/index/upload`、`/retrieval/protocol/*`
-- 当前没有独立的 `/chat` 或 `/file` controller：
-  - 文件上传/列表能力已并入 `POST/GET /collections/{collection_id}/files`
-  - 底层兼容上传仍保留在 `/retrieval/input/upload` 和 `/retrieval/index/upload`
-  - 检索问答能力当前通过 `/retrieval/query` 提供，产品主流程优先使用 collection 维度结果接口
+## 公开合同
 
-## 前端标准调用顺序
-1. `GET /collections`
-2. `POST /collections`
-3. `POST /collections/{collection_id}/files`
-4. `POST /collections/{collection_id}/tasks/index`
-5. 轮询 `GET /tasks/{task_id}`
-6. 进入 `GET /collections/{collection_id}/workspace`
-7. 再按页面进入：
-   - `GET /collections/{collection_id}/graph`
-   - `GET /collections/{collection_id}/graphml`
-   - `GET /collections/{collection_id}/protocol/steps`
-   - `GET /collections/{collection_id}/protocol/search`
-   - `POST /collections/{collection_id}/protocol/sop`
+- 业务接口统一位于：`/api/v1/*`
+- 文档与静态资源统一位于：`/api/*`
+- 旧公开入口 `/collections/*`、`/tasks/*`、`/retrieval/*`、`/docs`、`/redoc`、`/openapi.json`、`/static/*` 不再暴露
 
-## 前端页面映射
-### 集合列表页
-- 主接口：`GET /collections`
-- 关键字段：`items[].collection_id`、`items[].name`、`items[].status`、`items[].paper_count`、`items[].updated_at`
-- 展示重点：集合名称、论文数、最近更新时间、当前状态
+### 文档与静态资源
 
-### 新建集合弹窗
-- 主接口：`POST /collections`
-- 请求字段：`name`、`description`、`default_method`
-- 展示重点：最小创建表单，成功后跳转集合详情
+- `GET /api/docs`
+- `GET /api/redoc`
+- `GET /api/openapi.json`
+- `GET /api/static/*`
 
-### 集合文件页
-- 主接口：
-  - `GET /collections/{collection_id}/files`
-  - `POST /collections/{collection_id}/files`
-- 关键字段：`file_id`、`original_filename`、`stored_filename`、`status`、`size_bytes`、`created_at`
-- 展示重点：文件列表、上传状态、上传时间
+### App Layer
 
-### 处理进度区
-- 主接口：
-  - `POST /collections/{collection_id}/tasks/index`
-  - `GET /tasks/{task_id}`
-  - `GET /tasks/{task_id}/artifacts`
-- 关键字段：`task_id`、`status`、`current_stage`、`progress_percent`、`errors`、`warnings`
-- 展示重点：任务状态、阶段名称、进度百分比、失败信息
-- 轮询建议：`queued/running` 状态下每 2-3 秒轮询一次
+- `POST /api/v1/collections`
+- `GET /api/v1/collections`
+- `GET /api/v1/collections/{collection_id}`
+- `DELETE /api/v1/collections/{collection_id}`
+- `POST /api/v1/collections/{collection_id}/files`
+- `GET /api/v1/collections/{collection_id}/files`
+- `POST /api/v1/collections/{collection_id}/tasks/index`
+- `GET /api/v1/collections/{collection_id}/tasks`
+- `GET /api/v1/tasks/{task_id}`
+- `GET /api/v1/tasks/{task_id}/artifacts`
+- `GET /api/v1/collections/{collection_id}/workspace`
+- `GET /api/v1/collections/{collection_id}/graph`
+- `GET /api/v1/collections/{collection_id}/graphml`
+- `GET /api/v1/collections/{collection_id}/protocol/steps`
+- `GET /api/v1/collections/{collection_id}/protocol/search`
+- `POST /api/v1/collections/{collection_id}/protocol/sop`
 
-### 工作区首页
-- 主接口：`GET /collections/{collection_id}/workspace`
-- 关键字段：`collection`、`file_count`、`status_summary`、`artifacts`、`latest_task`、`recent_tasks`、`capabilities`
-- 展示重点：集合总览、当前是否可看图谱 / protocol / SOP、最近任务
+### Query 与 Reports
 
-### 图谱页
-- 主接口：
-  - `GET /collections/{collection_id}/graph`
-  - `GET /collections/{collection_id}/graphml`
-- 关键字段：`nodes`、`edges`、`truncated`、`community`
-- 展示重点：图谱预览、过滤条件、GraphML 下载
+- `POST /api/v1/query`
+- `GET /api/v1/collections/{collection_id}/reports/communities`
+- `GET /api/v1/collections/{collection_id}/reports/communities/{community_id}`
+- `GET /api/v1/collections/{collection_id}/reports/patterns`
 
-### Protocol 步骤页
-- 主接口：`GET /collections/{collection_id}/protocol/steps`
-- 关键字段：`items[].step_id`、`items[].paper_id`、`items[].order`、`items[].action`、`items[].materials`、`items[].conditions`、`items[].purpose`、`items[].confidence_score`
-- 展示重点：实验步骤顺序、动作、材料、条件、置信度
+## 推荐前端主流程
 
-### Protocol 搜索页
-- 主接口：`GET /collections/{collection_id}/protocol/search`
-- 关键字段：`items[].step_id`、`items[].paper_id`、`items[].action`、`items[].matched_fields`、`items[].excerpt`、`items[].score`
-- 展示重点：命中片段、命中字段、相似度排序
+1. `POST /api/v1/collections`
+2. `POST /api/v1/collections/{collection_id}/files`
+3. `POST /api/v1/collections/{collection_id}/tasks/index`
+4. 轮询 `GET /api/v1/tasks/{task_id}`
+5. 使用 `GET /api/v1/collections/{collection_id}/workspace` 驱动状态展示
+6. 按页面调用 graph / protocol / sop 相关 collection 维度接口
 
-### SOP 生成页
-- 主接口：`POST /collections/{collection_id}/protocol/sop`
-- 请求字段：`goal`、`target_properties`、`paper_ids`、`max_steps`
-- 关键字段：`sop_draft.objective`、`sop_draft.hypothesis`、`sop_draft.variables`、`sop_draft.steps`、`sop_draft.measurement_plan`、`sop_draft.risks`、`sop_draft.open_questions`
-- 展示重点：实验目标、步骤链、表征计划、风险和待确认问题
+## 迁移提示
 
-### 任务历史页
-- 主接口：`GET /collections/{collection_id}/tasks`
-- 关键字段：`items[].task_id`、`items[].status`、`items[].current_stage`、`items[].progress_percent`、`items[].created_at`、`items[].finished_at`
-- 展示重点：历史任务、成功/失败状态、最近运行时间
-
-## 产品主入口（App Layer）
-- 说明：这一层是科研助手的主流程入口，围绕 `collection_id` 和 `task_id` 工作。
-- 说明：本分支不再挂载独立 `chat` / `file` 路由，相关能力已合并到本章节与 `/retrieval` 兼容接口中。
-
-### 集合与文件
-- **POST** `/collections` — 创建论文集合
-  - 请求体：`name`（必填）、`description`（可选）、`default_method`（可选，默认 `standard`）
-  ```bash
-  curl -X POST http://localhost:8010/collections \
-    -H "Content-Type: application/json" \
-    -d '{"name":"Composite Papers","description":"复合材料论文集合"}'
-  ```
-
-- **GET** `/collections` — 列出论文集合
-  - 返回每个集合的基础元数据：`collection_id`、`name`、`status`、`paper_count`、`updated_at`
-  ```bash
-  curl http://localhost:8010/collections
-  ```
-
-- **GET** `/collections/{collection_id}` — 获取集合详情
-  ```bash
-  curl http://localhost:8010/collections/<collection_id>
-  ```
-
-- **DELETE** `/collections/{collection_id}` — 删除论文集合
-  - 返回：`collection_id`、`deleted_at`
-  - 说明：删除集合目录及其 app-layer 元数据、输入文件、输出产物
-  ```bash
-  curl -X DELETE http://localhost:8010/collections/<collection_id>
-  ```
-
-- **POST** `/collections/{collection_id}/files` — 上传论文到集合
-  - 表单字段：`file`
-  - 说明：当前是单文件上传接口；PDF 会自动转为文本后写入集合输入目录
-  ```bash
-  curl -X POST http://localhost:8010/collections/<collection_id>/files \
-    -F "file=@/path/to/paper.pdf"
-  ```
-
-- **GET** `/collections/{collection_id}/files` — 列出集合文件
-  - 返回：`file_id`、`original_filename`、`stored_filename`、`status`、`size_bytes`
-  ```bash
-  curl http://localhost:8010/collections/<collection_id>/files
-  ```
-
-### 任务
-- **POST** `/collections/{collection_id}/tasks/index` — 创建集合索引任务
-  - 请求体：`method`、`is_update_run`、`verbose`、`additional_context`
-  - 返回：`task_id`、`status`、`current_stage`、`progress_percent`、`errors`、`warnings`
-  ```bash
-  curl -X POST http://localhost:8010/collections/<collection_id>/tasks/index \
-    -H "Content-Type: application/json" \
-    -d '{"method":"standard","is_update_run":false,"verbose":false}'
-  ```
-
-- **GET** `/collections/{collection_id}/tasks` — 列出集合任务历史
-  - 查询参数：`status`（可选）、`limit`（默认 `20`）、`offset`（默认 `0`）
-  ```bash
-  curl "http://localhost:8010/collections/<collection_id>/tasks?status=completed&limit=20&offset=0"
-  ```
-
-- **GET** `/tasks/{task_id}` — 查询任务状态
-  - 前端轮询主接口
-  - 关键字段：`status`、`current_stage`、`progress_percent`、`errors`、`warnings`
-  ```bash
-  curl http://localhost:8010/tasks/<task_id>
-  ```
-
-- **GET** `/tasks/{task_id}/artifacts` — 查询任务产物状态
-  - 用于判断 `documents`、`graph`、`sections`、`procedure_blocks`、`protocol_steps` 是否已就绪
-  ```bash
-  curl http://localhost:8010/tasks/<task_id>/artifacts
-  ```
-
-### 工作区与结果
-- **GET** `/collections/{collection_id}/workspace` — 获取集合工作区概览
-  - 返回：`collection`、`file_count`、`status_summary`、`artifacts`、`latest_task`、`recent_tasks`、`capabilities`
-  - 用途：集合详情页主接口
-  ```bash
-  curl http://localhost:8010/collections/<collection_id>/workspace
-  ```
-
-- **GET** `/collections/{collection_id}/graph` — 获取集合图数据
-  - 查询参数：`max_nodes`（默认 `200`）、`min_weight`（默认 `0.0`）、`community_id`（可选）
-  - 返回：`nodes`、`edges`、`truncated`、`community`
-  ```bash
-  curl "http://localhost:8010/collections/<collection_id>/graph?max_nodes=200&min_weight=0"
-  ```
-
-- **GET** `/collections/{collection_id}/graphml` — 导出集合 GraphML
-  ```bash
-  curl -OJ "http://localhost:8010/collections/<collection_id>/graphml?max_nodes=200&min_weight=0"
-  ```
-
-- **GET** `/collections/{collection_id}/protocol/steps` — 列出集合 protocol steps
-  - 查询参数：`paper_id`、`block_type`、`limit`、`offset`
-  - 用途：展示从论文中抽取出的结构化实验步骤
-  ```bash
-  curl "http://localhost:8010/collections/<collection_id>/protocol/steps?limit=20"
-  ```
-
-- **GET** `/collections/{collection_id}/protocol/search` — 检索集合 protocol steps
-  - 查询参数：`q`（必填）、`paper_id`（可选）、`limit`（默认 `10`）
-  - 用途：按动作、材料、条件等检索步骤
-  ```bash
-  curl "http://localhost:8010/collections/<collection_id>/protocol/search?q=anneal%20600C&limit=5"
-  ```
-
-- **POST** `/collections/{collection_id}/protocol/sop` — 为集合生成 SOP 草案
-  - 请求体：`goal`、`target_properties`、`paper_ids`、`max_steps`
-  - 用途：基于现有 protocol steps 组装实验方案草案
-  ```bash
-  curl -X POST http://localhost:8010/collections/<collection_id>/protocol/sop \
-    -H "Content-Type: application/json" \
-    -d '{"goal":"为复合材料设计实验方案","target_properties":["mechanical","thermal"],"max_steps":8}'
-  ```
-
-## 兼容 / 调试接口（/retrieval）
-- 说明：这部分保留给兼容旧调用、底层调试和排障使用，不建议前端作为默认产品入口直接接入。
-- 说明：`/retrieval` 仍保留上传、索引、问答与导出能力，但它是引擎层接口，不再代表产品主流程。
-
-### 旧集合接口
-- **POST** `/retrieval/collections` — 创建集合
-  ```bash
-  curl -X POST http://localhost:8010/retrieval/collections \
-    -H "Content-Type: application/json" \
-    -d '{"name":"paper-lab"}'
-  ```
-
-- **GET** `/retrieval/collections` — 列出集合
-  ```bash
-  curl http://localhost:8010/retrieval/collections
-  ```
-
-- **DELETE** `/retrieval/collections/{collection_id}` — 删除集合
-  ```bash
-  curl -X DELETE http://localhost:8010/retrieval/collections/<COLLECTION_ID>
-  ```
-
-- **POST** `/retrieval/collections/{collection_id}/files` — 向集合上传文件
-  - 表单字段：`files`
-  ```bash
-  curl -X POST http://localhost:8010/retrieval/collections/<COLLECTION_ID>/files \
-    -F "files=@/path/to/paper1.pdf" \
-    -F "files=@/path/to/paper2.pdf"
-  ```
-
-- **GET** `/retrieval/collections/{collection_id}/files` — 列出集合文件
-  ```bash
-  curl http://localhost:8010/retrieval/collections/<COLLECTION_ID>/files
-  ```
-
-- **DELETE** `/retrieval/collections/{collection_id}/files` — 删除集合文件
-  - 查询参数：`key`
-  ```bash
-  curl -X DELETE "http://localhost:8010/retrieval/collections/<COLLECTION_ID>/files?key=uploads/<FILE_KEY>"
-  ```
-
-### 索引与检索
-- **POST** `/retrieval/index` — 启动索引流程
-  - 请求体：`collection_id`（可选）、`method`、`is_update_run`、`verbose`、`additional_context`
-  - 成功完成 GraphRAG 索引后，会继续自动生成 `sections.parquet`、`procedure_blocks.parquet`、`protocol_steps.parquet`
-  ```bash
-  curl -X POST http://localhost:8010/retrieval/index \
-    -H "Content-Type: application/json" \
-    -d '{"collection_id":"<COLLECTION_ID>","method":"standard","is_update_run":false,"verbose":false}'
-  ```
-
-- **POST** `/retrieval/index/upload` — 上传文件并启动索引
-  - 表单字段：`file`、`collection_id`（可选）、`method`、`is_update_run`、`verbose`
-  ```bash
-  curl -X POST http://localhost:8010/retrieval/index/upload \
-    -F "file=@/path/to/document.pdf" \
-    -F "collection_id=<COLLECTION_ID>" \
-    -F "method=standard" \
-    -F "is_update_run=false" \
-    -F "verbose=false"
-  ```
-
-- **POST** `/retrieval/input/upload` — 批量上传文件到输入存储
-  ```bash
-  curl -X POST http://localhost:8010/retrieval/input/upload \
-    -F "collection_id=<COLLECTION_ID>" \
-    -F "files=@/path/to/paper1.pdf" \
-    -F "files=@/path/to/paper2.pdf"
-  ```
-
-- **POST** `/retrieval/query` — 基于索引结果进行检索问答
-  - 请求体：`query`、`method`、`collection_id`、`response_type`、`community_level`、`dynamic_community_selection`、`include_context`、`verbose`
-  ```bash
-  curl -X POST http://localhost:8010/retrieval/query \
-    -H "Content-Type: application/json" \
-    -d '{
-      "collection_id":"<COLLECTION_ID>",
-      "query":"基于这些论文给出可执行的实验方案（步骤/变量/指标）",
-      "method":"global",
-      "response_type":"List of 5-7 Points",
-      "include_context":false
-    }'
-  ```
-
-### 图数据导出
-- **GET** `/retrieval/graphml` — 导出 GraphML
-  - 查询参数：`collection_id`、`max_nodes`、`min_weight`、`community_id`、`include_community`
-  ```bash
-  curl -OJ "http://localhost:8010/retrieval/graphml?collection_id=<COLLECTION_ID>&max_nodes=200&min_weight=0&include_community=true"
-  ```
-
-### Protocol 兼容接口
-- 说明：这些接口消费 protocol 中间产物。`output_path` 为空时，会回退到默认 collection 的 output 目录。
-- `/retrieval/protocol/extract` 只消费已经生成的 `sections.parquet`、`procedure_blocks.parquet`、`protocol_steps.parquet`，不会自行执行 parser/extractor。
-
-- **POST** `/retrieval/protocol/extract`
-  - 请求体：`output_path`、`paper_ids`、`limit`
-  ```bash
-  curl -X POST http://localhost:8010/retrieval/protocol/extract \
-    -H "Content-Type: application/json" \
-    -d '{"output_path":"/path/to/output","paper_ids":["paper-1"],"limit":20}'
-  ```
-
-- **GET** `/retrieval/protocol/steps`
-  - 查询参数：`output_path`、`paper_id`、`block_type`、`limit`、`offset`
-  ```bash
-  curl "http://localhost:8010/retrieval/protocol/steps?output_path=/path/to/output&paper_id=paper-1&limit=20"
-  ```
-
-- **GET** `/retrieval/protocol/search`
-  - 查询参数：`q`、`output_path`、`paper_id`、`limit`
-  ```bash
-  curl "http://localhost:8010/retrieval/protocol/search?q=anneal%20N2&output_path=/path/to/output&limit=5"
-  ```
-
-- **POST** `/retrieval/protocol/sop`
-  - 请求体：`goal`、`output_path`、`paper_ids`、`target_properties`、`max_steps`
-  ```bash
-  curl -X POST http://localhost:8010/retrieval/protocol/sop \
-    -H "Content-Type: application/json" \
-    -d '{
-      "goal":"Design a composite protocol for mechanical and thermal optimization",
-      "output_path":"/path/to/output",
-      "target_properties":["mechanical","thermal"],
-      "paper_ids":["paper-1"],
-      "max_steps":8
-    }'
-  ```
-
-### 兼容接口注意事项
-- PDF 需可复制文本；扫描版 PDF 暂不支持 OCR
-- Graph 证据字段依赖 `text_units.parquet` 与 `documents.parquet`
-- 新产品流不应依赖 `output_path`
-- 旧 `/retrieval/*` 接口仍可用于排障和底层能力验证
-
-## Protocol 数据合同（字段定义）
-- 下列结构为 `/retrieval/protocol/*` 及 collection 维度 protocol 结果接口的核心合同定义。
-- 目录级输入统一使用 `output_path` 指向 GraphRAG 产物目录；collection 维度接口内部会将 `collection_id` 映射到对应输出目录。
-
-- `NormalizedValueItem`
-  - `value`：归一化后的数值
-  - `unit`：归一化单位，建议温度统一 `K`、时长统一 `s`、压力统一 `Pa`
-  - `raw_value`：原始文本值
-  - `operator`：`=`、`>`、`<`、`~`、`range`
-  - `min_value` / `max_value`：区间值
-  - `status`：`reported` / `inferred` / `not_reported` / `ambiguous`
-
-- `ConditionItem`
-  - `temperature` / `duration` / `pressure` / `heating_rate` / `cooling_rate` / `ph`
-  - `atmosphere`
-  - `environment`
-  - `raw_text`
-
-- `MaterialRefItem`
-  - `name`
-  - `formula`
-  - `role`：`precursor` / `solvent` / `additive` / `matrix` / `filler` / `sample` / `product` / `other`
-  - `amount`
-  - `composition_note`
-  - `grade`
-  - `source_text`
-
-- `MeasurementSpecItem`
-  - `method`
-  - `instrument`
-  - `target_property`
-  - `metrics`
-  - `conditions`
-  - `output_ref`
-  - `source_text`
-
-- `ControlSpecItem`
-  - `control_type`：`baseline` / `blank` / `untreated` / `literature` / `ablation` / `other`
-  - `description`
-  - `rationale`
-  - `source_text`
-
-- `EvidenceRefItem`
-  - `paper_id`
-  - `section_id`
-  - `block_id`
-  - `snippet_id`
-  - `section_type`
-  - `page_start` / `page_end`
-  - `figure_or_table`
-  - `quote_span`
-  - `source_text`
-  - `confidence_score`
-
-- `ProtocolStepItem`
-  - `step_id`
-  - `paper_id`
-  - `order`
-  - `action`
-  - `section_id`
-  - `block_id`
-  - `phase`：`preparation` / `synthesis` / `post_treatment` / `characterization` / `property_test` / `analysis` / `other`
-  - `materials`
-  - `conditions`
-  - `purpose`
-  - `expected_output`
-  - `characterization`
-  - `controls`
-  - `evidence_refs`
-  - `confidence_score`
-
-- `SOPDraftItem`
-  - `sop_id`
-  - `objective`
-  - `hypothesis`
-  - `variables`
-  - `constraints`
-  - `controls`
-  - `steps`
-  - `measurement_plan`
-  - `acceptance_criteria`
-  - `risks`
-  - `open_questions`
-  - `review_status`
-
-- 预留请求/响应模型
-  - `ProtocolExtractRequest` / `ProtocolExtractResponse`
-  - `ProtocolStepListResponse`
-  - `ProtocolSearchHit` / `ProtocolSearchResponse`
-  - `SOPDraftRequest` / `SOPDraftResponse`
+- 浏览器与前端代码只能假设 `/api/v1/*` 与 `/api/*` 两类前缀。
+- 旧 `/retrieval/*` 不属于主应用公开浏览器接口，不应作为前端集成入口。
+- protocol 公共入口只保留 collection 维度 `/api/v1/collections/{collection_id}/protocol/*`。

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -8,23 +10,45 @@ from utils.logger import setup_logger
 # 初始化全局日志，确保 controllers/services 的日志能输出
 setup_logger("lens")
 
+PUBLIC_API_PREFIX = "/api"
+PUBLIC_API_V1_PREFIX = f"{PUBLIC_API_PREFIX}/v1"
+
+
+def _parse_cors_allowed_origins() -> list[str]:
+    raw = os.getenv("CORS_ALLOWED_ORIGINS", "").strip()
+    if not raw:
+        return []
+    return [origin.strip() for origin in raw.split(",") if origin.strip()]
+
 
 def create_app() -> FastAPI:
-    app = FastAPI(title="TsingAI-Lens API", version="0.2.0")
+    app = FastAPI(
+        title="TsingAI-Lens API",
+        version="0.2.0",
+        docs_url=f"{PUBLIC_API_PREFIX}/docs",
+        redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
+        openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",
+    )
+    cors_allowed_origins = _parse_cors_allowed_origins()
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
+        # Same-origin deployment does not require wildcard cross-origin access.
+        # Configure explicit origins via `CORS_ALLOWED_ORIGINS` when needed.
+        allow_origins=cors_allowed_origins,
+        allow_credentials=bool(cors_allowed_origins),
         allow_methods=["*"],
         allow_headers=["*"],
     )
 
     DATA_DIR.mkdir(parents=True, exist_ok=True)
-    app.mount("/static", StaticFiles(directory=DATA_DIR), name="static")
-    app.include_router(retrieval.router)
-    app.include_router(collections.router)
-    app.include_router(tasks.router)
-    app.include_router(workspace.router)
+    app.mount(f"{PUBLIC_API_PREFIX}/static", StaticFiles(directory=DATA_DIR), name="static")
+    # Only the flattened browser-visible retrieval surfaces stay public here.
+    # Engine-only `/retrieval/*` handlers, including raw protocol endpoints, are not mounted.
+    app.include_router(retrieval.public_query_router, prefix=PUBLIC_API_V1_PREFIX)
+    app.include_router(retrieval.public_reports_router, prefix=PUBLIC_API_V1_PREFIX)
+    app.include_router(collections.router, prefix=PUBLIC_API_V1_PREFIX)
+    app.include_router(tasks.router, prefix=PUBLIC_API_V1_PREFIX)
+    app.include_router(workspace.router, prefix=PUBLIC_API_V1_PREFIX)
     return app
 
 

--- a/backend/tests/test_units/test_app_layer_api.py
+++ b/backend/tests/test_units/test_app_layer_api.py
@@ -21,6 +21,8 @@ except ImportError:  # pragma: no cover
 if not FASTAPI_AVAILABLE:  # pragma: no cover
     pytest.skip("fastapi not installed", allow_module_level=True)
 
+API_V1_PREFIX = "/api/v1"
+
 
 class DummyWorkflowOutput:
     def __init__(self, workflow: str = "index", errors: list[str] | None = None):
@@ -130,8 +132,15 @@ def app_client(monkeypatch, tmp_path):
 
     from fastapi import FastAPI
     from controllers import collections as collections_controller
+    from controllers import retrieval as retrieval_controller
     from controllers import tasks as tasks_controller
     from controllers import workspace as workspace_controller
+    from controllers.schemas import (
+        QueryResponse,
+        ReportCommunityDetailResponse,
+        ReportCommunityListResponse,
+        ReportPatternsResponse,
+    )
     from services.artifact_registry_service import ArtifactRegistryService
     from services.collection_service import CollectionService
     from services.index_task_runner import IndexTaskRunner
@@ -155,6 +164,61 @@ def app_client(monkeypatch, tmp_path):
         _write_index_outputs(output_dir)
         return [DummyWorkflowOutput()]
 
+    async def fake_query_index(payload):  # noqa: ANN001
+        return QueryResponse(
+            answer="stub-answer",
+            method=str(payload.method),
+            collection_id=payload.collection_id or "default",
+            output_path=str(tmp_path / "output"),
+            context_data=None,
+        )
+
+    def fake_list_community_reports(  # noqa: ANN001
+        collection_id, level, limit, offset, min_size, sort
+    ):
+        return ReportCommunityListResponse(
+            collection_id=collection_id,
+            level=level,
+            total=0,
+            count=0,
+            items=[],
+        )
+
+    def fake_get_community_report_detail(  # noqa: ANN001
+        collection_id, community_id, level, entity_limit, relationship_limit, document_limit
+    ):
+        parsed_community_id = int(community_id) if str(community_id).isdigit() else None
+        return ReportCommunityDetailResponse(
+            collection_id=collection_id,
+            community_id=parsed_community_id,
+            human_readable_id=parsed_community_id,
+            level=level,
+            parent=None,
+            children=None,
+            title=None,
+            summary=None,
+            findings=None,
+            rating=None,
+            size=None,
+            document_count=0,
+            text_unit_count=0,
+            entities=[],
+            relationships=[],
+            documents=[],
+        )
+
+    def fake_list_patterns(collection_id, level, limit, sort):  # noqa: ANN001
+        return ReportPatternsResponse(
+            collection_id=collection_id,
+            level=level,
+            total_communities=0,
+            total_entities=0,
+            total_relationships=0,
+            total_documents=0,
+            count=0,
+            items=[],
+        )
+
     monkeypatch.setattr(collections_controller, "collection_service", collection_service)
     monkeypatch.setattr(collections_controller, "artifact_registry_service", artifact_registry)
     monkeypatch.setattr(tasks_controller, "collection_service", collection_service)
@@ -167,35 +231,47 @@ def app_client(monkeypatch, tmp_path):
     monkeypatch.setattr(collection_query_module, "collection_service", collection_service)
     monkeypatch.setattr(collection_query_module, "artifact_registry_service", artifact_registry)
     monkeypatch.setattr(workspace_controller, "workspace_service", workspace_service)
+    monkeypatch.setattr(retrieval_controller.query_uc, "query_index", fake_query_index)
+    monkeypatch.setattr(
+        retrieval_controller.reports_uc, "list_community_reports", fake_list_community_reports
+    )
+    monkeypatch.setattr(
+        retrieval_controller.reports_uc,
+        "get_community_report_detail",
+        fake_get_community_report_detail,
+    )
+    monkeypatch.setattr(retrieval_controller.reports_uc, "list_patterns", fake_list_patterns)
 
     app = FastAPI()
-    app.include_router(collections_controller.router)
-    app.include_router(tasks_controller.router)
-    app.include_router(workspace_controller.router)
+    app.include_router(retrieval_controller.public_query_router, prefix=API_V1_PREFIX)
+    app.include_router(retrieval_controller.public_reports_router, prefix=API_V1_PREFIX)
+    app.include_router(collections_controller.router, prefix=API_V1_PREFIX)
+    app.include_router(tasks_controller.router, prefix=API_V1_PREFIX)
+    app.include_router(workspace_controller.router, prefix=API_V1_PREFIX)
     return TestClient(app)
 
 
 def test_collection_task_and_query_flow(app_client):
-    create_resp = app_client.post("/collections", json={"name": "Composite Set"})
+    create_resp = app_client.post(f"{API_V1_PREFIX}/collections", json={"name": "Composite Set"})
     assert create_resp.status_code == 200
     collection_id = create_resp.json()["collection_id"]
 
     upload_resp = app_client.post(
-        f"/collections/{collection_id}/files",
+        f"{API_V1_PREFIX}/collections/{collection_id}/files",
         files={"file": ("paper.txt", b"Experimental Section\nMix and anneal.", "text/plain")},
     )
     assert upload_resp.status_code == 200
 
-    task_resp = app_client.post(f"/collections/{collection_id}/tasks/index", json={})
+    task_resp = app_client.post(f"{API_V1_PREFIX}/collections/{collection_id}/tasks/index", json={})
     assert task_resp.status_code == 200
     task_id = task_resp.json()["task_id"]
 
-    task_status = app_client.get(f"/tasks/{task_id}")
+    task_status = app_client.get(f"{API_V1_PREFIX}/tasks/{task_id}")
     assert task_status.status_code == 200
     assert task_status.json()["status"] == "completed"
     assert task_status.json()["current_stage"] == "artifacts_ready"
 
-    collection_tasks = app_client.get(f"/collections/{collection_id}/tasks")
+    collection_tasks = app_client.get(f"{API_V1_PREFIX}/collections/{collection_id}/tasks")
     assert collection_tasks.status_code == 200
     tasks_body = collection_tasks.json()
     assert tasks_body["collection_id"] == collection_id
@@ -203,13 +279,13 @@ def test_collection_task_and_query_flow(app_client):
     assert tasks_body["items"][0]["task_id"] == task_id
 
     completed_tasks = app_client.get(
-        f"/collections/{collection_id}/tasks",
+        f"{API_V1_PREFIX}/collections/{collection_id}/tasks",
         params={"status": "completed", "limit": 5, "offset": 0},
     )
     assert completed_tasks.status_code == 200
     assert completed_tasks.json()["count"] >= 1
 
-    artifacts = app_client.get(f"/tasks/{task_id}/artifacts")
+    artifacts = app_client.get(f"{API_V1_PREFIX}/tasks/{task_id}/artifacts")
     assert artifacts.status_code == 200
     body = artifacts.json()
     assert body["documents_ready"] is True
@@ -217,23 +293,23 @@ def test_collection_task_and_query_flow(app_client):
     assert body["sections_ready"] is True
     assert body["protocol_steps_ready"] is True
 
-    graph = app_client.get(f"/collections/{collection_id}/graph")
+    graph = app_client.get(f"{API_V1_PREFIX}/collections/{collection_id}/graph")
     assert graph.status_code == 200
     graph_body = graph.json()
     assert len(graph_body["nodes"]) == 2
     assert len(graph_body["edges"]) == 1
 
-    graphml = app_client.get(f"/collections/{collection_id}/graphml")
+    graphml = app_client.get(f"{API_V1_PREFIX}/collections/{collection_id}/graphml")
     assert graphml.status_code == 200
     assert graphml.headers["content-type"].startswith("application/graphml+xml")
 
-    steps = app_client.get(f"/collections/{collection_id}/protocol/steps")
+    steps = app_client.get(f"{API_V1_PREFIX}/collections/{collection_id}/protocol/steps")
     assert steps.status_code == 200
     assert steps.json()["count"] >= 1
     assert steps.json()["items"][0]["paper_title"] == "Composite Paper"
 
     search = app_client.get(
-        f"/collections/{collection_id}/protocol/search",
+        f"{API_V1_PREFIX}/collections/{collection_id}/protocol/search",
         params={"q": "anneal Ar", "limit": 5},
     )
     assert search.status_code == 200
@@ -241,7 +317,7 @@ def test_collection_task_and_query_flow(app_client):
     assert search.json()["items"][0]["paper_title"] == "Composite Paper"
 
     sop = app_client.post(
-        f"/collections/{collection_id}/protocol/sop",
+        f"{API_V1_PREFIX}/collections/{collection_id}/protocol/sop",
         json={"goal": "Design a composite SOP", "target_properties": ["mechanical", "thermal"]},
     )
     assert sop.status_code == 200
@@ -250,7 +326,7 @@ def test_collection_task_and_query_flow(app_client):
     assert sop_body["sop_draft"]["objective"] == "Design a composite SOP"
     assert sop_body["sop_draft"]["steps"][0]["paper_title"] == "Composite Paper"
 
-    workspace = app_client.get(f"/collections/{collection_id}/workspace")
+    workspace = app_client.get(f"{API_V1_PREFIX}/collections/{collection_id}/workspace")
     assert workspace.status_code == 200
     workspace_body = workspace.json()
     assert workspace_body["collection"]["collection_id"] == collection_id
@@ -261,21 +337,21 @@ def test_collection_task_and_query_flow(app_client):
 
 
 def test_delete_collection_removes_app_layer_collection(app_client):
-    create_resp = app_client.post("/collections", json={"name": "Delete Me"})
+    create_resp = app_client.post(f"{API_V1_PREFIX}/collections", json={"name": "Delete Me"})
     assert create_resp.status_code == 200
     collection_id = create_resp.json()["collection_id"]
 
-    get_resp = app_client.get(f"/collections/{collection_id}")
+    get_resp = app_client.get(f"{API_V1_PREFIX}/collections/{collection_id}")
     assert get_resp.status_code == 200
 
-    delete_resp = app_client.delete(f"/collections/{collection_id}")
+    delete_resp = app_client.delete(f"{API_V1_PREFIX}/collections/{collection_id}")
     assert delete_resp.status_code == 200
     assert delete_resp.json()["collection_id"] == collection_id
 
-    missing_resp = app_client.get(f"/collections/{collection_id}")
+    missing_resp = app_client.get(f"{API_V1_PREFIX}/collections/{collection_id}")
     assert missing_resp.status_code == 404
 
-    list_resp = app_client.get("/collections")
+    list_resp = app_client.get(f"{API_V1_PREFIX}/collections")
     assert list_resp.status_code == 200
     assert all(
         item["collection_id"] != collection_id for item in list_resp.json()["items"]
@@ -283,23 +359,23 @@ def test_delete_collection_removes_app_layer_collection(app_client):
 
 
 def test_collection_protocol_endpoints_return_readiness_error_until_artifacts_exist(app_client):
-    create_resp = app_client.post("/collections", json={"name": "Pending Collection"})
+    create_resp = app_client.post(f"{API_V1_PREFIX}/collections", json={"name": "Pending Collection"})
     assert create_resp.status_code == 200
     collection_id = create_resp.json()["collection_id"]
 
     upload_resp = app_client.post(
-        f"/collections/{collection_id}/files",
+        f"{API_V1_PREFIX}/collections/{collection_id}/files",
         files={"file": ("paper.txt", b"Experimental Section\nMix and anneal.", "text/plain")},
     )
     assert upload_resp.status_code == 200
 
-    workspace = app_client.get(f"/collections/{collection_id}/workspace")
+    workspace = app_client.get(f"{API_V1_PREFIX}/collections/{collection_id}/workspace")
     assert workspace.status_code == 200
     workspace_body = workspace.json()
     assert workspace_body["artifacts"]["protocol_steps_ready"] is False
     assert workspace_body["capabilities"]["can_view_protocol_steps"] is False
 
-    steps = app_client.get(f"/collections/{collection_id}/protocol/steps")
+    steps = app_client.get(f"{API_V1_PREFIX}/collections/{collection_id}/protocol/steps")
     assert steps.status_code == 409
     steps_detail = steps.json()["detail"]
     assert steps_detail["code"] == "protocol_artifacts_not_ready"
@@ -307,15 +383,45 @@ def test_collection_protocol_endpoints_return_readiness_error_until_artifacts_ex
     assert steps_detail["artifacts"]["protocol_steps_ready"] is False
 
     search = app_client.get(
-        f"/collections/{collection_id}/protocol/search",
+        f"{API_V1_PREFIX}/collections/{collection_id}/protocol/search",
         params={"q": "anneal", "limit": 5},
     )
     assert search.status_code == 409
     assert search.json()["detail"]["code"] == "protocol_artifacts_not_ready"
 
     sop = app_client.post(
-        f"/collections/{collection_id}/protocol/sop",
+        f"{API_V1_PREFIX}/collections/{collection_id}/protocol/sop",
         json={"goal": "Build a draft SOP"},
     )
     assert sop.status_code == 409
     assert sop.json()["detail"]["code"] == "protocol_artifacts_not_ready"
+
+
+def test_legacy_app_layer_routes_are_not_exposed(app_client):
+    assert app_client.get("/collections").status_code == 404
+    assert app_client.get("/tasks/test-task").status_code == 404
+    assert app_client.post("/retrieval/query", json={"query": "test"}).status_code == 404
+    assert (
+        app_client.post(f"{API_V1_PREFIX}/retrieval/query", json={"query": "test"}).status_code
+        == 404
+    )
+
+
+def test_public_query_and_reports_routes_are_exposed(app_client):
+    query_resp = app_client.post(f"{API_V1_PREFIX}/query", json={"query": "status"})
+    assert query_resp.status_code == 200
+    assert query_resp.json()["answer"] == "stub-answer"
+
+    reports_resp = app_client.get(f"{API_V1_PREFIX}/collections/demo/reports/communities")
+    assert reports_resp.status_code == 200
+    assert reports_resp.json()["collection_id"] == "demo"
+
+    detail_resp = app_client.get(
+        f"{API_V1_PREFIX}/collections/demo/reports/communities/42"
+    )
+    assert detail_resp.status_code == 200
+    assert detail_resp.json()["community_id"] == 42
+
+    patterns_resp = app_client.get(f"{API_V1_PREFIX}/collections/demo/reports/patterns")
+    assert patterns_resp.status_code == 200
+    assert patterns_resp.json()["collection_id"] == "demo"

--- a/backend/tests/test_units/test_protocol_api.py
+++ b/backend/tests/test_units/test_protocol_api.py
@@ -69,7 +69,8 @@ def test_cors_default_is_not_wildcard_with_credentials():
         None,
     )
     assert cors is not None
+    options = cors.kwargs
     assert not (
-        cors.options.get("allow_origins") == ["*"]
-        and cors.options.get("allow_credentials") is True
+        options.get("allow_origins") == ["*"]
+        and options.get("allow_credentials") is True
     )

--- a/backend/tests/test_units/test_protocol_api.py
+++ b/backend/tests/test_units/test_protocol_api.py
@@ -1,10 +1,9 @@
-import json
-
-import pandas as pd
 import pytest
 
 try:
     from fastapi.testclient import TestClient
+    from fastapi.middleware.cors import CORSMiddleware
+
     FASTAPI_AVAILABLE = True
 except ImportError:  # pragma: no cover
     FASTAPI_AVAILABLE = False
@@ -12,172 +11,65 @@ except ImportError:  # pragma: no cover
 if not FASTAPI_AVAILABLE:  # pragma: no cover
     pytest.skip("fastapi not installed", allow_module_level=True)
 
-from main import app
+from main import PUBLIC_API_PREFIX, PUBLIC_API_V1_PREFIX, app
 
 
 @pytest.fixture()
-def protocol_client(tmp_path):
-    output_dir = tmp_path / "output"
-    output_dir.mkdir(parents=True, exist_ok=True)
-    documents = pd.DataFrame(
-        [
-            {"id": "paper-1", "title": "Composite Annealing Study"},
-            {"id": "paper-2", "title": "Mechanical Validation Report"},
-        ]
+def client():
+    return TestClient(app)
+
+
+def test_docs_and_openapi_move_under_api_prefix(client):
+    docs_resp = client.get(f"{PUBLIC_API_PREFIX}/docs")
+    assert docs_resp.status_code == 200
+
+    redoc_resp = client.get(f"{PUBLIC_API_PREFIX}/redoc")
+    assert redoc_resp.status_code == 200
+
+    openapi_resp = client.get(f"{PUBLIC_API_PREFIX}/openapi.json")
+    assert openapi_resp.status_code == 200
+
+    openapi_text = openapi_resp.text
+    assert f"{PUBLIC_API_V1_PREFIX}/query" in openapi_text
+    assert (
+        f"{PUBLIC_API_V1_PREFIX}/collections/{{collection_id}}/reports/communities"
+        in openapi_text
     )
-
-    sections = pd.DataFrame(
-        [
-            {
-                "paper_id": "paper-1",
-                "section_id": "sec-1",
-                "section_type": "methods",
-                "title": "Experimental Section",
-                "text": "The samples were mixed and annealed.",
-                "order": 1,
-                "language": "en",
-            }
-        ]
+    assert (
+        f"{PUBLIC_API_V1_PREFIX}/collections/{{collection_id}}/protocol/steps"
+        in openapi_text
     )
-    blocks = pd.DataFrame(
-        [
-            {
-                "paper_id": "paper-1",
-                "section_id": "sec-1",
-                "block_id": "blk-1",
-                "block_type": "synthesis",
-                "text": "Mix powders and anneal at 600 C for 2 h under N2.",
-                "order": 1,
-            }
-        ]
+    assert f"{PUBLIC_API_V1_PREFIX}/retrieval/protocol/steps" not in openapi_text
+
+
+def test_static_moves_under_api_prefix(client):
+    assert client.get(f"{PUBLIC_API_PREFIX}/static/configs/default.yaml").status_code == 200
+    assert client.get("/static/configs/default.yaml").status_code == 404
+
+
+def test_legacy_public_routes_are_not_exposed(client):
+    assert client.get("/docs").status_code == 404
+    assert client.get("/redoc").status_code == 404
+    assert client.get("/openapi.json").status_code == 404
+    assert client.get("/retrieval/protocol/steps").status_code == 404
+    assert client.get(f"{PUBLIC_API_V1_PREFIX}/retrieval/protocol/steps").status_code == 404
+
+
+def test_real_app_legacy_browser_routes_return_404(client):
+    assert client.get("/collections").status_code == 404
+    assert client.get("/collections/test-collection").status_code == 404
+    assert client.get("/tasks/test-task").status_code == 404
+    assert client.post("/retrieval/query", json={"query": "test"}).status_code == 404
+    assert client.post(f"{PUBLIC_API_V1_PREFIX}/retrieval/query", json={"query": "test"}).status_code == 404
+
+
+def test_cors_default_is_not_wildcard_with_credentials():
+    cors = next(
+        (middleware for middleware in app.user_middleware if middleware.cls is CORSMiddleware),
+        None,
     )
-    steps = pd.DataFrame(
-        [
-            {
-                "step_id": "step-1",
-                "paper_id": "paper-1",
-                "section_id": "sec-1",
-                "block_id": "blk-1",
-                "block_type": "synthesis",
-                "order": 1,
-                "action": "Anneal mixed powders at 600 C under N2",
-                "purpose": "improve crystallinity",
-                "expected_output": "annealed composite",
-                "materials": json.dumps([
-                    {"name": "epoxy", "role": "matrix"},
-                    {"name": "SiO2", "role": "filler"},
-                ]),
-                "conditions": json.dumps(
-                    {
-                        "temperature_k": 873.15,
-                        "duration_s": 7200,
-                        "atmosphere": "N2",
-                    }
-                ),
-                "characterization": json.dumps([
-                    {"method": "XRD"},
-                    {"method": "SEM"},
-                ]),
-                "controls": json.dumps(["baseline_control"]),
-                "evidence_refs": json.dumps([
-                    {"paper_id": "paper-1", "snippet_id": "snip-1"}
-                ]),
-                "confidence_score": 0.91,
-            },
-            {
-                "step_id": "step-2",
-                "paper_id": "paper-2",
-                "section_id": "sec-2",
-                "block_id": "blk-2",
-                "block_type": "characterization",
-                "order": 2,
-                "action": "Measure tensile strength and thermal conductivity",
-                "purpose": "validate performance",
-                "expected_output": "property metrics",
-                "materials": json.dumps([{"name": "sample", "role": "sample"}]),
-                "conditions": json.dumps({"temperature_k": 298.15}),
-                "characterization": json.dumps([
-                    {"method": "tensile"},
-                    {"method": "thermal_conductivity"},
-                ]),
-                "controls": json.dumps([]),
-                "evidence_refs": json.dumps([
-                    {"paper_id": "paper-2", "snippet_id": "snip-2"}
-                ]),
-                "confidence_score": 0.85,
-            },
-        ]
+    assert cors is not None
+    assert not (
+        cors.options.get("allow_origins") == ["*"]
+        and cors.options.get("allow_credentials") is True
     )
-
-    documents.to_parquet(output_dir / "documents.parquet")
-    sections.to_parquet(output_dir / "sections.parquet")
-    blocks.to_parquet(output_dir / "procedure_blocks.parquet")
-    steps.to_parquet(output_dir / "protocol_steps.parquet")
-
-    client = TestClient(app)
-    return client, output_dir
-
-
-def test_protocol_extract_returns_summary(protocol_client):
-    client, output_dir = protocol_client
-    resp = client.post(
-        "/retrieval/protocol/extract",
-        json={"output_path": str(output_dir), "paper_ids": ["paper-1"], "limit": 5},
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["summary"]["sections"] == 1
-    assert body["summary"]["procedure_blocks"] == 1
-    assert body["summary"]["protocol_steps"] == 1
-    assert body["protocol_steps"][0]["paper_id"] == "paper-1"
-    assert body["protocol_steps"][0]["paper_title"] == "Composite Annealing Study"
-
-
-def test_protocol_steps_filters_by_paper(protocol_client):
-    client, output_dir = protocol_client
-    resp = client.get(
-        "/retrieval/protocol/steps",
-        params={"output_path": str(output_dir), "paper_id": "paper-2", "limit": 10},
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["count"] == 1
-    assert body["items"][0]["step_id"] == "step-2"
-    assert body["items"][0]["paper_title"] == "Mechanical Validation Report"
-
-
-def test_protocol_search_returns_ranked_hits(protocol_client):
-    client, output_dir = protocol_client
-    resp = client.get(
-        "/retrieval/protocol/search",
-        params={"output_path": str(output_dir), "q": "anneal N2", "limit": 5},
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["count"] >= 1
-    assert body["items"][0]["step_id"] == "step-1"
-    assert body["items"][0]["paper_title"] == "Composite Annealing Study"
-    assert "anneal" in body["items"][0]["matched_terms"]
-
-
-def test_protocol_sop_returns_structured_draft(protocol_client):
-    client, output_dir = protocol_client
-    resp = client.post(
-        "/retrieval/protocol/sop",
-        json={
-            "output_path": str(output_dir),
-            "goal": "Design a composite protocol for mechanical and thermal optimization",
-            "target_properties": ["mechanical", "thermal"],
-            "paper_ids": ["paper-1"],
-            "max_steps": 5,
-        },
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["count"] == 1
-    draft = body["sop_draft"]
-    assert draft["objective"] == "Design a composite protocol for mechanical and thermal optimization"
-    assert draft["steps"][0]["step_id"] == "step-1"
-    assert draft["steps"][0]["paper_title"] == "Composite Annealing Study"
-    assert any(item["property"] == "mechanical" for item in draft["measurement_plan"])
-    assert any(item["property"] == "thermal" for item in draft["measurement_plan"])


### PR DESCRIPTION
## Summary
- move backend browser-visible docs, OpenAPI, and static assets under `/api/*`
- expose browser-visible backend business routes only under `/api/v1/*`
- stop exposing legacy bare `/collections/*`, `/tasks/*`, `/retrieval/*`, `/docs`, `/redoc`, `/openapi.json`, and `/static/*` routes
- update backend docs and focused backend contract tests to match the new public surface
- fix the CORS middleware assertion test to read FastAPI middleware kwargs correctly

## Testing
- `uv run --project backend --with pytest pytest backend/tests/test_units/test_app_layer_api.py backend/tests/test_units/test_protocol_api.py -q`

## Notes
- collection-scoped protocol endpoints remain public at `/api/v1/collections/{collection_id}/protocol/*`
- raw retrieval protocol endpoints are intentionally not part of the public browser contract in this branch
- closes #56
