### PR TITLE
release: promote develop to main for v0.3.3

### DIFF
--- a/backend/application/core/README.md
+++ b/backend/application/core/README.md
@@ -4,10 +4,10 @@ This package owns the research-fact backbone produced from normalized Source
 artifacts.
 
 - `document_profile_service.py`
-  Document typing, protocol suitability, and collection summaries
+  LLM structured document typing, protocol suitability, and collection summaries
 - `evidence_card_service.py`
-  Evidence-card extraction and supporting backbone artifacts
+  LLM structured extraction for evidence/sample/result/test/baseline artifacts
 - `comparison_service.py`
-  Comparison-row generation and comparability evaluation
+  Deterministic comparison-row generation and comparability evaluation
 - `workspace_overview_service.py`
   Collection-facing overview assembled from Source state and Core artifacts

--- a/backend/application/core/comparison_service.py
+++ b/backend/application/core/comparison_service.py
@@ -11,6 +11,10 @@ from domain.core.comparison import (
     evaluate_comparison_assessment,
 )
 from domain.shared.enums import TRACEABILITY_STATUS_MISSING
+from application.core.core_semantic_version import (
+    core_semantic_rebuild_required,
+    write_core_semantic_manifest,
+)
 from application.source.collection_service import CollectionService
 from application.core.evidence_card_service import EvidenceCardService, EvidenceCardsNotReadyError
 from application.source.artifact_registry_service import ArtifactRegistryService
@@ -175,6 +179,8 @@ class ComparisonService:
                 pd.read_parquet(path),
                 _COMPARISON_JSON_COLUMNS,
             )
+            if core_semantic_rebuild_required(output_dir) and (output_dir / "documents.parquet").is_file():
+                rows = self.build_comparison_rows(collection_id, output_dir)
         else:
             rows = self.build_comparison_rows(collection_id, output_dir)
         return self._normalize_rows_table(rows, collection_id)
@@ -224,6 +230,7 @@ class ComparisonService:
             table,
             _COMPARISON_JSON_COLUMNS,
         ).to_parquet(base_dir / _COMPARISON_ROWS_FILE, index=False)
+        write_core_semantic_manifest(base_dir)
         self.artifact_registry_service.upsert(collection_id, base_dir)
         return table
 

--- a/backend/application/core/core_semantic_version.py
+++ b/backend/application/core/core_semantic_version.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+CURRENT_CORE_SEMANTIC_VERSION = "llm_v1"
+CORE_SEMANTIC_MANIFEST_FILE = "core_semantic_manifest.json"
+CORE_SEMANTIC_ARTIFACT_FILES = (
+    "document_profiles.parquet",
+    "evidence_cards.parquet",
+    "characterization_observations.parquet",
+    "structure_features.parquet",
+    "test_conditions.parquet",
+    "baseline_references.parquet",
+    "sample_variants.parquet",
+    "measurement_results.parquet",
+    "comparison_rows.parquet",
+)
+_STRUCTURAL_INPUT_FILES = (
+    "documents.parquet",
+    "sections.parquet",
+    "table_cells.parquet",
+)
+
+
+def core_semantic_manifest_path(base_dir: str | Path) -> Path:
+    return Path(base_dir).expanduser().resolve() / CORE_SEMANTIC_MANIFEST_FILE
+
+
+def structural_inputs_available(base_dir: str | Path) -> bool:
+    resolved = Path(base_dir).expanduser().resolve()
+    return any((resolved / filename).is_file() for filename in _STRUCTURAL_INPUT_FILES)
+
+
+def core_semantic_version_is_current(base_dir: str | Path) -> bool:
+    manifest_path = core_semantic_manifest_path(base_dir)
+    if not manifest_path.is_file():
+        return not structural_inputs_available(base_dir)
+
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return False
+    return payload.get("version") == CURRENT_CORE_SEMANTIC_VERSION
+
+
+def core_semantic_rebuild_required(base_dir: str | Path) -> bool:
+    return structural_inputs_available(base_dir) and not core_semantic_version_is_current(base_dir)
+
+
+def write_core_semantic_manifest(base_dir: str | Path) -> None:
+    manifest_path = core_semantic_manifest_path(base_dir)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps({"version": CURRENT_CORE_SEMANTIC_VERSION}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def purge_stale_core_semantic_artifacts(base_dir: str | Path) -> None:
+    resolved = Path(base_dir).expanduser().resolve()
+    if not core_semantic_rebuild_required(resolved):
+        return
+    for filename in (*CORE_SEMANTIC_ARTIFACT_FILES, CORE_SEMANTIC_MANIFEST_FILE):
+        path = resolved / filename
+        if path.is_file():
+            path.unlink()

--- a/backend/application/core/document_profile_service.py
+++ b/backend/application/core/document_profile_service.py
@@ -9,7 +9,6 @@ import pandas as pd
 
 from domain.core.document_profile import (
     DocumentProfile,
-    analyze_document_profile,
     summarize_document_profile_collection,
 )
 from domain.shared.enums import (
@@ -23,6 +22,15 @@ from infra.persistence.backbone_codec import (
     restore_frame_from_storage,
 )
 from application.source.collection_service import CollectionService
+from application.core.core_semantic_version import (
+    core_semantic_rebuild_required,
+    purge_stale_core_semantic_artifacts,
+    write_core_semantic_manifest,
+)
+from application.core.llm_structured_extractor import (
+    CoreLLMStructuredExtractor,
+    build_default_core_llm_structured_extractor,
+)
 from application.source.artifact_input_service import (
     build_document_records,
     load_collection_inputs,
@@ -95,11 +103,13 @@ class DocumentProfileService:
         self,
         collection_service: CollectionService | None = None,
         artifact_registry_service: ArtifactRegistryService | None = None,
+        structured_extractor: CoreLLMStructuredExtractor | None = None,
     ) -> None:
         self.collection_service = collection_service or CollectionService()
         self.artifact_registry_service = (
             artifact_registry_service or ArtifactRegistryService()
         )
+        self._structured_extractor = structured_extractor
 
     def list_document_profiles(
         self,
@@ -206,7 +216,10 @@ class DocumentProfileService:
                 pd.read_parquet(path),
                 _DOCUMENT_PROFILE_JSON_COLUMNS,
             )
-            if self._profile_rebuild_required(profiles) and (output_dir / "documents.parquet").is_file():
+            if (
+                self._profile_rebuild_required(profiles)
+                or core_semantic_rebuild_required(output_dir)
+            ) and (output_dir / "documents.parquet").is_file():
                 profiles = self.build_document_profiles(collection_id, output_dir)
         else:
             profiles = self.build_document_profiles(collection_id, output_dir)
@@ -222,6 +235,7 @@ class DocumentProfileService:
             if output_dir is not None
             else self._resolve_output_dir(collection_id)
         )
+        purge_stale_core_semantic_artifacts(base_dir)
         documents_path = base_dir / "documents.parquet"
         if not documents_path.is_file():
             raise DocumentProfilesNotReadyError(collection_id, base_dir)
@@ -264,8 +278,14 @@ class DocumentProfileService:
             profiles,
             _DOCUMENT_PROFILE_JSON_COLUMNS,
         ).to_parquet(base_dir / _DOCUMENT_PROFILES_FILE, index=False)
+        write_core_semantic_manifest(base_dir)
         self.artifact_registry_service.upsert(collection_id, base_dir)
         return profiles
+
+    def _get_structured_extractor(self) -> CoreLLMStructuredExtractor:
+        if self._structured_extractor is None:
+            self._structured_extractor = build_default_core_llm_structured_extractor()
+        return self._structured_extractor
 
     def count_protocol_suitable(self, profiles: pd.DataFrame) -> int:
         normalized = self._normalize_profiles_table(profiles, None)
@@ -304,16 +324,45 @@ class DocumentProfileService:
         )
         analysis_title = str(row.get("title") or document_id)
         text = str(row.get("text") or "")
-        profile = analyze_document_profile(
-            collection_id=collection_id,
-            document_id=document_id,
-            title=title,
-            source_filename=source_filename,
-            analysis_title=analysis_title,
-            text=text,
-            sections=sections,
+        profile_payload = {
+            "collection_id": collection_id,
+            "document_id": document_id,
+            "title": title,
+            "source_filename": source_filename,
+            "analysis_title": analysis_title,
+            "representative_text": text[:12000],
+            "sections": [
+                {
+                    "section_id": str(section.get("section_id") or ""),
+                    "section_type": str(section.get("section_type") or ""),
+                    "heading": self._normalize_optional_text(section.get("heading")),
+                    "text": str(section.get("text") or "")[:4000],
+                }
+                for section in sections
+                if isinstance(section, dict)
+            ],
+        }
+        extracted = self._get_structured_extractor().extract_document_profile(
+            profile_payload
         )
-        return profile.to_record()
+        normalized = DocumentProfile.from_mapping(
+            {
+                "document_id": document_id,
+                "collection_id": collection_id,
+                "title": title,
+                "source_filename": source_filename,
+                "doc_type": str(extracted.doc_type or DOC_TYPE_UNCERTAIN),
+                "protocol_extractable": str(
+                    extracted.protocol_extractable or PROTOCOL_EXTRACTABLE_UNCERTAIN
+                ),
+                "protocol_extractability_signals": list(
+                    extracted.protocol_extractability_signals
+                ),
+                "parsing_warnings": list(extracted.parsing_warnings),
+                "confidence": extracted.confidence,
+            }
+        )
+        return normalized.to_record()
 
     def summarize_document_profiles(self, profiles: pd.DataFrame) -> dict[str, Any]:
         normalized = self._normalize_profiles_table(profiles, None)

--- a/backend/application/core/evidence_card_service.py
+++ b/backend/application/core/evidence_card_service.py
@@ -2,13 +2,47 @@ from __future__ import annotations
 
 import json
 import re
-from urllib.parse import urlencode
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlencode
 from uuid import uuid4
 
 import pandas as pd
 
+from application.core.core_semantic_version import (
+    core_semantic_rebuild_required,
+    purge_stale_core_semantic_artifacts,
+    write_core_semantic_manifest,
+)
+from application.core.document_profile_service import (
+    DocumentProfileService,
+    DocumentProfilesNotReadyError,
+)
+from application.core.llm_extraction_models import (
+    BaselineReferencePayload,
+    ConditionContextPayload,
+    EvidenceAnchorPayload,
+    EvidenceCardPayload,
+    ExtractedTestConditionPayload,
+    MeasurementResultPayload,
+    ProcessContextPayload,
+    SampleVariantPayload,
+    StructuredExtractionBundle,
+    TestConditionPayloadModel,
+    TestContextPayload,
+)
+from application.core.llm_structured_extractor import (
+    CoreLLMStructuredExtractor,
+    build_default_core_llm_structured_extractor,
+)
+from application.source.artifact_input_service import (
+    build_document_records,
+    load_collection_inputs,
+    load_sections_artifact,
+    load_table_cells_artifact,
+)
+from application.source.artifact_registry_service import ArtifactRegistryService
+from application.source.collection_service import CollectionService
 from domain.core.evidence_backbone import (
     BaselineReference,
     CORE_NEUTRAL_DOMAIN_PROFILE,
@@ -21,33 +55,18 @@ from domain.core.evidence_backbone import (
 )
 from domain.shared.enums import (
     DOC_TYPE_REVIEW,
-    DOC_TYPE_UNCERTAIN,
     EPISTEMIC_DIRECTLY_OBSERVED,
     EPISTEMIC_INFERRED_FROM_CHARACTERIZATION,
-    EPISTEMIC_INFERRED_WITH_LOW_CONFIDENCE,
     EPISTEMIC_NORMALIZED_FROM_EVIDENCE,
     EPISTEMIC_UNRESOLVED,
     TRACEABILITY_STATUS_DIRECT,
     TRACEABILITY_STATUS_MISSING,
-    TRACEABILITY_STATUS_PARTIAL,
 )
 from infra.persistence.backbone_codec import (
     normalize_backbone_value,
     prepare_frame_for_storage,
     restore_frame_from_storage,
 )
-from application.source.collection_service import CollectionService
-from application.source.artifact_input_service import (
-    build_document_records,
-    load_collection_inputs,
-    load_sections_artifact,
-    load_table_cells_artifact,
-)
-from application.core.document_profile_service import (
-    DocumentProfileService,
-    DocumentProfilesNotReadyError,
-)
-from application.source.artifact_registry_service import ArtifactRegistryService
 
 
 _EVIDENCE_CARDS_FILE = "evidence_cards.parquet"
@@ -177,7 +196,7 @@ _MEASUREMENT_RESULT_COLUMNS = [
     "result_source_type",
     "epistemic_status",
 ]
-
+_EVIDENCE_SOURCE_TYPES = {"figure", "table", "method", "text"}
 _CHARACTERIZATION_METHODS = (
     "XRD",
     "SEM",
@@ -189,9 +208,6 @@ _CHARACTERIZATION_METHODS = (
     "TGA",
     "DMA",
 )
-
-_EVIDENCE_SOURCE_TYPES = {"figure", "table", "method", "text"}
-
 _PROPERTY_HINTS = (
     ("yield strength", "yield_strength"),
     ("tensile strength", "tensile_strength"),
@@ -209,64 +225,8 @@ _PROPERTY_HINTS = (
     ("density", "density"),
     ("strength", "strength"),
 )
-
-_MECHANISM_HINTS = (
-    "may be linked",
-    "attributed to",
-    "due to",
-    "because of",
-    "proposed as the cause",
-)
-
-_PROPERTY_SENTENCE_HINTS = (
-    "improv",
-    "increase",
-    "decrease",
-    "higher",
-    "lower",
-    "enhance",
-    "reduc",
-    "denser",
-    "better",
-)
-
-_TEMP_PATTERN = re.compile(r"(\d+(?:\.\d+)?)\s*(?:c|°c|k|f)\b", re.IGNORECASE)
-_TIME_PATTERN = re.compile(
-    r"(\d+(?:\.\d+)?)\s*(h|hr|hrs|hour|hours|min|mins|minute|minutes|s|sec|secs)\b",
-    re.IGNORECASE,
-)
-_ATMOSPHERE_PATTERN = re.compile(
-    r"\b(?:under|in)\s+(air|argon|ar|nitrogen|n2|vacuum)\b", re.IGNORECASE
-)
-_TABLE_NUMERIC_PATTERN = re.compile(r"[-+]?\d+(?:\.\d+)?")
-_TABLE_SAMPLE_HEADER_HINTS = ("sample", "group", "variant", "condition")
-_TABLE_BASELINE_HEADER_HINTS = ("baseline", "control", "reference")
-_TABLE_VARIANT_HEADER_HINTS = (
-    "current",
-    "power",
-    "speed",
-    "heating",
-    "beam",
-    "strategy",
-    "temperature",
-    "orientation",
-    "direction",
-    "content",
-    "wt%",
-    "vol%",
-    "loading",
-    "ratio",
-)
 _OBSERVED_VALUE_PATTERN = re.compile(
     r"([-+]?\d+(?:\.\d+)?)\s*(nm|um|μm|mm|cm|m2/g|m\^2/g|m²/g|mpa|gpa|pa|%)\b",
-    re.IGNORECASE,
-)
-_RANGE_VALUE_PATTERN = re.compile(
-    r"([-+]?\d+(?:\.\d+)?)\s*(?:-|to|–)\s*([-+]?\d+(?:\.\d+)?)",
-    re.IGNORECASE,
-)
-_CLAIM_VALUE_PATTERN = re.compile(
-    r"\b(?:of|to|at)\s+([-+]?\d+(?:\.\d+)?)\s*([A-Za-z%/0-9\-\^²·]+)?",
     re.IGNORECASE,
 )
 _PHASE_PATTERN = re.compile(
@@ -324,6 +284,7 @@ class EvidenceCardService:
         collection_service: CollectionService | None = None,
         artifact_registry_service: ArtifactRegistryService | None = None,
         document_profile_service: DocumentProfileService | None = None,
+        structured_extractor: CoreLLMStructuredExtractor | None = None,
     ) -> None:
         self.collection_service = collection_service or CollectionService()
         self.artifact_registry_service = (
@@ -333,6 +294,12 @@ class EvidenceCardService:
             collection_service=self.collection_service,
             artifact_registry_service=self.artifact_registry_service,
         )
+        self._structured_extractor = structured_extractor
+
+    def _get_structured_extractor(self) -> CoreLLMStructuredExtractor:
+        if self._structured_extractor is None:
+            self._structured_extractor = build_default_core_llm_structured_extractor()
+        return self._structured_extractor
 
     def list_evidence_cards(
         self,
@@ -422,6 +389,8 @@ class EvidenceCardService:
                 pd.read_parquet(path),
                 _EVIDENCE_JSON_COLUMNS,
             )
+            if core_semantic_rebuild_required(output_dir) and (output_dir / "documents.parquet").is_file():
+                cards = self.build_evidence_cards(collection_id, output_dir)
         else:
             cards = self.build_evidence_cards(collection_id, output_dir)
         return self._normalize_cards_table(cards, collection_id)
@@ -436,6 +405,7 @@ class EvidenceCardService:
             if output_dir is not None
             else self._resolve_output_dir(collection_id)
         )
+        purge_stale_core_semantic_artifacts(base_dir)
         documents_path = base_dir / "documents.parquet"
         if not documents_path.is_file():
             raise EvidenceCardsNotReadyError(collection_id, base_dir)
@@ -451,92 +421,133 @@ class EvidenceCardService:
             table_cells = load_table_cells_artifact(base_dir)
         except FileNotFoundError as exc:
             raise EvidenceCardsNotReadyError(collection_id, base_dir) from exc
+
         document_records = build_document_records(documents, text_units)
         sections_by_doc = self._group_sections_by_document(sections)
         table_cells_by_doc = self._group_table_cells_by_document(table_cells)
-
         profile_by_doc = {
             str(row.get("document_id")): dict(row)
             for _, row in profiles.iterrows()
         }
 
-        cards: list[dict[str, Any]] = []
+        card_rows: list[dict[str, Any]] = []
+        sample_variant_rows: list[dict[str, Any]] = []
+        test_condition_rows: list[dict[str, Any]] = []
+        baseline_rows: list[dict[str, Any]] = []
+        measurement_rows: list[dict[str, Any]] = []
+
+        extractor = self._get_structured_extractor()
+
         for _, row in document_records.iterrows():
             document_id = str(row.get("paper_id") or "")
             profile = profile_by_doc.get(document_id)
             if not profile:
                 continue
-            title = str(row.get("title") or document_id)
-            text = str(row.get("text") or "")
+
+            title = (
+                self._normalize_scalar_text(profile.get("title"))
+                or self._normalize_scalar_text(row.get("title"))
+                or document_id
+            )
+            source_filename = self._normalize_scalar_text(profile.get("source_filename"))
             doc_sections = sections_by_doc.get(document_id, [])
-            cards.extend(
-                self._build_cards_for_document(
+            grouped_rows = self._group_table_rows(table_cells_by_doc.get(document_id, []))
+            document_state = self._build_document_state()
+
+            for section in doc_sections:
+                bundle = extractor.extract_section_bundle(
+                    self._build_section_extraction_payload(
+                        document_id=document_id,
+                        title=title,
+                        source_filename=source_filename,
+                        profile=profile,
+                        section=section,
+                    )
+                )
+                self._materialize_bundle(
+                    bundle=bundle,
                     collection_id=collection_id,
                     document_id=document_id,
-                    title=title,
-                    text=text,
-                    text_unit_ids=self._normalize_list(row.get("text_unit_ids")),
-                    profile=profile,
-                    sections=doc_sections,
-                    table_cells=table_cells_by_doc.get(document_id, []),
+                    section=section,
+                    table_id=None,
+                    row_index=None,
+                    card_rows=card_rows,
+                    sample_variant_rows=sample_variant_rows,
+                    test_condition_rows=test_condition_rows,
+                    baseline_rows=baseline_rows,
+                    measurement_rows=measurement_rows,
+                    document_state=document_state,
                 )
-            )
 
-        cards_table = pd.DataFrame(
-            cards,
-            columns=[
-                "evidence_id",
-                "document_id",
-                "collection_id",
-                "claim_text",
-                "claim_type",
-                "evidence_source_type",
-                "evidence_anchors",
-                "material_system",
-                "condition_context",
-                "confidence",
-                "traceability_status",
-            ],
+            if str(profile.get("doc_type") or "") != DOC_TYPE_REVIEW:
+                for (table_id, row_index), row_cells in grouped_rows.items():
+                    bundle = extractor.extract_table_row_bundle(
+                        self._build_table_row_extraction_payload(
+                            document_id=document_id,
+                            title=title,
+                            source_filename=source_filename,
+                            profile=profile,
+                            table_id=table_id,
+                            row_index=row_index,
+                            row_cells=row_cells,
+                            sections=doc_sections,
+                        )
+                    )
+                    self._materialize_bundle(
+                        bundle=bundle,
+                        collection_id=collection_id,
+                        document_id=document_id,
+                        section=None,
+                        table_id=table_id,
+                        row_index=row_index,
+                        card_rows=card_rows,
+                        sample_variant_rows=sample_variant_rows,
+                        test_condition_rows=test_condition_rows,
+                        baseline_rows=baseline_rows,
+                        measurement_rows=measurement_rows,
+                        document_state=document_state,
+                    )
+
+        cards_table = self._normalize_cards_table(
+            pd.DataFrame(
+                card_rows,
+                columns=[
+                    "evidence_id",
+                    "document_id",
+                    "collection_id",
+                    "claim_text",
+                    "claim_type",
+                    "evidence_source_type",
+                    "evidence_anchors",
+                    "material_system",
+                    "condition_context",
+                    "confidence",
+                    "traceability_status",
+                ],
+            ),
+            collection_id,
         )
-        cards_table = self._normalize_cards_table(cards_table, collection_id)
-
-        base_dir.mkdir(parents=True, exist_ok=True)
-        prepare_frame_for_storage(
-            cards_table,
-            _EVIDENCE_JSON_COLUMNS,
-        ).to_parquet(base_dir / _EVIDENCE_CARDS_FILE, index=False)
-        self._persist_core_artifacts(
-            base_dir=base_dir,
-            collection_id=collection_id,
-            cards_table=cards_table,
-            sections_by_doc=sections_by_doc,
-            table_cells_by_doc=table_cells_by_doc,
+        sample_variants = self._normalize_sample_variants_table(
+            pd.DataFrame(sample_variant_rows, columns=_SAMPLE_VARIANT_COLUMNS),
+            collection_id,
         )
-        self.artifact_registry_service.upsert(collection_id, base_dir)
+        test_conditions = self._normalize_test_conditions_table(
+            pd.DataFrame(test_condition_rows, columns=_TEST_CONDITION_COLUMNS),
+            collection_id,
+        )
+        baseline_references = self._normalize_baseline_references_table(
+            pd.DataFrame(baseline_rows, columns=_BASELINE_REFERENCE_COLUMNS),
+            collection_id,
+        )
+        measurement_results = self._normalize_measurement_results_table(
+            pd.DataFrame(measurement_rows, columns=_MEASUREMENT_RESULT_COLUMNS),
+            collection_id,
+        )
 
-        return cards_table
-
-    def _persist_core_artifacts(
-        self,
-        *,
-        base_dir: Path,
-        collection_id: str,
-        cards_table: pd.DataFrame,
-        sections_by_doc: dict[str, list[dict[str, Any]]],
-        table_cells_by_doc: dict[str, list[dict[str, Any]]],
-    ) -> None:
         characterization = self._build_characterization_observations(
             collection_id=collection_id,
             cards_table=cards_table,
             sections_by_doc=sections_by_doc,
-            table_cells_by_doc=table_cells_by_doc,
-        )
-        test_conditions = self._build_test_conditions(cards_table, collection_id)
-        baseline_references = self._build_baseline_references(cards_table, collection_id)
-        sample_variants = self._build_sample_variants(
-            collection_id=collection_id,
-            cards_table=cards_table,
-            table_cells_by_doc=table_cells_by_doc,
         )
         characterization = self._attach_variant_ids_to_characterization(
             characterization,
@@ -551,16 +562,12 @@ class EvidenceCardService:
             baseline_references,
             sample_variants,
         )
-        measurement_results = self._build_measurement_results(
-            collection_id=collection_id,
-            cards_table=cards_table,
-            sample_variants=sample_variants,
-            characterization=characterization,
-            structure_features=structure_features,
-            test_conditions=test_conditions,
-            baseline_references=baseline_references,
-        )
 
+        base_dir.mkdir(parents=True, exist_ok=True)
+        prepare_frame_for_storage(
+            cards_table,
+            _EVIDENCE_JSON_COLUMNS,
+        ).to_parquet(base_dir / _EVIDENCE_CARDS_FILE, index=False)
         prepare_frame_for_storage(
             characterization,
             _CHARACTERIZATION_JSON_COLUMNS,
@@ -586,13 +593,617 @@ class EvidenceCardService:
             _MEASUREMENT_RESULTS_JSON_COLUMNS,
         ).to_parquet(base_dir / _MEASUREMENT_RESULTS_FILE, index=False)
 
+        write_core_semantic_manifest(base_dir)
+        self.artifact_registry_service.upsert(collection_id, base_dir)
+        return cards_table
+
+    def _build_document_state(self) -> dict[str, Any]:
+        return {
+            "variant_ids_by_key": {},
+            "variant_records_by_id": {},
+            "test_condition_ids_by_key": {},
+            "test_condition_records_by_id": {},
+            "baseline_ids_by_key": {},
+            "baseline_records_by_id": {},
+            "card_keys": set(),
+        }
+
+    def _build_section_extraction_payload(
+        self,
+        *,
+        document_id: str,
+        title: str,
+        source_filename: str | None,
+        profile: dict[str, Any],
+        section: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "document_id": document_id,
+            "document_title": title,
+            "source_filename": source_filename,
+            "document_profile": {
+                "doc_type": str(profile.get("doc_type") or ""),
+                "protocol_extractable": str(profile.get("protocol_extractable") or ""),
+            },
+            "section": {
+                "section_id": str(section.get("section_id") or ""),
+                "section_type": str(section.get("section_type") or ""),
+                "heading": self._normalize_scalar_text(section.get("heading")),
+                "text": str(section.get("text") or "")[:12000],
+                "text_unit_ids": self._normalize_list(section.get("text_unit_ids")),
+            },
+        }
+
+    def _build_table_row_extraction_payload(
+        self,
+        *,
+        document_id: str,
+        title: str,
+        source_filename: str | None,
+        profile: dict[str, Any],
+        table_id: str,
+        row_index: int,
+        row_cells: list[dict[str, Any]],
+        sections: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        return {
+            "document_id": document_id,
+            "document_title": title,
+            "source_filename": source_filename,
+            "document_profile": {
+                "doc_type": str(profile.get("doc_type") or ""),
+                "protocol_extractable": str(profile.get("protocol_extractable") or ""),
+            },
+            "table_row": {
+                "table_id": table_id,
+                "row_index": row_index,
+                "row_summary": self._build_table_row_summary(row_cells),
+                "cells": [
+                    {
+                        "header_path": self._normalize_scalar_text(cell.get("header_path")),
+                        "cell_text": self._normalize_scalar_text(cell.get("cell_text")),
+                        "unit_hint": self._normalize_scalar_text(cell.get("unit_hint")),
+                    }
+                    for cell in sorted(
+                        row_cells,
+                        key=lambda item: self._safe_int(item.get("col_index")) or 0,
+                    )
+                ],
+            },
+            "nearby_context": {
+                "methods_text": self._first_section_text_by_type(sections, "methods"),
+                "characterization_text": self._first_section_text_by_type(
+                    sections,
+                    "characterization",
+                ),
+            },
+        }
+
+    def _materialize_bundle(
+        self,
+        *,
+        bundle: StructuredExtractionBundle,
+        collection_id: str,
+        document_id: str,
+        section: dict[str, Any] | None,
+        table_id: str | None,
+        row_index: int | None,
+        card_rows: list[dict[str, Any]],
+        sample_variant_rows: list[dict[str, Any]],
+        test_condition_rows: list[dict[str, Any]],
+        baseline_rows: list[dict[str, Any]],
+        measurement_rows: list[dict[str, Any]],
+        document_state: dict[str, Any],
+    ) -> None:
+        local_variant_ids: dict[str, str] = {}
+        local_test_condition_ids: dict[str, str] = {}
+        local_baseline_ids: dict[str, str] = {}
+        bundle_anchor_ids: list[str] = []
+
+        for variant in bundle.sample_variants:
+            variant_id, created = self._materialize_variant_row(
+                collection_id=collection_id,
+                document_id=document_id,
+                payload=variant,
+                section=section,
+                table_id=table_id,
+                row_index=row_index,
+                rows=sample_variant_rows,
+                document_state=document_state,
+            )
+            local_variant_ids[variant.variant_ref] = variant_id
+            if created:
+                document_state["variant_records_by_id"][variant_id] = created
+
+        for condition in bundle.test_conditions:
+            condition_id, created = self._materialize_test_condition_row(
+                collection_id=collection_id,
+                document_id=document_id,
+                payload=condition,
+                section=section,
+                table_id=table_id,
+                rows=test_condition_rows,
+                document_state=document_state,
+            )
+            local_test_condition_ids[condition.test_condition_ref] = condition_id
+            if created:
+                document_state["test_condition_records_by_id"][condition_id] = created
+
+        for baseline in bundle.baseline_references:
+            baseline_id, created = self._materialize_baseline_row(
+                collection_id=collection_id,
+                document_id=document_id,
+                payload=baseline,
+                section=section,
+                table_id=table_id,
+                rows=baseline_rows,
+                document_state=document_state,
+            )
+            local_baseline_ids[baseline.baseline_ref] = baseline_id
+            if created:
+                document_state["baseline_records_by_id"][baseline_id] = created
+
+        for result in bundle.measurement_results:
+            anchors = self._materialize_anchor_payloads(
+                anchors=result.anchors,
+                document_id=document_id,
+                section=section,
+                table_id=table_id,
+            )
+            anchor_ids = [anchor["anchor_id"] for anchor in anchors]
+            bundle_anchor_ids.extend(
+                anchor_id for anchor_id in anchor_ids if anchor_id not in bundle_anchor_ids
+            )
+            linked_variant_id = self._resolve_local_or_single_id(
+                result.variant_ref,
+                local_variant_ids,
+            )
+            linked_test_condition_id = self._resolve_local_or_single_id(
+                result.test_condition_ref,
+                local_test_condition_ids,
+            )
+            linked_baseline_id = self._resolve_local_or_single_id(
+                result.baseline_ref,
+                local_baseline_ids,
+            )
+
+            measurement_record = MeasurementResult.from_mapping(
+                {
+                    "result_id": f"res_{uuid4().hex[:12]}",
+                    "document_id": document_id,
+                    "collection_id": collection_id,
+                    "domain_profile": CORE_NEUTRAL_DOMAIN_PROFILE,
+                    "variant_id": linked_variant_id,
+                    "property_normalized": self._normalize_property_name(
+                        result.property_normalized
+                    ),
+                    "result_type": self._normalize_result_type(result.result_type),
+                    "value_payload": self._sanitize_value_payload(
+                        result.value_payload.model_dump(exclude_none=True)
+                    ),
+                    "unit": self._sanitize_unit(result.unit),
+                    "test_condition_id": linked_test_condition_id,
+                    "baseline_id": linked_baseline_id,
+                    "structure_feature_ids": [],
+                    "characterization_observation_ids": [],
+                    "evidence_anchor_ids": anchor_ids,
+                    "traceability_status": (
+                        TRACEABILITY_STATUS_DIRECT if anchor_ids else TRACEABILITY_STATUS_MISSING
+                    ),
+                    "result_source_type": "table" if table_id else "text",
+                    "epistemic_status": (
+                        EPISTEMIC_DIRECTLY_OBSERVED if table_id else EPISTEMIC_NORMALIZED_FROM_EVIDENCE
+                    ),
+                }
+            ).to_record()
+            if not measurement_record["value_payload"]:
+                continue
+            measurement_rows.append(measurement_record)
+
+            variant_record = (
+                document_state["variant_records_by_id"].get(linked_variant_id)
+                if linked_variant_id
+                else None
+            )
+            test_condition_record = (
+                document_state["test_condition_records_by_id"].get(linked_test_condition_id)
+                if linked_test_condition_id
+                else None
+            )
+            baseline_record = (
+                document_state["baseline_records_by_id"].get(linked_baseline_id)
+                if linked_baseline_id
+                else None
+            )
+            self._append_card_row(
+                card_rows=card_rows,
+                document_state=document_state,
+                payload=EvidenceCardPayload(
+                    claim_text=result.claim_text,
+                    claim_type="property",
+                    evidence_source_type="table" if table_id else "text",
+                    material_system=self._to_material_payload(
+                        (variant_record or {}).get("host_material_system")
+                    ),
+                    condition_context=self._condition_context_from_records(
+                        test_condition_record,
+                        baseline_record,
+                    ),
+                    anchors=[
+                        EvidenceAnchorPayload(
+                            quote=str(anchor.get("quote") or anchor.get("quote_span") or ""),
+                            source_type=str(anchor.get("source_type") or "text"),
+                            section_id=self._normalize_scalar_text(anchor.get("section_id")),
+                            snippet_id=self._normalize_scalar_text(anchor.get("snippet_id")),
+                            figure_or_table=self._normalize_scalar_text(
+                                anchor.get("figure_or_table")
+                            ),
+                            page=self._safe_int(anchor.get("page")),
+                        )
+                        for anchor in anchors
+                    ],
+                    confidence=result.confidence,
+                ),
+                collection_id=collection_id,
+                document_id=document_id,
+                section=section,
+                table_id=table_id,
+            )
+
+        for card in bundle.evidence_cards:
+            anchors = self._materialize_anchor_payloads(
+                anchors=card.anchors,
+                document_id=document_id,
+                section=section,
+                table_id=table_id,
+            )
+            bundle_anchor_ids.extend(
+                anchor["anchor_id"]
+                for anchor in anchors
+                if anchor["anchor_id"] not in bundle_anchor_ids
+            )
+            self._append_card_row(
+                card_rows=card_rows,
+                document_state=document_state,
+                payload=card,
+                collection_id=collection_id,
+                document_id=document_id,
+                section=section,
+                table_id=table_id,
+                prebuilt_anchors=anchors,
+            )
+
+        for variant_id in local_variant_ids.values():
+            variant_record = document_state["variant_records_by_id"].get(variant_id)
+            if variant_record is None:
+                continue
+            for anchor_id in bundle_anchor_ids:
+                if anchor_id not in variant_record["source_anchor_ids"]:
+                    variant_record["source_anchor_ids"].append(anchor_id)
+
+        for condition_id in local_test_condition_ids.values():
+            condition_record = document_state["test_condition_records_by_id"].get(condition_id)
+            if condition_record is None:
+                continue
+            for anchor_id in bundle_anchor_ids:
+                if anchor_id not in condition_record["evidence_anchor_ids"]:
+                    condition_record["evidence_anchor_ids"].append(anchor_id)
+
+        for baseline_id in local_baseline_ids.values():
+            baseline_record = document_state["baseline_records_by_id"].get(baseline_id)
+            if baseline_record is None:
+                continue
+            for anchor_id in bundle_anchor_ids:
+                if anchor_id not in baseline_record["evidence_anchor_ids"]:
+                    baseline_record["evidence_anchor_ids"].append(anchor_id)
+
+    def _materialize_variant_row(
+        self,
+        *,
+        collection_id: str,
+        document_id: str,
+        payload: SampleVariantPayload,
+        section: dict[str, Any] | None,
+        table_id: str | None,
+        row_index: int | None,
+        rows: list[dict[str, Any]],
+        document_state: dict[str, Any],
+    ) -> tuple[str, dict[str, Any] | None]:
+        normalized_material = self._normalize_material_system_payload(
+            payload.host_material_system.model_dump(exclude_none=True)
+            if payload.host_material_system
+            else {}
+        )
+        variable_axis_type = self._normalize_variant_axis_type(payload.variable_axis_type)
+        variable_value = self._normalize_scalar_variant_value(payload.variable_value)
+        variant_key = (
+            document_id,
+            str(payload.variant_label or "").strip().lower(),
+            str(variable_axis_type or "").strip().lower(),
+            str(variable_value if variable_value is not None else "").strip().lower(),
+            str(normalized_material.get("family") or "").strip().lower(),
+        )
+        existing_id = document_state["variant_ids_by_key"].get(variant_key)
+        if existing_id:
+            return existing_id, None
+
+        variant_record = SampleVariant.from_mapping(
+            {
+                "variant_id": f"var_{uuid4().hex[:12]}",
+                "document_id": document_id,
+                "collection_id": collection_id,
+                "domain_profile": CORE_NEUTRAL_DOMAIN_PROFILE,
+                "variant_label": str(payload.variant_label or "").strip(),
+                "host_material_system": normalized_material,
+                "composition": self._normalize_scalar_text(payload.composition),
+                "variable_axis_type": variable_axis_type,
+                "variable_value": variable_value,
+                "process_context": self._normalize_condition_payload(
+                    payload.process_context.model_dump(exclude_none=True)
+                ),
+                "profile_payload": {
+                    "source_kind": payload.source_kind,
+                    "section_id": self._normalize_scalar_text(section.get("section_id"))
+                    if section
+                    else None,
+                    "table_id": table_id,
+                    "row_index": row_index,
+                },
+                "structure_feature_ids": [],
+                "source_anchor_ids": [],
+                "confidence": payload.confidence,
+                "epistemic_status": str(payload.epistemic_status or EPISTEMIC_NORMALIZED_FROM_EVIDENCE),
+            }
+        ).to_record()
+        rows.append(variant_record)
+        document_state["variant_ids_by_key"][variant_key] = variant_record["variant_id"]
+        return variant_record["variant_id"], variant_record
+
+    def _materialize_test_condition_row(
+        self,
+        *,
+        collection_id: str,
+        document_id: str,
+        payload: ExtractedTestConditionPayload,
+        section: dict[str, Any] | None,
+        table_id: str | None,
+        rows: list[dict[str, Any]],
+        document_state: dict[str, Any],
+    ) -> tuple[str, dict[str, Any] | None]:
+        normalized_payload = self._normalize_condition_payload(
+            payload.condition_payload.model_dump(exclude_none=True)
+        )
+        property_type = self._normalize_property_name(payload.property_type)
+        condition_key = (
+            document_id,
+            property_type,
+            json.dumps(normalized_payload, sort_keys=True, ensure_ascii=False),
+        )
+        existing_id = document_state["test_condition_ids_by_key"].get(condition_key)
+        if existing_id:
+            return existing_id, None
+
+        template_type = self._infer_condition_template_type(property_type)
+        scope_level = "table" if table_id else ("experiment" if section and str(section.get("section_type")) == "methods" else "measurement")
+        missing_fields = self._infer_missing_condition_fields(
+            payload=normalized_payload,
+            template_type=template_type,
+            scope_level=scope_level,
+        )
+        condition_record = TestCondition.from_mapping(
+            {
+                "test_condition_id": f"tc_{uuid4().hex[:12]}",
+                "document_id": document_id,
+                "collection_id": collection_id,
+                "domain_profile": CORE_NEUTRAL_DOMAIN_PROFILE,
+                "property_type": property_type,
+                "template_type": template_type,
+                "scope_level": scope_level,
+                "condition_payload": normalized_payload,
+                "condition_completeness": self._infer_condition_completeness(
+                    payload=normalized_payload,
+                    missing_fields=missing_fields,
+                ),
+                "missing_fields": missing_fields,
+                "evidence_anchor_ids": [],
+                "confidence": payload.confidence,
+                "epistemic_status": str(payload.epistemic_status or EPISTEMIC_NORMALIZED_FROM_EVIDENCE),
+            }
+        ).to_record()
+        rows.append(condition_record)
+        document_state["test_condition_ids_by_key"][condition_key] = condition_record["test_condition_id"]
+        return condition_record["test_condition_id"], condition_record
+
+    def _materialize_baseline_row(
+        self,
+        *,
+        collection_id: str,
+        document_id: str,
+        payload: BaselineReferencePayload,
+        section: dict[str, Any] | None,
+        table_id: str | None,
+        rows: list[dict[str, Any]],
+        document_state: dict[str, Any],
+    ) -> tuple[str, dict[str, Any] | None]:
+        baseline_label = str(payload.baseline_label or "").strip()
+        baseline_key = (document_id, baseline_label.lower())
+        existing_id = document_state["baseline_ids_by_key"].get(baseline_key)
+        if existing_id:
+            return existing_id, None
+
+        baseline_record = BaselineReference.from_mapping(
+            {
+                "baseline_id": f"base_{uuid4().hex[:12]}",
+                "document_id": document_id,
+                "collection_id": collection_id,
+                "domain_profile": CORE_NEUTRAL_DOMAIN_PROFILE,
+                "variant_id": None,
+                "baseline_type": self._classify_baseline_type(baseline_label),
+                "baseline_label": baseline_label,
+                "baseline_scope": "table" if table_id else "measurement",
+                "evidence_anchor_ids": [],
+                "confidence": payload.confidence,
+                "epistemic_status": str(payload.epistemic_status or EPISTEMIC_NORMALIZED_FROM_EVIDENCE),
+            }
+        ).to_record()
+        rows.append(baseline_record)
+        document_state["baseline_ids_by_key"][baseline_key] = baseline_record["baseline_id"]
+        return baseline_record["baseline_id"], baseline_record
+
+    def _append_card_row(
+        self,
+        *,
+        card_rows: list[dict[str, Any]],
+        document_state: dict[str, Any],
+        payload: EvidenceCardPayload,
+        collection_id: str,
+        document_id: str,
+        section: dict[str, Any] | None,
+        table_id: str | None,
+        prebuilt_anchors: list[dict[str, Any]] | None = None,
+    ) -> None:
+        anchors = prebuilt_anchors or self._materialize_anchor_payloads(
+            anchors=payload.anchors,
+            document_id=document_id,
+            section=section,
+            table_id=table_id,
+        )
+        anchor_signature = tuple(
+            str(anchor.get("quote") or anchor.get("quote_span") or "").strip()
+            for anchor in anchors
+        )
+        card_key = (
+            document_id,
+            str(payload.claim_text or "").strip().lower(),
+            str(payload.claim_type or "").strip().lower(),
+            str(payload.evidence_source_type or "").strip().lower(),
+            anchor_signature,
+        )
+        if card_key in document_state["card_keys"]:
+            return
+
+        card_rows.append(
+            {
+                "evidence_id": f"ev_{uuid4().hex[:12]}",
+                "document_id": document_id,
+                "collection_id": collection_id,
+                "claim_text": str(payload.claim_text or "").strip(),
+                "claim_type": self._normalize_claim_type(payload.claim_type),
+                "evidence_source_type": (
+                    str(payload.evidence_source_type or "text")
+                    if str(payload.evidence_source_type or "text") in _EVIDENCE_SOURCE_TYPES
+                    else ("table" if table_id else "text")
+                ),
+                "evidence_anchors": anchors,
+                "material_system": self._normalize_material_system_payload(
+                    payload.material_system.model_dump(exclude_none=True)
+                    if payload.material_system
+                    else {}
+                ),
+                "condition_context": self._normalize_condition_context_payload(
+                    payload.condition_context.model_dump(exclude_none=True)
+                ),
+                "confidence": payload.confidence,
+                "traceability_status": (
+                    TRACEABILITY_STATUS_DIRECT if anchors else TRACEABILITY_STATUS_MISSING
+                ),
+            }
+        )
+        document_state["card_keys"].add(card_key)
+
+    def _materialize_anchor_payloads(
+        self,
+        *,
+        anchors: list[EvidenceAnchorPayload],
+        document_id: str,
+        section: dict[str, Any] | None,
+        table_id: str | None,
+    ) -> list[dict[str, Any]]:
+        payload: list[dict[str, Any]] = []
+        section_id = self._normalize_scalar_text(section.get("section_id")) if section else None
+        snippet_ids = self._normalize_list(section.get("text_unit_ids")) if section else []
+        for anchor in anchors:
+            quote = self._normalize_scalar_text(anchor.quote)
+            source_type = (
+                str(anchor.source_type or "text")
+                if str(anchor.source_type or "text") in _EVIDENCE_SOURCE_TYPES
+                else ("table" if table_id else "text")
+            )
+            payload.append(
+                {
+                    "anchor_id": f"anchor_{uuid4().hex[:12]}",
+                    "document_id": document_id,
+                    "source_type": source_type,
+                    "section_id": self._normalize_scalar_text(anchor.section_id) or section_id,
+                    "block_id": None,
+                    "snippet_id": self._normalize_scalar_text(anchor.snippet_id)
+                    or (snippet_ids[0] if snippet_ids else None),
+                    "figure_or_table": self._normalize_scalar_text(anchor.figure_or_table) or table_id,
+                    "page": anchor.page,
+                    "quote": quote,
+                    "quote_span": quote,
+                }
+            )
+        return payload
+
+    def _resolve_local_or_single_id(
+        self,
+        reference: str | None,
+        lookup: dict[str, str],
+    ) -> str | None:
+        if reference and lookup.get(reference):
+            return lookup[reference]
+        if len(lookup) == 1:
+            return next(iter(lookup.values()))
+        return None
+
+    def _to_material_payload(self, value: Any) -> Any:
+        normalized = self._normalize_material_system_payload(value)
+        return {
+            "family": normalized.get("family"),
+            "composition": normalized.get("composition"),
+        }
+
+    def _condition_context_from_records(
+        self,
+        test_condition: dict[str, Any] | None,
+        baseline: dict[str, Any] | None,
+    ) -> ConditionContextPayload:
+        payload = self._normalize_condition_payload(
+            (test_condition or {}).get("condition_payload")
+        )
+        return ConditionContextPayload(
+            process=ProcessContextPayload(
+                temperatures_c=list(payload.get("temperatures_c") or []),
+                durations=[str(item) for item in payload.get("durations") or []],
+                atmosphere=self._normalize_scalar_text(payload.get("atmosphere")),
+            ),
+            baseline={"control": self._normalize_scalar_text((baseline or {}).get("baseline_label"))},
+            test=TestContextPayload(
+                methods=[str(item) for item in payload.get("methods") or []],
+                method=self._normalize_scalar_text(payload.get("method")),
+            ),
+        )
+
+    def _first_section_text_by_type(
+        self,
+        sections: list[dict[str, Any]],
+        section_type: str,
+    ) -> str | None:
+        for section in sections:
+            if str(section.get("section_type") or "") != section_type:
+                continue
+            text = str(section.get("text") or "").strip()
+            if text:
+                return text[:4000]
+        return None
+
     def _build_characterization_observations(
         self,
         *,
         collection_id: str,
         cards_table: pd.DataFrame,
         sections_by_doc: dict[str, list[dict[str, Any]]],
-        table_cells_by_doc: dict[str, list[dict[str, Any]]],
     ) -> pd.DataFrame:
         rows: list[dict[str, Any]] = []
         characterization_cards = (
@@ -638,43 +1249,8 @@ class EvidenceCardService:
                                 "observed_unit": observed_unit,
                                 "condition_context": condition_context,
                                 "evidence_anchor_ids": anchor_ids,
-                                "confidence": 0.84 if observed_value is not None else 0.78,
+                                "confidence": 0.82 if observed_value is not None else 0.76,
                                 "epistemic_status": EPISTEMIC_DIRECTLY_OBSERVED,
-                            }
-                        ).to_record()
-                    )
-
-        for document_id, table_cells in table_cells_by_doc.items():
-            grouped_rows: dict[tuple[str, int], list[dict[str, Any]]] = {}
-            for cell in table_cells:
-                table_id = str(cell.get("table_id") or "").strip()
-                row_index = self._safe_int(cell.get("row_index"))
-                if not table_id or row_index is None or row_index <= 0:
-                    continue
-                grouped_rows.setdefault((table_id, row_index), []).append(cell)
-
-            for (_table_id, _row_index), row_cells in grouped_rows.items():
-                summary = self._build_table_row_summary(row_cells)
-                methods = self._extract_characterization_methods(summary)
-                if not methods:
-                    continue
-                observed_value, observed_unit = self._extract_observed_value_and_unit(summary)
-                for method in methods:
-                    rows.append(
-                        CharacterizationObservation.from_mapping(
-                            {
-                                "observation_id": f"obs_{uuid4().hex[:12]}",
-                                "document_id": str(document_id),
-                                "collection_id": collection_id,
-                                "variant_id": None,
-                                "characterization_type": method.lower(),
-                                "observation_text": summary,
-                                "observed_value": observed_value,
-                                "observed_unit": observed_unit,
-                                "condition_context": self._normalize_condition_context_payload({}),
-                                "evidence_anchor_ids": [],
-                                "confidence": 0.68,
-                                "epistemic_status": EPISTEMIC_NORMALIZED_FROM_EVIDENCE,
                             }
                         ).to_record()
                     )
@@ -693,292 +1269,10 @@ class EvidenceCardService:
             return self._normalize_structure_features_table(
                 pd.DataFrame(columns=_STRUCTURE_FEATURE_COLUMNS)
             )
-
         for _, observation in characterization.iterrows():
             rows.extend(self._extract_structure_features_from_observation(observation))
-
         return self._normalize_structure_features_table(
             pd.DataFrame(rows, columns=_STRUCTURE_FEATURE_COLUMNS)
-        )
-
-    def _build_test_conditions(
-        self,
-        cards_table: pd.DataFrame,
-        collection_id: str,
-    ) -> pd.DataFrame:
-        rows: list[dict[str, Any]] = []
-        dedupe: set[tuple[str, str, str, str]] = set()
-        if cards_table is None or cards_table.empty:
-            return self._normalize_test_conditions_table(
-                pd.DataFrame(columns=_TEST_CONDITION_COLUMNS),
-                collection_id,
-            )
-
-        for _, row in cards_table.iterrows():
-            condition_context = self._normalize_condition_context_payload(
-                row.get("condition_context")
-            )
-            process_context = condition_context.get("process", {})
-            test_context = condition_context.get("test", {})
-            payload = {
-                "method": test_context.get("method"),
-                "methods": self._normalize_list(test_context.get("methods")),
-                "temperatures_c": list(process_context.get("temperatures_c") or []),
-                "durations": list(process_context.get("durations") or []),
-                "atmosphere": process_context.get("atmosphere"),
-            }
-            payload = {
-                key: value
-                for key, value in payload.items()
-                if value not in (None, "", [], {})
-            }
-            if not payload:
-                continue
-
-            property_type = self._infer_property_type_from_card(
-                claim_type=str(row.get("claim_type") or ""),
-                claim_text=str(row.get("claim_text") or ""),
-            )
-            template_type = self._infer_condition_template_type(property_type)
-            scope_level = self._infer_condition_scope_level(
-                str(row.get("evidence_source_type") or "")
-            )
-            missing_fields = self._infer_missing_condition_fields(
-                payload=payload,
-                template_type=template_type,
-                scope_level=scope_level,
-            )
-            condition_completeness = self._infer_condition_completeness(
-                payload=payload,
-                missing_fields=missing_fields,
-            )
-            dedupe_key = (
-                str(row.get("document_id") or ""),
-                property_type,
-                scope_level,
-                json.dumps(payload, sort_keys=True, ensure_ascii=False),
-            )
-            if dedupe_key in dedupe:
-                continue
-            dedupe.add(dedupe_key)
-            rows.append(
-                TestCondition.from_mapping(
-                    {
-                        "test_condition_id": f"tc_{uuid4().hex[:12]}",
-                        "document_id": str(row.get("document_id") or ""),
-                        "collection_id": collection_id,
-                        "domain_profile": CORE_NEUTRAL_DOMAIN_PROFILE,
-                        "property_type": property_type,
-                        "template_type": template_type,
-                        "scope_level": scope_level,
-                        "condition_payload": payload,
-                        "condition_completeness": condition_completeness,
-                        "missing_fields": missing_fields,
-                        "evidence_anchor_ids": self._extract_anchor_ids(
-                            row.get("evidence_anchors")
-                        ),
-                        "confidence": 0.82 if condition_completeness == "complete" else 0.72,
-                        "epistemic_status": (
-                            EPISTEMIC_NORMALIZED_FROM_EVIDENCE
-                            if condition_completeness != "unresolved"
-                            else EPISTEMIC_UNRESOLVED
-                        ),
-                    }
-                ).to_record()
-            )
-
-        return self._normalize_test_conditions_table(
-            pd.DataFrame(rows, columns=_TEST_CONDITION_COLUMNS),
-            collection_id,
-        )
-
-    def _build_baseline_references(
-        self,
-        cards_table: pd.DataFrame,
-        collection_id: str,
-    ) -> pd.DataFrame:
-        rows: list[dict[str, Any]] = []
-        dedupe: set[tuple[str, str, str]] = set()
-        if cards_table is None or cards_table.empty:
-            return self._normalize_baseline_references_table(
-                pd.DataFrame(columns=_BASELINE_REFERENCE_COLUMNS),
-                collection_id,
-            )
-
-        for _, row in cards_table.iterrows():
-            condition_context = self._normalize_condition_context_payload(
-                row.get("condition_context")
-            )
-            baseline_label = str(
-                (condition_context.get("baseline") or {}).get("control") or ""
-            ).strip()
-            if not baseline_label:
-                continue
-
-            baseline_scope = self._infer_baseline_scope(
-                str(row.get("evidence_source_type") or "")
-            )
-            dedupe_key = (
-                str(row.get("document_id") or ""),
-                baseline_label.lower(),
-                baseline_scope,
-            )
-            if dedupe_key in dedupe:
-                continue
-            dedupe.add(dedupe_key)
-
-            baseline_type = self._classify_baseline_type(baseline_label)
-            epistemic_status = (
-                EPISTEMIC_NORMALIZED_FROM_EVIDENCE
-                if self._baseline_label_is_explicit(baseline_label)
-                else EPISTEMIC_INFERRED_WITH_LOW_CONFIDENCE
-            )
-            rows.append(
-                BaselineReference.from_mapping(
-                    {
-                        "baseline_id": f"base_{uuid4().hex[:12]}",
-                        "document_id": str(row.get("document_id") or ""),
-                        "collection_id": collection_id,
-                        "domain_profile": CORE_NEUTRAL_DOMAIN_PROFILE,
-                        "variant_id": None,
-                        "baseline_type": baseline_type,
-                        "baseline_label": baseline_label,
-                        "baseline_scope": baseline_scope,
-                        "evidence_anchor_ids": self._extract_anchor_ids(
-                            row.get("evidence_anchors")
-                        ),
-                        "confidence": (
-                            0.8
-                            if epistemic_status == EPISTEMIC_NORMALIZED_FROM_EVIDENCE
-                            else 0.64
-                        ),
-                        "epistemic_status": epistemic_status,
-                    }
-                ).to_record()
-            )
-
-        return self._normalize_baseline_references_table(
-            pd.DataFrame(rows, columns=_BASELINE_REFERENCE_COLUMNS),
-            collection_id,
-        )
-
-    def _build_sample_variants(
-        self,
-        *,
-        collection_id: str,
-        cards_table: pd.DataFrame,
-        table_cells_by_doc: dict[str, list[dict[str, Any]]],
-    ) -> pd.DataFrame:
-        rows: list[dict[str, Any]] = []
-        dedupe: set[tuple[str, str, str, str]] = set()
-        document_ids = set(table_cells_by_doc)
-        if cards_table is not None and not cards_table.empty:
-            document_ids.update(cards_table["document_id"].astype(str).tolist())
-
-        for document_id in sorted(document_ids):
-            document_cards = self._filter_rows_by_document(cards_table, document_id)
-            host_material_system = self._resolve_host_material_system(document_cards)
-            document_process_context = self._merge_process_contexts(document_cards)
-            table_rows = self._group_table_rows(table_cells_by_doc.get(document_id, []))
-            table_variant_count = 0
-
-            for (table_id, row_index), row_cells in table_rows.items():
-                ordered_cells = sorted(
-                    row_cells,
-                    key=lambda item: self._safe_int(item.get("col_index")) or 0,
-                )
-                sample_label = self._resolve_table_sample_label(ordered_cells)
-                variable_header, variable_value = self._resolve_table_variant_axis(ordered_cells)
-                if not sample_label and variable_header is None:
-                    continue
-                variant_label = (
-                    sample_label
-                    or f"{variable_header}: {variable_value}"
-                    if variable_header and variable_value is not None
-                    else None
-                )
-                if not variant_label:
-                    continue
-                variable_axis_type = self._infer_variable_axis_type(variable_header)
-                dedupe_key = (
-                    str(document_id),
-                    str(variant_label).strip().lower(),
-                    str(variable_axis_type or "").strip().lower(),
-                    str(variable_value if variable_value is not None else "").strip().lower(),
-                )
-                if dedupe_key in dedupe:
-                    continue
-                dedupe.add(dedupe_key)
-                row_summary = self._build_table_row_summary(ordered_cells)
-                rows.append(
-                    SampleVariant.from_mapping(
-                        {
-                            "variant_id": f"var_{uuid4().hex[:12]}",
-                            "document_id": str(document_id),
-                            "collection_id": collection_id,
-                            "domain_profile": CORE_NEUTRAL_DOMAIN_PROFILE,
-                            "variant_label": variant_label,
-                            "host_material_system": host_material_system,
-                            "composition": host_material_system.get("composition"),
-                            "variable_axis_type": variable_axis_type,
-                            "variable_value": self._normalize_variant_value(variable_value),
-                            "process_context": self._build_variant_process_context(
-                                document_process_context=document_process_context,
-                                variable_axis_type=variable_axis_type,
-                                variable_value=variable_value,
-                            ),
-                            "profile_payload": {
-                                "source_kind": "table_row",
-                                "table_id": table_id,
-                                "row_index": row_index,
-                                "row_summary": row_summary,
-                                "variable_header": variable_header,
-                                "baseline_label": (
-                                    self._resolve_table_baseline(ordered_cells) or {}
-                                ).get("control"),
-                            },
-                            "structure_feature_ids": [],
-                            "source_anchor_ids": self._collect_table_row_anchor_ids(
-                                document_cards,
-                                table_id=table_id,
-                                row_summary=row_summary,
-                                sample_label=sample_label,
-                            ),
-                            "confidence": (
-                                0.86 if sample_label and variable_value is not None else 0.76
-                            ),
-                            "epistemic_status": EPISTEMIC_NORMALIZED_FROM_EVIDENCE,
-                        }
-                    ).to_record()
-                )
-                table_variant_count += 1
-
-            non_table_property_cards = document_cards[
-                (document_cards["claim_type"].astype(str) == "property")
-                & (document_cards["evidence_source_type"].astype(str) != "table")
-            ] if not document_cards.empty else pd.DataFrame(columns=document_cards.columns)
-            if table_variant_count == 0 or not non_table_property_cards.empty:
-                default_variant = self._build_default_sample_variant(
-                    collection_id=collection_id,
-                    document_id=document_id,
-                    document_cards=document_cards,
-                    host_material_system=host_material_system,
-                    document_process_context=document_process_context,
-                )
-                if default_variant is not None:
-                    dedupe_key = (
-                        str(document_id),
-                        str(default_variant["variant_label"]).strip().lower(),
-                        str(default_variant["variable_axis_type"] or "").strip().lower(),
-                        str(default_variant["variable_value"] or "").strip().lower(),
-                    )
-                    if dedupe_key not in dedupe:
-                        dedupe.add(dedupe_key)
-                        rows.append(default_variant)
-
-        return self._normalize_sample_variants_table(
-            pd.DataFrame(rows, columns=_SAMPLE_VARIANT_COLUMNS),
-            collection_id,
         )
 
     def _attach_variant_ids_to_characterization(
@@ -988,16 +1282,15 @@ class EvidenceCardService:
     ) -> pd.DataFrame:
         if characterization is None or characterization.empty:
             return self._normalize_characterization_table(characterization, None)
+        if sample_variants is None or sample_variants.empty:
+            return self._normalize_characterization_table(characterization, None)
 
         normalized = characterization.copy()
         for index, row in normalized.iterrows():
-            matched_variant_id = self._match_variant_id_from_text(
-                document_id=str(row.get("document_id") or ""),
-                text=str(row.get("observation_text") or ""),
-                sample_variants=sample_variants,
-            )
-            if matched_variant_id:
-                normalized.at[index, "variant_id"] = matched_variant_id
+            document_id = str(row.get("document_id") or "")
+            document_variants = self._filter_rows_by_document(sample_variants, document_id)
+            if len(document_variants) == 1:
+                normalized.at[index, "variant_id"] = document_variants.iloc[0]["variant_id"]
         return self._normalize_characterization_table(normalized, None)
 
     def _attach_variant_ids_to_baseline_references(
@@ -1010,13 +1303,16 @@ class EvidenceCardService:
 
         normalized = baseline_references.copy()
         for index, row in normalized.iterrows():
-            matched_variant_id = self._match_variant_id_from_label(
-                document_id=str(row.get("document_id") or ""),
-                label=str(row.get("baseline_label") or ""),
-                sample_variants=sample_variants,
-            )
-            if matched_variant_id:
-                normalized.at[index, "variant_id"] = matched_variant_id
+            document_id = str(row.get("document_id") or "")
+            label = str(row.get("baseline_label") or "").strip().lower()
+            if not label:
+                continue
+            document_variants = self._filter_rows_by_document(sample_variants, document_id)
+            matched = document_variants[
+                document_variants["variant_label"].astype(str).str.lower() == label
+            ]
+            if len(matched) == 1:
+                normalized.at[index, "variant_id"] = matched.iloc[0]["variant_id"]
         return self._normalize_baseline_references_table(normalized, None)
 
     def _attach_structure_feature_ids_to_variants(
@@ -1030,110 +1326,16 @@ class EvidenceCardService:
         normalized = sample_variants.copy()
         for index, row in normalized.iterrows():
             variant_id = str(row.get("variant_id") or "")
-            document_id = str(row.get("document_id") or "")
-            feature_ids = self._collect_related_structure_feature_ids(
-                document_id=document_id,
-                variant_id=variant_id or None,
-                structure_features=structure_features,
-                sample_variants=sample_variants,
-            )
+            feature_ids = []
+            if not structure_features.empty:
+                matched = structure_features[
+                    structure_features["variant_id"].astype(str) == variant_id
+                ]
+                feature_ids = [
+                    str(value) for value in matched["feature_id"].tolist() if str(value).strip()
+                ]
             normalized.at[index, "structure_feature_ids"] = feature_ids
         return self._normalize_sample_variants_table(normalized, None)
-
-    def _build_measurement_results(
-        self,
-        *,
-        collection_id: str,
-        cards_table: pd.DataFrame,
-        sample_variants: pd.DataFrame,
-        characterization: pd.DataFrame,
-        structure_features: pd.DataFrame,
-        test_conditions: pd.DataFrame,
-        baseline_references: pd.DataFrame,
-    ) -> pd.DataFrame:
-        rows: list[dict[str, Any]] = []
-        if cards_table is None or cards_table.empty:
-            return self._normalize_measurement_results_table(
-                pd.DataFrame(columns=_MEASUREMENT_RESULT_COLUMNS),
-                collection_id,
-            )
-
-        property_cards = cards_table[cards_table["claim_type"].astype(str) == "property"]
-        for _, row in property_cards.iterrows():
-            document_id = str(row.get("document_id") or "")
-            claim_text = str(row.get("claim_text") or "").strip()
-            property_normalized = self._infer_property_type_from_card(
-                claim_type=str(row.get("claim_type") or ""),
-                claim_text=claim_text,
-            )
-            result_type = self._infer_result_type(
-                claim_text=claim_text,
-                property_normalized=property_normalized,
-            )
-            value_payload, unit = self._build_result_value_payload(
-                claim_text=claim_text,
-                result_type=result_type,
-            )
-            if not value_payload:
-                continue
-
-            variant_id = self._resolve_variant_id_for_card(
-                card_row=row,
-                sample_variants=sample_variants,
-            )
-            rows.append(
-                MeasurementResult.from_mapping(
-                    {
-                        "result_id": f"res_{uuid4().hex[:12]}",
-                        "document_id": document_id,
-                        "collection_id": collection_id,
-                        "domain_profile": CORE_NEUTRAL_DOMAIN_PROFILE,
-                        "variant_id": variant_id,
-                        "property_normalized": property_normalized,
-                        "result_type": result_type,
-                        "value_payload": value_payload,
-                        "unit": unit,
-                        "test_condition_id": self._resolve_test_condition_id(
-                            card_row=row,
-                            property_normalized=property_normalized,
-                            test_conditions=test_conditions,
-                        ),
-                        "baseline_id": self._resolve_baseline_id(
-                            card_row=row,
-                            baseline_references=baseline_references,
-                        ),
-                        "structure_feature_ids": self._collect_related_structure_feature_ids(
-                            document_id=document_id,
-                            variant_id=variant_id,
-                            structure_features=structure_features,
-                            sample_variants=sample_variants,
-                        ),
-                        "characterization_observation_ids": self._collect_related_characterization_ids(
-                            document_id=document_id,
-                            variant_id=variant_id,
-                            characterization=characterization,
-                            sample_variants=sample_variants,
-                        ),
-                        "evidence_anchor_ids": self._extract_anchor_ids(
-                            row.get("evidence_anchors")
-                        ),
-                        "traceability_status": str(
-                            row.get("traceability_status") or TRACEABILITY_STATUS_MISSING
-                        ),
-                        "result_source_type": str(row.get("evidence_source_type") or "text"),
-                        "epistemic_status": (
-                            EPISTEMIC_DIRECTLY_OBSERVED
-                            if str(row.get("evidence_source_type") or "") == "table"
-                            else EPISTEMIC_NORMALIZED_FROM_EVIDENCE
-                        ),
-                    }
-                ).to_record()
-            )
-
-        return self._normalize_measurement_results_table(
-            pd.DataFrame(rows, columns=_MEASUREMENT_RESULT_COLUMNS),
-            collection_id,
-        )
 
     def _filter_rows_by_document(
         self,
@@ -1143,44 +1345,6 @@ class EvidenceCardService:
         if frame is None or frame.empty or "document_id" not in frame.columns:
             return pd.DataFrame(columns=frame.columns if frame is not None else [])
         return frame[frame["document_id"].astype(str) == str(document_id)]
-
-    def _resolve_host_material_system(
-        self,
-        document_cards: pd.DataFrame,
-    ) -> dict[str, Any]:
-        if document_cards is not None and not document_cards.empty:
-            for _, row in document_cards.iterrows():
-                material_system = self._normalize_material_system_payload(
-                    row.get("material_system")
-                )
-                if material_system.get("family") != "unspecified material system":
-                    return material_system
-        return self._normalize_material_system_payload({})
-
-    def _merge_process_contexts(
-        self,
-        document_cards: pd.DataFrame,
-    ) -> dict[str, Any]:
-        merged = {
-            "temperatures_c": [],
-            "durations": [],
-            "atmosphere": None,
-        }
-        if document_cards is None or document_cards.empty:
-            return merged
-
-        for _, row in document_cards.iterrows():
-            context = self._normalize_condition_context_payload(row.get("condition_context"))
-            process = context.get("process", {})
-            for value in process.get("temperatures_c") or []:
-                if value not in merged["temperatures_c"]:
-                    merged["temperatures_c"].append(value)
-            for value in process.get("durations") or []:
-                if value not in merged["durations"]:
-                    merged["durations"].append(value)
-            if merged["atmosphere"] is None and process.get("atmosphere"):
-                merged["atmosphere"] = process.get("atmosphere")
-        return merged
 
     def _group_table_rows(
         self,
@@ -1195,64 +1359,86 @@ class EvidenceCardService:
             grouped.setdefault((table_id, row_index), []).append(cell)
         return grouped
 
-    def _resolve_table_variant_axis(
+    def _build_table_row_summary(
         self,
         row_cells: list[dict[str, Any]],
-    ) -> tuple[str | None, Any]:
-        for cell in row_cells:
-            header = str(cell.get("header_path") or "").strip()
-            if not header:
-                continue
-            if self._is_table_sample_header(header) or self._is_table_baseline_header(header):
-                continue
-            if self._infer_property_type_from_header(header) != "qualitative":
-                continue
-            cell_text = str(cell.get("cell_text") or "").strip()
-            if not cell_text:
-                continue
-            return header, cell_text
-        return None, None
-
-    def _infer_property_type_from_header(
-        self,
-        header: str,
     ) -> str:
-        lowered = str(header or "").lower()
+        ordered = sorted(
+            row_cells,
+            key=lambda item: self._safe_int(item.get("col_index")) or 0,
+        )
+        parts: list[str] = []
+        for cell in ordered:
+            header = self._normalize_scalar_text(cell.get("header_path"))
+            value = self._normalize_scalar_text(cell.get("cell_text"))
+            if not value:
+                continue
+            parts.append(f"{header}: {value}" if header else value)
+        return "; ".join(parts)
+
+    def _normalize_property_name(self, value: Any) -> str:
+        raw = str(value or "").strip().lower()
+        if not raw:
+            return "qualitative"
+        if raw in {
+            "yield_strength",
+            "tensile_strength",
+            "flexural_strength",
+            "fatigue_life",
+            "retention",
+            "hardness",
+            "conductivity",
+            "modulus",
+            "elongation",
+            "strength",
+        }:
+            return raw
+        lowered = raw.replace("_", " ")
         for token, normalized in _PROPERTY_HINTS:
             if token in lowered:
                 return normalized
-        return "qualitative"
+        normalized = re.sub(r"[^a-z0-9]+", "_", lowered).strip("_")
+        return normalized or "qualitative"
 
-    def _infer_variable_axis_type(
-        self,
-        header: str | None,
-    ) -> str:
-        lowered = str(header or "").strip().lower()
-        if not lowered:
-            return "unspecified_variant_axis"
+    def _normalize_claim_type(self, value: Any) -> str:
+        lowered = str(value or "").strip().lower()
+        if lowered in {"process", "characterization", "property", "mechanism"}:
+            return lowered
+        return "property" if "property" in lowered else "qualitative"
+
+    def _normalize_result_type(self, value: Any) -> str:
+        lowered = str(value or "").strip().lower()
+        if lowered in {"scalar", "range", "retention", "trend", "optimum", "fitted_value"}:
+            return lowered
+        return "scalar"
+
+    def _normalize_variant_axis_type(self, value: Any) -> str | None:
+        text = self._normalize_scalar_text(value)
+        if text is None:
+            return None
+        if re.fullmatch(r"[-+]?\d+(?:\.\d+)?", text):
+            return None
+        lowered = text.lower()
         if "current" in lowered:
             return "induction_current"
-        if "beam" in lowered and "strategy" in lowered:
-            return "beam_strategy"
-        if "heating" in lowered:
-            return "in_situ_heating"
-        if "temperature" in lowered:
-            return "temperature"
-        if "power" in lowered:
-            return "laser_power"
-        if "speed" in lowered:
-            return "scan_speed"
-        if "orientation" in lowered:
-            return "specimen_orientation"
-        if "direction" in lowered:
-            return "build_direction"
-        if any(token in lowered for token in ("wt%", "vol%", "content", "loading", "ratio")):
-            return "composition_loading"
         normalized = re.sub(r"[^a-z0-9]+", "_", lowered).strip("_")
-        return normalized or "unspecified_variant_axis"
+        return normalized or None
 
-    def _normalize_variant_value(self, value: Any) -> Any:
-        text = str(value or "").strip()
+    def _normalize_scalar_variant_value(self, value: Any) -> Any:
+        normalized = normalize_backbone_value(value)
+        if normalized is None:
+            return None
+        if isinstance(normalized, bool):
+            return str(normalized).lower()
+        if isinstance(normalized, int):
+            return normalized
+        if isinstance(normalized, float):
+            if pd.isna(normalized):
+                return None
+            if normalized.is_integer():
+                return int(normalized)
+            return normalized
+        text = str(normalized).strip()
         if not text:
             return None
         if re.fullmatch(r"[-+]?\d+", text):
@@ -1261,1010 +1447,22 @@ class EvidenceCardService:
             return float(text)
         return text
 
-    def _build_variant_process_context(
-        self,
-        *,
-        document_process_context: dict[str, Any],
-        variable_axis_type: str,
-        variable_value: Any,
-    ) -> dict[str, Any]:
-        payload = dict(document_process_context)
-        if variable_axis_type in {
-            "induction_current",
-            "beam_strategy",
-            "in_situ_heating",
-            "temperature",
-            "laser_power",
-            "scan_speed",
-            "specimen_orientation",
-            "build_direction",
-        } and variable_value not in (None, ""):
-            payload[variable_axis_type] = self._normalize_variant_value(variable_value)
-        return self._normalize_condition_payload(payload)
-
-    def _collect_table_row_anchor_ids(
-        self,
-        document_cards: pd.DataFrame,
-        *,
-        table_id: str,
-        row_summary: str,
-        sample_label: str | None,
-    ) -> list[str]:
-        if document_cards is None or document_cards.empty:
-            return []
-        anchor_ids: list[str] = []
-        table_cards = document_cards[
-            document_cards["evidence_source_type"].astype(str) == "table"
-        ]
-        for _, row in table_cards.iterrows():
-            claim_text = str(row.get("claim_text") or "")
-            anchors = self._normalize_evidence_anchors_payload(row.get("evidence_anchors"))
-            for anchor in anchors:
-                if str(anchor.get("figure_or_table") or "") != str(table_id):
-                    continue
-                anchor_quote = str(anchor.get("quote_span") or anchor.get("quote") or "")
-                label_match = sample_label and sample_label.lower() in claim_text.lower()
-                summary_match = row_summary and anchor_quote == row_summary
-                if not label_match and not summary_match:
-                    continue
-                anchor_id = self._normalize_scalar_text(anchor.get("anchor_id"))
-                if anchor_id and anchor_id not in anchor_ids:
-                    anchor_ids.append(anchor_id)
-        return anchor_ids
-
-    def _build_default_sample_variant(
-        self,
-        *,
-        collection_id: str,
-        document_id: str,
-        document_cards: pd.DataFrame,
-        host_material_system: dict[str, Any],
-        document_process_context: dict[str, Any],
-    ) -> dict[str, Any] | None:
-        if document_cards is None or document_cards.empty:
+    def _sanitize_unit(self, value: Any) -> str | None:
+        text = self._normalize_scalar_text(value)
+        if text is None:
             return None
-        variant_label = str(host_material_system.get("family") or document_id).strip()
-        if not variant_label:
+        if re.fullmatch(r"\d{4}", text):
             return None
-        return SampleVariant.from_mapping(
-            {
-                "variant_id": f"var_{uuid4().hex[:12]}",
-                "document_id": str(document_id),
-                "collection_id": collection_id,
-                "domain_profile": CORE_NEUTRAL_DOMAIN_PROFILE,
-                "variant_label": variant_label,
-                "host_material_system": host_material_system,
-                "composition": host_material_system.get("composition"),
-                "variable_axis_type": None,
-                "variable_value": None,
-                "process_context": self._normalize_condition_payload(document_process_context),
-                "profile_payload": {"source_kind": "document_default"},
-                "structure_feature_ids": [],
-                "source_anchor_ids": self._collect_document_anchor_ids(document_cards),
-                "confidence": 0.62,
-                "epistemic_status": EPISTEMIC_INFERRED_WITH_LOW_CONFIDENCE,
-            }
-        ).to_record()
+        return text
 
-    def _collect_document_anchor_ids(
-        self,
-        document_cards: pd.DataFrame,
-    ) -> list[str]:
-        anchor_ids: list[str] = []
-        if document_cards is None or document_cards.empty:
-            return anchor_ids
-        for _, row in document_cards.iterrows():
-            for anchor_id in self._extract_anchor_ids(row.get("evidence_anchors")):
-                if anchor_id not in anchor_ids:
-                    anchor_ids.append(anchor_id)
-        return anchor_ids
-
-    def _match_variant_id_from_text(
-        self,
-        *,
-        document_id: str,
-        text: str,
-        sample_variants: pd.DataFrame,
-    ) -> str | None:
-        document_variants = self._filter_rows_by_document(sample_variants, document_id)
-        if document_variants.empty:
-            return None
-
-        non_default = document_variants[
-            document_variants["profile_payload"].apply(
-                lambda payload: str((self._normalize_object(payload) or {}).get("source_kind") or "")
-                != "document_default"
-            )
-        ]
-        lowered = str(text or "").lower()
-        matches: list[str] = []
-        for _, row in non_default.iterrows():
-            variant_id = self._normalize_scalar_text(row.get("variant_id"))
-            if variant_id is None:
+    def _sanitize_value_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        normalized: dict[str, Any] = {}
+        for key, value in payload.items():
+            parsed = normalize_backbone_value(value)
+            if parsed in (None, "", [], {}):
                 continue
-            label = str(row.get("variant_label") or "").strip().lower()
-            if label and label in lowered:
-                matches.append(variant_id)
-                continue
-            variable_value = row.get("variable_value")
-            if isinstance(variable_value, str) and variable_value.strip().lower() in lowered:
-                matches.append(variant_id)
-        unique_matches = list(dict.fromkeys(matches))
-        if len(unique_matches) == 1:
-            return unique_matches[0]
-        if len(non_default) == 1:
-            return self._normalize_scalar_text(non_default.iloc[0].get("variant_id"))
-        if len(non_default) == 0 and len(document_variants) == 1:
-            return self._normalize_scalar_text(document_variants.iloc[0].get("variant_id"))
-        return None
-
-    def _match_variant_id_from_label(
-        self,
-        *,
-        document_id: str,
-        label: str,
-        sample_variants: pd.DataFrame,
-    ) -> str | None:
-        lowered = str(label or "").strip().lower()
-        if not lowered:
-            return None
-        document_variants = self._filter_rows_by_document(sample_variants, document_id)
-        if document_variants.empty:
-            return None
-        matched = document_variants[
-            document_variants["variant_label"].astype(str).str.lower() == lowered
-        ]
-        if len(matched) == 1:
-            return self._normalize_scalar_text(matched.iloc[0].get("variant_id"))
-        return None
-
-    def _resolve_variant_id_for_card(
-        self,
-        *,
-        card_row: pd.Series,
-        sample_variants: pd.DataFrame,
-    ) -> str | None:
-        document_id = str(card_row.get("document_id") or "")
-        source_type = str(card_row.get("evidence_source_type") or "")
-        claim_text = str(card_row.get("claim_text") or "")
-        if source_type != "table":
-            return self._match_variant_id_from_text(
-                document_id=document_id,
-                text=claim_text,
-                sample_variants=sample_variants,
-            )
-
-        document_variants = self._filter_rows_by_document(sample_variants, document_id)
-        if document_variants.empty:
-            return None
-
-        anchors = self._normalize_evidence_anchors_payload(card_row.get("evidence_anchors"))
-        table_id = None
-        row_summary = None
-        if anchors:
-            table_id = str(anchors[0].get("figure_or_table") or "").strip() or None
-            row_summary = str(anchors[0].get("quote_span") or anchors[0].get("quote") or "").strip() or None
-
-        candidates = document_variants[
-            document_variants["profile_payload"].apply(
-                lambda payload: str((self._normalize_object(payload) or {}).get("table_id") or "")
-                == str(table_id or "")
-            )
-        ] if table_id else document_variants.iloc[0:0]
-        if not candidates.empty:
-            for _, variant in candidates.iterrows():
-                variant_id = self._normalize_scalar_text(variant.get("variant_id"))
-                label = str(variant.get("variant_label") or "").strip().lower()
-                profile_payload = self._normalize_object(variant.get("profile_payload")) or {}
-                candidate_summary = str(profile_payload.get("row_summary") or "").strip()
-                if label and label in claim_text.lower():
-                    return variant_id
-                if row_summary and candidate_summary and row_summary == candidate_summary:
-                    return variant_id
-            if len(candidates) == 1:
-                return self._normalize_scalar_text(candidates.iloc[0].get("variant_id"))
-
-        return self._match_variant_id_from_text(
-            document_id=document_id,
-            text=claim_text,
-            sample_variants=sample_variants,
-        )
-
-    def _resolve_test_condition_id(
-        self,
-        *,
-        card_row: pd.Series,
-        property_normalized: str,
-        test_conditions: pd.DataFrame,
-    ) -> str | None:
-        document_id = str(card_row.get("document_id") or "")
-        document_conditions = self._filter_rows_by_document(test_conditions, document_id)
-        if document_conditions.empty:
-            return None
-
-        property_conditions = document_conditions[
-            document_conditions["property_type"].astype(str) == str(property_normalized)
-        ]
-        payload = self._build_condition_payload_from_card(card_row)
-        if payload:
-            payload_text = json.dumps(payload, sort_keys=True, ensure_ascii=False)
-            exact_matches = property_conditions[
-                property_conditions["condition_payload"].apply(
-                    lambda value: json.dumps(
-                        self._normalize_condition_payload(value),
-                        sort_keys=True,
-                        ensure_ascii=False,
-                    )
-                    == payload_text
-                )
-            ]
-            if len(exact_matches) == 1:
-                return self._normalize_scalar_text(exact_matches.iloc[0].get("test_condition_id"))
-        if len(property_conditions) == 1:
-            return self._normalize_scalar_text(property_conditions.iloc[0].get("test_condition_id"))
-        if len(document_conditions) == 1:
-            return self._normalize_scalar_text(document_conditions.iloc[0].get("test_condition_id"))
-        return None
-
-    def _build_condition_payload_from_card(
-        self,
-        card_row: pd.Series,
-    ) -> dict[str, Any]:
-        condition_context = self._normalize_condition_context_payload(
-            card_row.get("condition_context")
-        )
-        process_context = condition_context.get("process", {})
-        test_context = condition_context.get("test", {})
-        payload = {
-            "method": test_context.get("method"),
-            "methods": self._normalize_list(test_context.get("methods")),
-            "temperatures_c": list(process_context.get("temperatures_c") or []),
-            "durations": list(process_context.get("durations") or []),
-            "atmosphere": process_context.get("atmosphere"),
-        }
-        return {
-            key: value
-            for key, value in payload.items()
-            if value not in (None, "", [], {})
-        }
-
-    def _resolve_baseline_id(
-        self,
-        *,
-        card_row: pd.Series,
-        baseline_references: pd.DataFrame,
-    ) -> str | None:
-        document_id = str(card_row.get("document_id") or "")
-        document_baselines = self._filter_rows_by_document(baseline_references, document_id)
-        if document_baselines.empty:
-            return None
-
-        condition_context = self._normalize_condition_context_payload(
-            card_row.get("condition_context")
-        )
-        baseline_label = str(
-            (condition_context.get("baseline") or {}).get("control") or ""
-        ).strip()
-        if baseline_label:
-            matched = document_baselines[
-                document_baselines["baseline_label"].astype(str).str.lower()
-                == baseline_label.lower()
-            ]
-            if len(matched) == 1:
-                return self._normalize_scalar_text(matched.iloc[0].get("baseline_id"))
-        if len(document_baselines) == 1:
-            return self._normalize_scalar_text(document_baselines.iloc[0].get("baseline_id"))
-        return None
-
-    def _collect_related_structure_feature_ids(
-        self,
-        *,
-        document_id: str,
-        variant_id: str | None,
-        structure_features: pd.DataFrame,
-        sample_variants: pd.DataFrame,
-    ) -> list[str]:
-        return self._collect_related_ids(
-            frame=structure_features,
-            document_id=document_id,
-            variant_id=variant_id,
-            id_column="feature_id",
-            sample_variants=sample_variants,
-        )
-
-    def _collect_related_characterization_ids(
-        self,
-        *,
-        document_id: str,
-        variant_id: str | None,
-        characterization: pd.DataFrame,
-        sample_variants: pd.DataFrame,
-    ) -> list[str]:
-        return self._collect_related_ids(
-            frame=characterization,
-            document_id=document_id,
-            variant_id=variant_id,
-            id_column="observation_id",
-            sample_variants=sample_variants,
-        )
-
-    def _collect_related_ids(
-        self,
-        *,
-        frame: pd.DataFrame,
-        document_id: str,
-        variant_id: str | None,
-        id_column: str,
-        sample_variants: pd.DataFrame,
-    ) -> list[str]:
-        document_rows = self._filter_rows_by_document(frame, document_id)
-        if document_rows.empty or id_column not in document_rows.columns:
-            return []
-
-        if variant_id:
-            specific = document_rows[
-                document_rows["variant_id"].astype(str) == str(variant_id)
-            ]
-            if not specific.empty:
-                return [str(value) for value in specific[id_column].tolist() if str(value).strip()]
-            if self._count_non_default_variants(document_id, sample_variants) <= 1:
-                generic = document_rows[
-                    document_rows["variant_id"].isna()
-                    | (document_rows["variant_id"].astype(str) == "")
-                    | (document_rows["variant_id"].astype(str) == "None")
-                ]
-                return [str(value) for value in generic[id_column].tolist() if str(value).strip()]
-            return []
-
-        if self._count_non_default_variants(document_id, sample_variants) <= 1:
-            generic = document_rows[
-                document_rows["variant_id"].isna()
-                | (document_rows["variant_id"].astype(str) == "")
-                | (document_rows["variant_id"].astype(str) == "None")
-            ]
-            return [str(value) for value in generic[id_column].tolist() if str(value).strip()]
-        return []
-
-    def _count_non_default_variants(
-        self,
-        document_id: str,
-        sample_variants: pd.DataFrame,
-    ) -> int:
-        document_variants = self._filter_rows_by_document(sample_variants, document_id)
-        if document_variants.empty:
-            return 0
-        count = 0
-        for _, row in document_variants.iterrows():
-            payload = self._normalize_object(row.get("profile_payload")) or {}
-            if str(payload.get("source_kind") or "") != "document_default":
-                count += 1
-        return count
-
-    def _infer_result_type(
-        self,
-        *,
-        claim_text: str,
-        property_normalized: str,
-    ) -> str:
-        lowered = str(claim_text or "").lower()
-        if property_normalized == "retention" or "retention" in lowered:
-            return "retention"
-        if _RANGE_VALUE_PATTERN.search(claim_text):
-            return "range"
-        if any(token in lowered for token in ("optimal", "optimum", "best")):
-            return "optimum"
-        if any(token in lowered for token in ("fit", "fitted", "arrhenius", "tauc")):
-            return "fitted_value"
-        if (
-            any(token in lowered for token in ("increased", "decreased", "higher", "lower"))
-            and _CLAIM_VALUE_PATTERN.search(claim_text) is None
-        ):
-            return "trend"
-        return "scalar"
-
-    def _build_result_value_payload(
-        self,
-        *,
-        claim_text: str,
-        result_type: str,
-    ) -> tuple[dict[str, Any], str | None]:
-        range_match = _RANGE_VALUE_PATTERN.search(claim_text)
-        if result_type == "range" and range_match is not None:
-            return (
-                {
-                    "min": float(range_match.group(1)),
-                    "max": float(range_match.group(2)),
-                    "statement": claim_text,
-                },
-                self._resolve_claim_unit(claim_text),
-            )
-
-        value, unit = self._extract_claim_value_and_unit(claim_text)
-        if result_type == "retention":
-            if value is None:
-                return ({}, unit)
-            return (
-                {
-                    "retention_percent": value,
-                    "statement": claim_text,
-                },
-                unit or "%",
-            )
-        if result_type == "trend":
-            direction = "increase" if "increase" in claim_text.lower() or "higher" in claim_text.lower() else "decrease"
-            payload: dict[str, Any] = {
-                "direction": direction,
-                "statement": claim_text,
-            }
-            if value is not None:
-                payload["value"] = value
-            return payload, unit
-        if result_type in {"optimum", "fitted_value"}:
-            payload = {"statement": claim_text}
-            if value is not None:
-                payload["value"] = value
-            return payload, unit
-        if value is None:
-            return ({}, unit)
-        return (
-            {
-                "value": value,
-                "statement": claim_text,
-            },
-            unit,
-        )
-
-    def _extract_claim_value_and_unit(
-        self,
-        claim_text: str,
-    ) -> tuple[float | None, str | None]:
-        match = _CLAIM_VALUE_PATTERN.search(claim_text)
-        if match is not None:
-            return float(match.group(1)), self._normalize_unit_text(match.group(2))
-
-        matches = list(re.finditer(r"([-+]?\d+(?:\.\d+)?)(?:\s*([A-Za-z%/0-9\-\^²·]+))?", claim_text))
-        if not matches:
-            return None, self._resolve_claim_unit(claim_text)
-        last = matches[-1]
-        return float(last.group(1)), self._normalize_unit_text(last.group(2)) or self._resolve_claim_unit(claim_text)
-
-    def _resolve_claim_unit(self, claim_text: str) -> str | None:
-        unit_match = re.search(r"\(([^)]+)\)", claim_text)
-        if unit_match:
-            return self._normalize_unit_text(unit_match.group(1))
-        explicit = re.search(r"\b(MPa|GPa|Pa|%|S/cm|mS/cm|W/mK|wt%|vol%)\b", claim_text, re.IGNORECASE)
-        if explicit:
-            return self._normalize_unit_text(explicit.group(1))
-        return None
-
-    def _normalize_unit_text(self, value: Any) -> str | None:
-        text = str(value or "").strip().strip(".,;:")
-        return text or None
-
-    def _normalize_sample_variants_table(
-        self,
-        sample_variants: pd.DataFrame,
-        collection_id: str | None,
-    ) -> pd.DataFrame:
-        if sample_variants is None or sample_variants.empty:
-            return pd.DataFrame(columns=_SAMPLE_VARIANT_COLUMNS)
-
-        normalized = sample_variants.copy()
-        if collection_id is not None and "collection_id" not in normalized.columns:
-            normalized["collection_id"] = collection_id
-        if "domain_profile" not in normalized.columns:
-            normalized["domain_profile"] = CORE_NEUTRAL_DOMAIN_PROFILE
-        records = []
-        for _, row in normalized.iterrows():
-            payload = dict(row)
-            payload["host_material_system"] = self._normalize_material_system_payload(
-                row.get("host_material_system")
-            )
-            payload["process_context"] = self._normalize_condition_payload(
-                row.get("process_context")
-            )
-            profile_payload = self._normalize_object(row.get("profile_payload"))
-            payload["profile_payload"] = (
-                profile_payload if isinstance(profile_payload, dict) else {}
-            )
-            payload["structure_feature_ids"] = self._normalize_list(
-                row.get("structure_feature_ids")
-            )
-            payload["source_anchor_ids"] = self._normalize_list(
-                row.get("source_anchor_ids")
-            )
-            records.append(SampleVariant.from_mapping(payload).to_record())
-        return pd.DataFrame(records, columns=_SAMPLE_VARIANT_COLUMNS)
-
-    def _normalize_measurement_results_table(
-        self,
-        measurement_results: pd.DataFrame,
-        collection_id: str | None,
-    ) -> pd.DataFrame:
-        if measurement_results is None or measurement_results.empty:
-            return pd.DataFrame(columns=_MEASUREMENT_RESULT_COLUMNS)
-
-        normalized = measurement_results.copy()
-        if collection_id is not None and "collection_id" not in normalized.columns:
-            normalized["collection_id"] = collection_id
-        if "domain_profile" not in normalized.columns:
-            normalized["domain_profile"] = CORE_NEUTRAL_DOMAIN_PROFILE
-        records = []
-        for _, row in normalized.iterrows():
-            payload = dict(row)
-            value_payload = self._normalize_object(row.get("value_payload"))
-            payload["value_payload"] = value_payload if isinstance(value_payload, dict) else {}
-            payload["structure_feature_ids"] = self._normalize_list(
-                row.get("structure_feature_ids")
-            )
-            payload["characterization_observation_ids"] = self._normalize_list(
-                row.get("characterization_observation_ids")
-            )
-            payload["evidence_anchor_ids"] = self._normalize_list(
-                row.get("evidence_anchor_ids")
-            )
-            records.append(MeasurementResult.from_mapping(payload).to_record())
-        return pd.DataFrame(records, columns=_MEASUREMENT_RESULT_COLUMNS)
-
-    def _normalize_characterization_table(
-        self,
-        characterization: pd.DataFrame,
-        collection_id: str | None,
-    ) -> pd.DataFrame:
-        if characterization is None or characterization.empty:
-            return pd.DataFrame(columns=_CHARACTERIZATION_COLUMNS)
-
-        normalized = characterization.copy()
-        if collection_id is not None and "collection_id" not in normalized.columns:
-            normalized["collection_id"] = collection_id
-        records = []
-        for _, row in normalized.iterrows():
-            payload = dict(row)
-            payload["condition_context"] = self._normalize_condition_context_payload(
-                row.get("condition_context")
-            )
-            payload["evidence_anchor_ids"] = self._normalize_list(
-                row.get("evidence_anchor_ids")
-            )
-            records.append(CharacterizationObservation.from_mapping(payload).to_record())
-        return pd.DataFrame(records, columns=_CHARACTERIZATION_COLUMNS)
-
-    def _normalize_structure_features_table(
-        self,
-        structure_features: pd.DataFrame,
-    ) -> pd.DataFrame:
-        if structure_features is None or structure_features.empty:
-            return pd.DataFrame(columns=_STRUCTURE_FEATURE_COLUMNS)
-
-        records = []
-        for _, row in structure_features.iterrows():
-            payload = dict(row)
-            payload["source_observation_ids"] = self._normalize_list(
-                row.get("source_observation_ids")
-            )
-            records.append(StructureFeature.from_mapping(payload).to_record())
-        return pd.DataFrame(records, columns=_STRUCTURE_FEATURE_COLUMNS)
-
-    def _normalize_test_conditions_table(
-        self,
-        test_conditions: pd.DataFrame,
-        collection_id: str | None,
-    ) -> pd.DataFrame:
-        if test_conditions is None or test_conditions.empty:
-            return pd.DataFrame(columns=_TEST_CONDITION_COLUMNS)
-
-        normalized = test_conditions.copy()
-        if collection_id is not None and "collection_id" not in normalized.columns:
-            normalized["collection_id"] = collection_id
-        if "domain_profile" not in normalized.columns:
-            normalized["domain_profile"] = CORE_NEUTRAL_DOMAIN_PROFILE
-        records = []
-        for _, row in normalized.iterrows():
-            payload = dict(row)
-            payload["condition_payload"] = self._normalize_condition_payload(
-                row.get("condition_payload")
-            )
-            payload["missing_fields"] = self._normalize_list(row.get("missing_fields"))
-            payload["evidence_anchor_ids"] = self._normalize_list(
-                row.get("evidence_anchor_ids")
-            )
-            records.append(TestCondition.from_mapping(payload).to_record())
-        return pd.DataFrame(records, columns=_TEST_CONDITION_COLUMNS)
-
-    def _normalize_baseline_references_table(
-        self,
-        baseline_references: pd.DataFrame,
-        collection_id: str | None,
-    ) -> pd.DataFrame:
-        if baseline_references is None or baseline_references.empty:
-            return pd.DataFrame(columns=_BASELINE_REFERENCE_COLUMNS)
-
-        normalized = baseline_references.copy()
-        if collection_id is not None and "collection_id" not in normalized.columns:
-            normalized["collection_id"] = collection_id
-        if "domain_profile" not in normalized.columns:
-            normalized["domain_profile"] = CORE_NEUTRAL_DOMAIN_PROFILE
-        records = []
-        for _, row in normalized.iterrows():
-            payload = dict(row)
-            payload["evidence_anchor_ids"] = self._normalize_list(
-                row.get("evidence_anchor_ids")
-            )
-            records.append(BaselineReference.from_mapping(payload).to_record())
-        return pd.DataFrame(records, columns=_BASELINE_REFERENCE_COLUMNS)
-
-    def _resolve_output_dir(self, collection_id: str) -> Path:
-        self.collection_service.get_collection(collection_id)
-        try:
-            artifacts = self.artifact_registry_service.get(collection_id)
-        except FileNotFoundError:
-            artifacts = None
-        if artifacts and artifacts.get("output_path"):
-            return Path(str(artifacts["output_path"])).expanduser().resolve()
-        return self.collection_service.get_paths(collection_id).output_dir.resolve()
-
-    def _build_cards_for_document(
-        self,
-        collection_id: str,
-        document_id: str,
-        title: str,
-        text: str,
-        text_unit_ids: list[str],
-        profile: dict[str, Any],
-        sections: list[dict[str, Any]],
-        table_cells: list[dict[str, Any]],
-    ) -> list[dict[str, Any]]:
-        cards: list[dict[str, Any]] = []
-        material_system = self._infer_material_system(title, text)
-        doc_type = str(profile.get("doc_type") or DOC_TYPE_UNCERTAIN)
-
-        if doc_type != DOC_TYPE_REVIEW:
-            for section in sections:
-                section_type = str(section.get("section_type") or "")
-                if section_type == "methods":
-                    cards.append(
-                        self._build_section_card(
-                            collection_id,
-                            document_id,
-                            material_system,
-                            section,
-                            claim_type="process",
-                            claim_text=self._first_sentence(section.get("text"))
-                            or "The document reports a process route.",
-                            confidence=0.82,
-                        )
-                    )
-                    break
-            for section in sections:
-                section_type = str(section.get("section_type") or "")
-                if section_type == "characterization":
-                    methods = self._extract_characterization_methods(section.get("text"))
-                    cards.append(
-                        self._build_section_card(
-                            collection_id,
-                            document_id,
-                            material_system,
-                            section,
-                            claim_type="characterization",
-                            claim_text=self._build_characterization_claim(methods)
-                            or self._first_sentence(section.get("text"))
-                            or "The document reports characterization evidence.",
-                            confidence=0.78,
-                        )
-                    )
-                    break
-
-            cards.extend(
-                self._build_table_property_cards(
-                    collection_id=collection_id,
-                    document_id=document_id,
-                    material_system=material_system,
-                    table_cells=table_cells,
-                )
-            )
-
-        candidate_sentence = self._find_claim_sentence(text)
-        if candidate_sentence:
-            claim_type = (
-                "mechanism"
-                if any(hint in candidate_sentence.lower() for hint in _MECHANISM_HINTS)
-                else "property"
-            )
-            cards.append(
-                self._build_text_claim_card(
-                    collection_id=collection_id,
-                    document_id=document_id,
-                    material_system=material_system,
-                    claim_text=candidate_sentence,
-                    full_text=text,
-                    text_unit_ids=text_unit_ids,
-                    claim_type=claim_type,
-                )
-            )
-
-        return cards
-
-    def _build_section_card(
-        self,
-        collection_id: str,
-        document_id: str,
-        material_system: dict[str, Any],
-        section: dict[str, Any],
-        claim_type: str,
-        claim_text: str,
-        confidence: float,
-    ) -> dict[str, Any]:
-        section_text = str(section.get("text") or "")
-        section_id = str(section.get("section_id") or "")
-        snippet_ids = self._normalize_list(section.get("text_unit_ids"))
-        evidence_anchors = [
-            {
-                "anchor_id": f"anchor_{uuid4().hex[:12]}",
-                "source_type": "method",
-                "section_id": section_id or None,
-                "block_id": None,
-                "snippet_id": snippet_ids[0] if snippet_ids else None,
-                "figure_or_table": None,
-                "quote_span": self._first_sentence(section_text) or section_text[:240] or None,
-            }
-        ]
-        return {
-            "evidence_id": f"ev_{uuid4().hex[:12]}",
-            "document_id": document_id,
-            "collection_id": collection_id,
-            "claim_text": claim_text,
-            "claim_type": claim_type,
-            "evidence_source_type": "method",
-            "evidence_anchors": evidence_anchors,
-            "material_system": self._normalize_material_system_payload(material_system),
-            "condition_context": self._normalize_condition_context_payload({
-                "process": self._extract_process_context(section_text),
-                "baseline": {},
-                "test": self._extract_test_context(section_text),
-            }),
-            "confidence": round(confidence, 2),
-            "traceability_status": TRACEABILITY_STATUS_DIRECT,
-        }
-
-    def _build_text_claim_card(
-        self,
-        collection_id: str,
-        document_id: str,
-        material_system: dict[str, Any],
-        claim_text: str,
-        full_text: str,
-        text_unit_ids: list[str],
-        claim_type: str,
-    ) -> dict[str, Any]:
-        baseline = self._extract_baseline_context(claim_text)
-        test_context = self._extract_test_context(full_text)
-        evidence_anchors = [
-            {
-                "anchor_id": f"anchor_{uuid4().hex[:12]}",
-                "source_type": "text",
-                "section_id": None,
-                "block_id": None,
-                "snippet_id": text_unit_ids[0] if text_unit_ids else None,
-                "figure_or_table": None,
-                "quote_span": claim_text,
-            }
-        ]
-        traceability_status = (
-            TRACEABILITY_STATUS_DIRECT if text_unit_ids else TRACEABILITY_STATUS_PARTIAL
-        )
-        return {
-            "evidence_id": f"ev_{uuid4().hex[:12]}",
-            "document_id": document_id,
-            "collection_id": collection_id,
-            "claim_text": claim_text,
-            "claim_type": claim_type,
-            "evidence_source_type": "text",
-            "evidence_anchors": evidence_anchors,
-            "material_system": self._normalize_material_system_payload(material_system),
-            "condition_context": self._normalize_condition_context_payload({
-                "process": self._extract_process_context(full_text),
-                "baseline": baseline,
-                "test": test_context,
-            }),
-            "confidence": (
-                0.74 if traceability_status == TRACEABILITY_STATUS_DIRECT else 0.66
-            ),
-            "traceability_status": traceability_status,
-        }
-
-    def _build_table_property_cards(
-        self,
-        *,
-        collection_id: str,
-        document_id: str,
-        material_system: dict[str, Any],
-        table_cells: list[dict[str, Any]],
-    ) -> list[dict[str, Any]]:
-        if not table_cells:
-            return []
-
-        grouped_rows: dict[tuple[str, int], list[dict[str, Any]]] = {}
-        for cell in table_cells:
-            table_id = str(cell.get("table_id") or "").strip()
-            row_index = self._safe_int(cell.get("row_index"))
-            if not table_id or row_index is None or row_index <= 0:
-                continue
-            grouped_rows.setdefault((table_id, row_index), []).append(cell)
-
-        cards: list[dict[str, Any]] = []
-        for (table_id, _row_index), row_cells in grouped_rows.items():
-            ordered_cells = sorted(
-                (cell for cell in row_cells if isinstance(cell, dict)),
-                key=lambda item: self._safe_int(item.get("col_index")) or 0,
-            )
-            sample_label = self._resolve_table_sample_label(ordered_cells)
-            baseline = self._resolve_table_baseline(ordered_cells)
-            row_summary = self._build_table_row_summary(ordered_cells)
-
-            for cell in ordered_cells:
-                header = str(cell.get("header_path") or "").strip()
-                if not header:
-                    continue
-                if self._is_table_sample_header(header) or self._is_table_baseline_header(header):
-                    continue
-                if self._infer_property_type_from_header(header) == "qualitative":
-                    continue
-
-                cell_text = str(cell.get("cell_text") or "").strip()
-                numeric_value = self._extract_table_numeric_value(cell_text)
-                if numeric_value is None:
-                    continue
-
-                unit = self._resolve_table_unit(cell)
-                claim_text = self._build_table_property_claim(
-                    sample_label=sample_label,
-                    header=header,
-                    numeric_value=numeric_value,
-                    unit=unit,
-                )
-                cards.append(
-                    {
-                        "evidence_id": f"ev_{uuid4().hex[:12]}",
-                        "document_id": document_id,
-                        "collection_id": collection_id,
-                        "claim_text": claim_text,
-                        "claim_type": "property",
-                        "evidence_source_type": "table",
-                        "evidence_anchors": [
-                            {
-                                "anchor_id": f"anchor_{uuid4().hex[:12]}",
-                                "source_type": "table",
-                                "section_id": None,
-                                "block_id": None,
-                                "snippet_id": None,
-                                "figure_or_table": table_id,
-                                "quote_span": row_summary or claim_text,
-                            }
-                        ],
-                        "material_system": self._normalize_material_system_payload(material_system),
-                        "condition_context": self._normalize_condition_context_payload(
-                            {
-                                "process": {},
-                                "baseline": baseline,
-                                "test": {},
-                            }
-                        ),
-                        "confidence": 0.8 if unit else 0.74,
-                        "traceability_status": TRACEABILITY_STATUS_DIRECT,
-                    }
-                )
-
-        return cards
-
-    def _infer_material_system(self, title: str, text: str) -> dict[str, Any]:
-        source = f"{title} {text}".lower()
-        family = None
-        composition = None
-        if "carbon fiber" in source:
-            family = "carbon fiber composite"
-        elif "epoxy" in source and "sio2" in source:
-            family = "epoxy/SiO2 composite"
-            composition = "epoxy + SiO2"
-        elif "epoxy" in source and "composite" in source:
-            family = "epoxy composite"
-        elif "composite" in source:
-            family = "composite"
-        elif title.strip():
-            family = title.strip()
-        else:
-            family = "unspecified material system"
-        if composition is None and title.strip() and title.strip() != family:
-            composition = title.strip()
-        return {"family": family, "composition": composition}
-
-    def _resolve_table_sample_label(
-        self,
-        row_cells: list[dict[str, Any]],
-    ) -> str | None:
-        for cell in row_cells:
-            header = str(cell.get("header_path") or "").strip()
-            if self._is_table_sample_header(header):
-                text = str(cell.get("cell_text") or "").strip()
-                if text:
-                    return text
-        for cell in row_cells:
-            header = str(cell.get("header_path") or "").strip()
-            text = str(cell.get("cell_text") or "").strip()
-            if not text or self._extract_table_numeric_value(text) is not None:
-                continue
-            if self._is_table_baseline_header(header):
-                continue
-            return text
-        return None
-
-    def _resolve_table_baseline(
-        self,
-        row_cells: list[dict[str, Any]],
-    ) -> dict[str, Any]:
-        for cell in row_cells:
-            header = str(cell.get("header_path") or "").strip()
-            if not self._is_table_baseline_header(header):
-                continue
-            text = str(cell.get("cell_text") or "").strip()
-            if text:
-                return {"control": text}
-        return {}
-
-    def _build_table_row_summary(
-        self,
-        row_cells: list[dict[str, Any]],
-    ) -> str:
-        parts: list[str] = []
-        for cell in row_cells:
-            header = str(cell.get("header_path") or "").strip()
-            text = str(cell.get("cell_text") or "").strip()
-            if not text:
-                continue
-            if header:
-                parts.append(f"{header}: {text}")
-            else:
-                parts.append(text)
-        return "; ".join(parts)
-
-    def _is_table_sample_header(self, header: str) -> bool:
-        lowered = str(header or "").strip().lower()
-        return any(hint in lowered for hint in _TABLE_SAMPLE_HEADER_HINTS)
-
-    def _is_table_baseline_header(self, header: str) -> bool:
-        lowered = str(header or "").strip().lower()
-        return any(hint in lowered for hint in _TABLE_BASELINE_HEADER_HINTS)
-
-    def _extract_table_numeric_value(self, cell_text: str) -> str | None:
-        match = _TABLE_NUMERIC_PATTERN.search(str(cell_text or ""))
-        if match is None:
-            return None
-        return match.group(0)
-
-    def _resolve_table_unit(self, cell: dict[str, Any]) -> str | None:
-        for candidate in (cell.get("unit_hint"), cell.get("header_path")):
-            text = str(candidate or "").strip()
-            if not text:
-                continue
-            unit_match = re.search(r"\(([^)]+)\)", text)
-            if unit_match:
-                return unit_match.group(1).strip() or None
-            if text.lower() in {"mpa", "gpa", "pa", "%", "s/cm", "ms/cm", "w/mk", "wt%", "vol%"}:
-                return text
-        return None
-
-    def _build_table_property_claim(
-        self,
-        *,
-        sample_label: str | None,
-        header: str,
-        numeric_value: str,
-        unit: str | None,
-    ) -> str:
-        subject = sample_label or "Sample"
-        property_label = header
-        if unit:
-            return f"{subject} reported {property_label} of {numeric_value} {unit}."
-        return f"{subject} reported {property_label} of {numeric_value}."
+            normalized[key] = parsed
+        return normalized
 
     def _extract_observed_value_and_unit(
         self,
@@ -2399,22 +1597,6 @@ class EvidenceCardService:
             }
         ).to_record()
 
-    def _infer_property_type_from_card(
-        self,
-        *,
-        claim_type: str,
-        claim_text: str,
-    ) -> str:
-        lowered = str(claim_text or "").lower()
-        for token, normalized in _PROPERTY_HINTS:
-            if token in lowered:
-                return normalized
-        if claim_type == "characterization":
-            return "characterization"
-        if claim_type == "process":
-            return "process_route"
-        return claim_type or "qualitative"
-
     def _infer_condition_template_type(
         self,
         property_type: str,
@@ -2437,17 +1619,6 @@ class EvidenceCardService:
         if property_type == "characterization":
             return "characterization"
         return "generic_materials_measurement"
-
-    def _infer_condition_scope_level(
-        self,
-        evidence_source_type: str,
-    ) -> str:
-        source_type = str(evidence_source_type or "").strip()
-        if source_type == "table":
-            return "table"
-        if source_type == "method":
-            return "experiment"
-        return "measurement"
 
     def _infer_missing_condition_fields(
         self,
@@ -2476,15 +1647,6 @@ class EvidenceCardService:
             return "partial"
         return "complete"
 
-    def _infer_baseline_scope(
-        self,
-        evidence_source_type: str,
-    ) -> str:
-        source_type = str(evidence_source_type or "").strip()
-        if source_type == "table":
-            return "table"
-        return "measurement"
-
     def _classify_baseline_type(
         self,
         baseline_label: str,
@@ -2502,44 +1664,6 @@ class EvidenceCardService:
             return "conventional_process_reference"
         return "implicit_within_document_control"
 
-    def _baseline_label_is_explicit(
-        self,
-        baseline_label: str,
-    ) -> bool:
-        lowered = str(baseline_label or "").lower()
-        return any(
-            token in lowered
-            for token in (
-                "baseline",
-                "control",
-                "reference",
-                "benchmark",
-                "literature",
-                "without",
-            )
-        )
-
-    def _normalize_condition_payload(
-        self,
-        value: Any,
-    ) -> dict[str, Any]:
-        payload = self._normalize_object(value) or {}
-        if not isinstance(payload, dict):
-            return {}
-
-        normalized: dict[str, Any] = {}
-        for key, item in payload.items():
-            parsed = self._normalize_object(item)
-            if isinstance(parsed, list):
-                normalized[key] = [entry for entry in parsed if entry not in (None, "", [], {})]
-            else:
-                normalized[key] = parsed
-        return {
-            key: value
-            for key, value in normalized.items()
-            if value not in (None, "", [], {})
-        }
-
     def _extract_anchor_ids(
         self,
         evidence_anchors: Any,
@@ -2556,69 +1680,9 @@ class EvidenceCardService:
                 anchor_ids.append(anchor_id)
         return anchor_ids
 
-    def _extract_process_context(self, text: Any) -> dict[str, Any]:
-        source = str(text or "")
-        temperatures = [float(match.group(1)) for match in _TEMP_PATTERN.finditer(source)]
-        durations = [match.group(0) for match in _TIME_PATTERN.finditer(source)]
-        atmosphere = None
-        match = _ATMOSPHERE_PATTERN.search(source)
-        if match:
-            atmosphere = match.group(1)
-        context: dict[str, Any] = {}
-        if temperatures:
-            context["temperatures_c"] = temperatures
-        if durations:
-            context["durations"] = durations
-        if atmosphere:
-            context["atmosphere"] = atmosphere
-        return context
-
-    def _extract_test_context(self, text: Any) -> dict[str, Any]:
-        source = str(text or "")
-        methods = self._extract_characterization_methods(source)
-        context: dict[str, Any] = {}
-        if methods:
-            context["methods"] = methods
-            if len(methods) == 1:
-                context["method"] = methods[0]
-        return context
-
-    def _extract_baseline_context(self, sentence: str) -> dict[str, Any]:
-        lowered = sentence.lower()
-        baseline: dict[str, Any] = {}
-        if "relative to" in lowered:
-            baseline["control"] = sentence.split("relative to", 1)[1].strip(" .")
-        elif "than the" in lowered:
-            baseline["control"] = sentence.split("than the", 1)[1].strip(" .")
-        elif "than" in lowered:
-            baseline["control"] = sentence.split("than", 1)[1].strip(" .")
-        return baseline
-
     def _extract_characterization_methods(self, text: Any) -> list[str]:
         source = str(text or "")
         return [method for method in _CHARACTERIZATION_METHODS if method.lower() in source.lower()]
-
-    def _build_characterization_claim(self, methods: list[str]) -> str | None:
-        if not methods:
-            return None
-        joined = ", ".join(methods)
-        return f"The document reports characterization using {joined}."
-
-    def _find_claim_sentence(self, text: str) -> str | None:
-        sentences = self._split_sentences(text)
-        for sentence in sentences:
-            lowered = sentence.lower()
-            if any(hint in lowered for hint in _PROPERTY_SENTENCE_HINTS):
-                return sentence
-        return None
-
-    def _split_sentences(self, text: str) -> list[str]:
-        chunks = re.split(r"(?<=[\.\!\?])\s+|\n+", str(text or ""))
-        return [chunk.strip() for chunk in chunks if chunk.strip()]
-
-    def _first_sentence(self, text: Any) -> str | None:
-        sentences = self._split_sentences(str(text or ""))
-        return sentences[0] if sentences else None
 
     def _group_sections_by_document(
         self,
@@ -2628,12 +1692,7 @@ class EvidenceCardService:
             return {}
         grouped: dict[str, list[dict[str, Any]]] = {}
         for _, row in sections.iterrows():
-            document_id = str(
-                row.get("paper_id")
-                or row.get("document_id")
-                or row.get("id")
-                or ""
-            )
+            document_id = str(row.get("paper_id") or row.get("document_id") or row.get("id") or "")
             grouped.setdefault(document_id, []).append(dict(row))
         return grouped
 
@@ -2844,7 +1903,6 @@ class EvidenceCardService:
 
         explicit_char_range = self._normalize_char_range_payload(anchor.get("char_range"))
         explicit_bbox = self._normalize_bbox_payload(anchor.get("bbox"))
-        locator_type = str(anchor.get("locator_type") or "section")
         locator_confidence = str(anchor.get("locator_confidence") or "low")
 
         if explicit_char_range is not None:
@@ -2893,8 +1951,6 @@ class EvidenceCardService:
                         "end": section_start + local_index + len(match_text),
                     }
                     section_id = self._normalize_scalar_text(section.get("section_id")) or section_id
-                    locator_type = "char_range"
-                    locator_confidence = "high"
 
             if resolved_char_range is None and full_text:
                 global_index = full_text.find(match_text)
@@ -2907,8 +1963,6 @@ class EvidenceCardService:
                     section_id = (
                         self._normalize_scalar_text(section.get("section_id")) if section else section_id
                     ) or section_id
-                    locator_type = "char_range"
-                    locator_confidence = "medium"
 
         if resolved_char_range is not None:
             return {
@@ -2917,7 +1971,7 @@ class EvidenceCardService:
                 "char_range": resolved_char_range,
                 "bbox": None,
                 "locator_type": "char_range",
-                "locator_confidence": locator_confidence,
+                "locator_confidence": "medium" if snippet_text else "high",
                 "quote": match_text,
                 "quote_span": match_text,
             }
@@ -3106,15 +2160,24 @@ class EvidenceCardService:
         if not isinstance(payload, dict):
             text = str(payload).strip()
             return {
-                "family": text or "unspecified material system",
+                "family": self._sanitize_material_family(text),
                 "composition": None,
             }
-        family = str(payload.get("family") or "").strip() or "unspecified material system"
-        composition = str(payload.get("composition") or "").strip() or None
+        family = self._sanitize_material_family(payload.get("family"))
+        composition = self._normalize_scalar_text(payload.get("composition"))
         return {
-            "family": family,
+            "family": family or "unspecified material system",
             "composition": composition,
         }
+
+    def _sanitize_material_family(self, value: Any) -> str | None:
+        text = self._normalize_scalar_text(value)
+        if text is None:
+            return None
+        lowered = text.lower()
+        if lowered.endswith((".pdf", ".txt", ".docx")):
+            return None
+        return text
 
     def _normalize_condition_context_payload(self, value: Any) -> dict[str, Any]:
         payload = self._normalize_object(value) or {}
@@ -3159,6 +2222,27 @@ class EvidenceCardService:
             },
         }
 
+    def _normalize_condition_payload(
+        self,
+        value: Any,
+    ) -> dict[str, Any]:
+        payload = self._normalize_object(value) or {}
+        if not isinstance(payload, dict):
+            return {}
+
+        normalized: dict[str, Any] = {}
+        for key, item in payload.items():
+            parsed = self._normalize_object(item)
+            if isinstance(parsed, list):
+                normalized[key] = [entry for entry in parsed if entry not in (None, "", [], {})]
+            else:
+                normalized[key] = parsed
+        return {
+            key: value
+            for key, value in normalized.items()
+            if value not in (None, "", [], {})
+        }
+
     def _normalize_object(self, value: Any) -> Any:
         return normalize_backbone_value(value)
 
@@ -3169,3 +2253,172 @@ class EvidenceCardService:
         if isinstance(normalized, list):
             return [str(item) for item in normalized if str(item).strip()]
         return [str(normalized)]
+
+    def _normalize_sample_variants_table(
+        self,
+        sample_variants: pd.DataFrame,
+        collection_id: str | None,
+    ) -> pd.DataFrame:
+        if sample_variants is None or sample_variants.empty:
+            return pd.DataFrame(columns=_SAMPLE_VARIANT_COLUMNS)
+
+        normalized = sample_variants.copy()
+        if collection_id is not None and "collection_id" not in normalized.columns:
+            normalized["collection_id"] = collection_id
+        if "domain_profile" not in normalized.columns:
+            normalized["domain_profile"] = CORE_NEUTRAL_DOMAIN_PROFILE
+        records = []
+        for _, row in normalized.iterrows():
+            payload = dict(row)
+            payload["host_material_system"] = self._normalize_material_system_payload(
+                row.get("host_material_system")
+            )
+            payload["process_context"] = self._normalize_condition_payload(
+                row.get("process_context")
+            )
+            profile_payload = self._normalize_object(row.get("profile_payload"))
+            payload["profile_payload"] = (
+                profile_payload if isinstance(profile_payload, dict) else {}
+            )
+            payload["structure_feature_ids"] = self._normalize_list(
+                row.get("structure_feature_ids")
+            )
+            payload["source_anchor_ids"] = self._normalize_list(
+                row.get("source_anchor_ids")
+            )
+            records.append(SampleVariant.from_mapping(payload).to_record())
+        return pd.DataFrame(records, columns=_SAMPLE_VARIANT_COLUMNS)
+
+    def _normalize_measurement_results_table(
+        self,
+        measurement_results: pd.DataFrame,
+        collection_id: str | None,
+    ) -> pd.DataFrame:
+        if measurement_results is None or measurement_results.empty:
+            return pd.DataFrame(columns=_MEASUREMENT_RESULT_COLUMNS)
+
+        normalized = measurement_results.copy()
+        if collection_id is not None and "collection_id" not in normalized.columns:
+            normalized["collection_id"] = collection_id
+        if "domain_profile" not in normalized.columns:
+            normalized["domain_profile"] = CORE_NEUTRAL_DOMAIN_PROFILE
+        records = []
+        for _, row in normalized.iterrows():
+            payload = dict(row)
+            value_payload = self._normalize_object(row.get("value_payload"))
+            payload["value_payload"] = value_payload if isinstance(value_payload, dict) else {}
+            payload["structure_feature_ids"] = self._normalize_list(
+                row.get("structure_feature_ids")
+            )
+            payload["characterization_observation_ids"] = self._normalize_list(
+                row.get("characterization_observation_ids")
+            )
+            payload["evidence_anchor_ids"] = self._normalize_list(
+                row.get("evidence_anchor_ids")
+            )
+            records.append(MeasurementResult.from_mapping(payload).to_record())
+        return pd.DataFrame(records, columns=_MEASUREMENT_RESULT_COLUMNS)
+
+    def _normalize_characterization_table(
+        self,
+        characterization: pd.DataFrame,
+        collection_id: str | None,
+    ) -> pd.DataFrame:
+        if characterization is None or characterization.empty:
+            return pd.DataFrame(columns=_CHARACTERIZATION_COLUMNS)
+
+        normalized = characterization.copy()
+        if collection_id is not None and "collection_id" not in normalized.columns:
+            normalized["collection_id"] = collection_id
+        records = []
+        for _, row in normalized.iterrows():
+            payload = dict(row)
+            payload["condition_context"] = self._normalize_condition_context_payload(
+                row.get("condition_context")
+            )
+            payload["evidence_anchor_ids"] = self._normalize_list(
+                row.get("evidence_anchor_ids")
+            )
+            records.append(CharacterizationObservation.from_mapping(payload).to_record())
+        return pd.DataFrame(records, columns=_CHARACTERIZATION_COLUMNS)
+
+    def _normalize_structure_features_table(
+        self,
+        structure_features: pd.DataFrame,
+    ) -> pd.DataFrame:
+        if structure_features is None or structure_features.empty:
+            return pd.DataFrame(columns=_STRUCTURE_FEATURE_COLUMNS)
+
+        records = []
+        for _, row in structure_features.iterrows():
+            payload = dict(row)
+            payload["source_observation_ids"] = self._normalize_list(
+                row.get("source_observation_ids")
+            )
+            records.append(StructureFeature.from_mapping(payload).to_record())
+        return pd.DataFrame(records, columns=_STRUCTURE_FEATURE_COLUMNS)
+
+    def _normalize_test_conditions_table(
+        self,
+        test_conditions: pd.DataFrame,
+        collection_id: str | None,
+    ) -> pd.DataFrame:
+        if test_conditions is None or test_conditions.empty:
+            return pd.DataFrame(columns=_TEST_CONDITION_COLUMNS)
+
+        normalized = test_conditions.copy()
+        if collection_id is not None and "collection_id" not in normalized.columns:
+            normalized["collection_id"] = collection_id
+        if "domain_profile" not in normalized.columns:
+            normalized["domain_profile"] = CORE_NEUTRAL_DOMAIN_PROFILE
+        records = []
+        for _, row in normalized.iterrows():
+            payload = dict(row)
+            payload["condition_payload"] = self._normalize_condition_payload(
+                row.get("condition_payload")
+            )
+            payload["missing_fields"] = self._normalize_list(row.get("missing_fields"))
+            payload["evidence_anchor_ids"] = self._normalize_list(
+                row.get("evidence_anchor_ids")
+            )
+            records.append(TestCondition.from_mapping(payload).to_record())
+        return pd.DataFrame(records, columns=_TEST_CONDITION_COLUMNS)
+
+    def _normalize_baseline_references_table(
+        self,
+        baseline_references: pd.DataFrame,
+        collection_id: str | None,
+    ) -> pd.DataFrame:
+        if baseline_references is None or baseline_references.empty:
+            return pd.DataFrame(columns=_BASELINE_REFERENCE_COLUMNS)
+
+        normalized = baseline_references.copy()
+        if collection_id is not None and "collection_id" not in normalized.columns:
+            normalized["collection_id"] = collection_id
+        if "domain_profile" not in normalized.columns:
+            normalized["domain_profile"] = CORE_NEUTRAL_DOMAIN_PROFILE
+        records = []
+        for _, row in normalized.iterrows():
+            payload = dict(row)
+            payload["evidence_anchor_ids"] = self._normalize_list(
+                row.get("evidence_anchor_ids")
+            )
+            records.append(BaselineReference.from_mapping(payload).to_record())
+        return pd.DataFrame(records, columns=_BASELINE_REFERENCE_COLUMNS)
+
+    def _resolve_output_dir(self, collection_id: str) -> Path:
+        self.collection_service.get_collection(collection_id)
+        try:
+            artifacts = self.artifact_registry_service.get(collection_id)
+        except FileNotFoundError:
+            artifacts = None
+        if artifacts and artifacts.get("output_path"):
+            return Path(str(artifacts["output_path"])).expanduser().resolve()
+        return self.collection_service.get_paths(collection_id).output_dir.resolve()
+
+
+__all__ = [
+    "EvidenceCardNotFoundError",
+    "EvidenceCardsNotReadyError",
+    "EvidenceCardService",
+]

--- a/backend/application/core/llm_extraction_models.py
+++ b/backend/application/core/llm_extraction_models.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class MaterialSystemPayload(_StrictModel):
+    family: str | None = None
+    composition: str | None = None
+
+
+class ProcessContextPayload(_StrictModel):
+    temperatures_c: list[float] = Field(default_factory=list)
+    durations: list[str] = Field(default_factory=list)
+    atmosphere: str | None = None
+
+
+class BaselineContextPayload(_StrictModel):
+    control: str | None = None
+
+
+class TestContextPayload(_StrictModel):
+    methods: list[str] = Field(default_factory=list)
+    method: str | None = None
+
+
+class ConditionContextPayload(_StrictModel):
+    process: ProcessContextPayload = Field(default_factory=ProcessContextPayload)
+    baseline: BaselineContextPayload = Field(default_factory=BaselineContextPayload)
+    test: TestContextPayload = Field(default_factory=TestContextPayload)
+
+
+class EvidenceAnchorPayload(_StrictModel):
+    quote: str | None = None
+    source_type: Literal["text", "method", "table", "figure"] = "text"
+    section_id: str | None = None
+    snippet_id: str | None = None
+    figure_or_table: str | None = None
+    page: int | None = None
+
+
+class EvidenceCardPayload(_StrictModel):
+    claim_text: str
+    claim_type: str
+    evidence_source_type: Literal["text", "method", "table", "figure"] = "text"
+    material_system: MaterialSystemPayload | None = None
+    condition_context: ConditionContextPayload = Field(default_factory=ConditionContextPayload)
+    anchors: list[EvidenceAnchorPayload] = Field(default_factory=list)
+    confidence: float = 0.0
+
+
+class SampleVariantPayload(_StrictModel):
+    variant_ref: str
+    variant_label: str
+    host_material_system: MaterialSystemPayload | None = None
+    composition: str | None = None
+    variable_axis_type: str | None = None
+    variable_value: str | int | float | None = None
+    process_context: ProcessContextPayload = Field(default_factory=ProcessContextPayload)
+    confidence: float = 0.0
+    epistemic_status: str = "normalized_from_evidence"
+    source_kind: Literal["section", "table_row"] = "section"
+
+
+class TestConditionPayloadModel(_StrictModel):
+    method: str | None = None
+    methods: list[str] = Field(default_factory=list)
+    temperatures_c: list[float] = Field(default_factory=list)
+    durations: list[str] = Field(default_factory=list)
+    atmosphere: str | None = None
+
+
+class ExtractedTestConditionPayload(_StrictModel):
+    test_condition_ref: str
+    property_type: str
+    condition_payload: TestConditionPayloadModel = Field(default_factory=TestConditionPayloadModel)
+    confidence: float = 0.0
+    epistemic_status: str = "normalized_from_evidence"
+
+
+class BaselineReferencePayload(_StrictModel):
+    baseline_ref: str
+    baseline_label: str
+    confidence: float = 0.0
+    epistemic_status: str = "normalized_from_evidence"
+
+
+class MeasurementValuePayload(_StrictModel):
+    value: float | None = None
+    min: float | None = None
+    max: float | None = None
+    retention_percent: float | None = None
+    direction: str | None = None
+    statement: str | None = None
+
+
+class MeasurementResultPayload(_StrictModel):
+    result_ref: str
+    claim_text: str
+    property_normalized: str
+    result_type: str
+    value_payload: MeasurementValuePayload = Field(default_factory=MeasurementValuePayload)
+    unit: str | None = None
+    variant_ref: str | None = None
+    test_condition_ref: str | None = None
+    baseline_ref: str | None = None
+    anchors: list[EvidenceAnchorPayload] = Field(default_factory=list)
+    confidence: float = 0.0
+
+
+class StructuredExtractionBundle(_StrictModel):
+    evidence_cards: list[EvidenceCardPayload] = Field(default_factory=list)
+    sample_variants: list[SampleVariantPayload] = Field(default_factory=list)
+    test_conditions: list[ExtractedTestConditionPayload] = Field(default_factory=list)
+    baseline_references: list[BaselineReferencePayload] = Field(default_factory=list)
+    measurement_results: list[MeasurementResultPayload] = Field(default_factory=list)
+
+
+class StructuredDocumentProfile(_StrictModel):
+    doc_type: str
+    protocol_extractable: str
+    protocol_extractability_signals: list[str] = Field(default_factory=list)
+    parsing_warnings: list[str] = Field(default_factory=list)
+    confidence: float = 0.0

--- a/backend/application/core/llm_extraction_prompts.py
+++ b/backend/application/core/llm_extraction_prompts.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+_COMMON_SYSTEM_PROMPT = """
+You are extracting structured research facts for a materials-literature backend.
+
+Non-negotiable rules:
+- Extract only facts directly supported by the provided input.
+- If evidence is missing or ambiguous, use null or an empty list.
+- Never infer material systems from filenames.
+- Never treat years, citation numbers, row numbers, or footnote markers as result values.
+- Never treat years, reference numbers, or numbering artifacts as units.
+- Reject literature-summary rows or review-summary rows that are not directly attributable.
+- Preserve anchors needed for downstream traceback.
+- Prefer fewer, higher-signal outputs over speculative coverage.
+""".strip()
+
+
+def build_document_profile_prompt(payload: dict[str, Any]) -> tuple[str, str]:
+    user_prompt = (
+        "Classify this document for the Core evidence/comparison backbone.\n\n"
+        f"Input JSON:\n{json.dumps(payload, ensure_ascii=False, indent=2)}\n\n"
+        "Return only schema-valid structured data."
+    )
+    return _COMMON_SYSTEM_PROMPT, user_prompt
+
+
+def build_section_extraction_prompt(payload: dict[str, Any]) -> tuple[str, str]:
+    user_prompt = (
+        "Extract section-grounded research facts from this one document section.\n\n"
+        f"Input JSON:\n{json.dumps(payload, ensure_ascii=False, indent=2)}\n\n"
+        "You may emit section evidence cards, sample variants, test conditions, "
+        "baseline references, and measurement results only if they are directly grounded "
+        "in this section."
+    )
+    return _COMMON_SYSTEM_PROMPT, user_prompt
+
+
+def build_table_row_extraction_prompt(payload: dict[str, Any]) -> tuple[str, str]:
+    user_prompt = (
+        "Extract row-grounded research facts from this one table row.\n\n"
+        f"Input JSON:\n{json.dumps(payload, ensure_ascii=False, indent=2)}\n\n"
+        "Use the row and header context only. Skip outputs when the row is a literature "
+        "summary rather than a directly attributable study row."
+    )
+    return _COMMON_SYSTEM_PROMPT, user_prompt

--- a/backend/application/core/llm_structured_extractor.py
+++ b/backend/application/core/llm_structured_extractor.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any
+
+from application.core.llm_extraction_models import (
+    StructuredDocumentProfile,
+    StructuredExtractionBundle,
+)
+from application.core.llm_extraction_prompts import (
+    build_document_profile_prompt,
+    build_section_extraction_prompt,
+    build_table_row_extraction_prompt,
+)
+from infra.llm.openai_structured_client import (
+    OpenAIStructuredClient,
+    build_openai_structured_client,
+)
+
+
+class CoreLLMStructuredExtractor:
+    """Core-owned LLM structured extraction entrypoint."""
+
+    def __init__(
+        self,
+        client: OpenAIStructuredClient | None = None,
+    ) -> None:
+        self.client = client or build_openai_structured_client()
+
+    def extract_document_profile(self, payload: dict[str, Any]) -> StructuredDocumentProfile:
+        system_prompt, user_prompt = build_document_profile_prompt(payload)
+        response = self.client.parse(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            response_model=StructuredDocumentProfile,
+        )
+        if not isinstance(response, StructuredDocumentProfile):
+            raise TypeError("unexpected document profile response type")
+        return response
+
+    def extract_section_bundle(self, payload: dict[str, Any]) -> StructuredExtractionBundle:
+        system_prompt, user_prompt = build_section_extraction_prompt(payload)
+        response = self.client.parse(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            response_model=StructuredExtractionBundle,
+        )
+        if not isinstance(response, StructuredExtractionBundle):
+            raise TypeError("unexpected section extraction response type")
+        return response
+
+    def extract_table_row_bundle(self, payload: dict[str, Any]) -> StructuredExtractionBundle:
+        system_prompt, user_prompt = build_table_row_extraction_prompt(payload)
+        response = self.client.parse(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            response_model=StructuredExtractionBundle,
+        )
+        if not isinstance(response, StructuredExtractionBundle):
+            raise TypeError("unexpected table row extraction response type")
+        return response
+
+
+def build_default_core_llm_structured_extractor() -> CoreLLMStructuredExtractor:
+    return CoreLLMStructuredExtractor()

--- a/backend/docs/plans/core/README.md
+++ b/backend/docs/plans/core/README.md
@@ -10,6 +10,9 @@ domain-semantic backfill.
   Earlier stabilization wave for the shared parsing seam
 - [`core-parsing-quality-hardening-plan.md`](core-parsing-quality-hardening-plan.md)
   Current Core quality hardening wave
+- [`core-llm-structured-extraction-hard-cutover-plan.md`](core-llm-structured-extraction-hard-cutover-plan.md)
+  Child implementation plan for hard-cutting Core semantic extraction to
+  schema-bound LLM parsing
 - [`claim-traceback-navigation-implementation-plan.md`](claim-traceback-navigation-implementation-plan.md)
   Core traceback vertical slice for reviewable evidence grounding
 - [`minimal-core-domain-backfill-plan.md`](minimal-core-domain-backfill-plan.md)

--- a/backend/docs/plans/core/core-llm-structured-extraction-hard-cutover-plan.md
+++ b/backend/docs/plans/core/core-llm-structured-extraction-hard-cutover-plan.md
@@ -1,0 +1,405 @@
+# Core LLM Structured Extraction Hard Cutover Plan
+
+## Summary
+
+This document records the backend-owned child execution plan for hard-cutting
+the current Core parsing and evidence backbone away from heuristic extraction
+and onto LLM structured extraction.
+
+This is not a new architecture layer and not a Source-owned parser expansion.
+It is a Core child plan inside the existing Lens v1 backbone:
+
+`document_profiles -> evidence_cards -> comparison_rows`
+
+The purpose of this cutover is straightforward:
+
+- stop treating noisy heuristic inference as the primary semantic extractor
+- move Core fact extraction onto schema-bound LLM parsing
+- keep `comparison_rows` as a deterministic Core judgment surface rather than
+  an opaque model-generated final artifact
+
+For the broader backend roadmap, read
+[`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md).
+For the immediate parent quality wave, read
+[`core-parsing-quality-hardening-plan.md`](core-parsing-quality-hardening-plan.md).
+For the layering rule that keeps stable research facts in Core rather than in
+Source, read
+[`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md).
+
+## Why This Child Plan Exists
+
+The current backend already has the right high-level layering:
+
+- Source hands off structural artifacts such as `documents`, `text_units`,
+  `sections`, and `table_cells`
+- Core owns stable research-fact extraction and collection-facing review
+  artifacts
+- derived and downstream surfaces consume Core outputs rather than defining the
+  facts themselves
+
+The problem is not missing layers. The problem is that the current Core
+semantic extraction is still dominated by heuristics:
+
+- keyword scoring for `document_profiles`
+- regex and section heuristics for `evidence_cards`
+- table-row guessing for `sample_variants`
+- value and unit guessing for `measurement_results`
+- condition and baseline inference from weak context fragments
+
+That rule-heavy path is now producing visibly bad collection-facing outputs on
+real documents:
+
+- filenames leaking into material-system fields
+- review papers producing fake comparison candidates
+- years, numbering, or citation artifacts being treated as result values or
+  units
+- document-level process context being over-merged into row-level comparison
+  displays
+
+At this point, further heuristic tuning would only create a larger brittle
+ruleset around the wrong primary extraction strategy.
+
+## Decision
+
+The backend should hard-cut Core extraction to LLM structured parsing.
+
+That means:
+
+- Source remains a structural handoff layer
+- Core becomes an LLM-first semantic extraction layer
+- `comparison_rows` stay deterministic and assembled from Core backbone
+  artifacts
+- the old heuristic extraction path is removed rather than retained as a
+  fallback
+
+This plan explicitly rejects:
+
+- dual-path extraction
+- compatibility shims between old heuristic artifacts and new LLM artifacts
+- partial roll-forward where one artifact stays heuristic only because it is
+  already working "well enough"
+- letting Source emit stable Core research facts directly
+
+## Place In The System
+
+### Five-Layer Position
+
+This cutover belongs to Layer 3, the Research Intelligence Core.
+
+It is not:
+
+- Goal Brief / Intake work
+- Source runtime parser ownership expansion
+- Goal Consumer / Decision-layer work
+- a derived-surface graph or report redesign
+
+### Ownership Boundary
+
+The dependency direction after cutover should remain:
+
+- Source owns structural raw material
+- Core owns stable research-fact extraction
+- downstream views consume Core artifacts
+
+Source may still use rules to split text and tables, but it must not become the
+owner of stable semantic artifacts such as evidence cards, sample variants,
+measurement results, or comparison judgments.
+
+## Scope
+
+This hard-cutover plan covers:
+
+- replacing heuristic `document_profiles` classification with LLM structured
+  extraction
+- replacing heuristic evidence, variant, result, test-condition, and baseline
+  extraction with LLM structured extraction
+- preserving deterministic Core assembly for `comparison_rows`
+- invalidating old heuristic-produced Core artifacts rather than supporting
+  mixed reads
+- adding benchmark and regression coverage for known collection-facing failure
+  modes
+
+This plan does not cover:
+
+- redesigning Source document loading or chunking ownership
+- moving stable Core facts into Source artifacts
+- letting LLMs directly emit final `comparison_rows`
+- graph or protocol surface redesign
+- adapter, wrapper, facade, or compatibility-layer work
+
+## Hard-Cutover Shape
+
+### What Source Still Produces
+
+Source should continue to produce only structural handoff artifacts:
+
+- `documents`
+- `text_units`
+- `sections`
+- `table_cells`
+
+Those are the inputs Core will consume for semantic extraction.
+
+### What Core Must Extract With LLM Structured Parsing
+
+Core should switch these artifacts to LLM structured extraction:
+
+- `document_profiles`
+- `evidence_cards`
+- `sample_variants`
+- `measurement_results`
+- `test_conditions`
+- `baseline_references`
+
+Core may continue to derive:
+
+- `characterization_observations`
+- `structure_features`
+
+from stronger LLM-grounded evidence outputs when deterministic extraction still
+adds value.
+
+### What Must Stay Deterministic
+
+`comparison_rows` should remain deterministic and assembled from the backbone
+artifacts above.
+
+The backend should keep model output away from the final comparison surface for
+three reasons:
+
+- deterministic comparability judgment remains auditable
+- API behavior stays easier to reason about and test
+- collection-facing review does not become hostage to one opaque prompt output
+
+## New Extraction Architecture
+
+The cutover should introduce one minimal permanent OpenAI structured-calling
+seam in backend infrastructure and three Core extraction slices above it.
+
+### Slice 1: Document Profile Extraction
+
+Input:
+
+- document title candidates
+- source filename
+- section summaries
+- representative document text
+
+Output:
+
+- `doc_type`
+- `protocol_extractable`
+- `protocol_extractability_signals`
+- `parsing_warnings`
+- confidence and contamination markers
+
+### Slice 2: Section Evidence Extraction
+
+Input:
+
+- one Core-relevant section at a time
+- document title and document-level identity
+- section type and local source anchor context
+
+Output:
+
+- `evidence_cards`
+- section-grounded condition context
+- section-grounded baseline context
+- traceability-ready anchors
+
+### Slice 3: Table Row Extraction
+
+Input:
+
+- document title
+- table title if available
+- header path values
+- one row's cells
+- nearby methods or characterization context when available
+
+Output:
+
+- `sample_variants`
+- `measurement_results`
+- `test_conditions`
+- `baseline_references`
+
+The extraction unit should be one table row, not the whole paper, so the model
+is forced to reason over bounded local evidence instead of mixing unrelated
+studies in review-heavy documents.
+
+## Structured Calling Contract
+
+The implementation should use schema-bound structured extraction rather than
+free-text parsing repair.
+
+The intended call shape is:
+
+- one minimal OpenAI-compatible client
+- `beta.chat.completions.parse`
+- Pydantic response models for each extraction slice
+
+The design goal is:
+
+- model freedom inside the prompt
+- schema certainty at the boundary
+- no post-hoc regex salvage as the primary correctness mechanism
+
+## Prompt Rules
+
+Every extraction prompt should enforce the same non-negotiables:
+
+- extract only facts supported by the provided text, row, or section
+- when evidence is missing or ambiguous, return `null` or an empty list
+- do not infer missing material systems from filenames
+- do not treat years, citation numbers, row numbers, or footnote markers as
+  result values
+- do not treat years, reference numbers, or numbering artifacts as units
+- do not emit comparison-ready results from literature-summary rows unless the
+  row is directly grounded and locally attributable
+- mark review contamination explicitly
+- preserve provenance needed for traceback and downstream rejection decisions
+
+The prompts should be domain-aware rather than generic. The model must be told
+what a usable research result looks like and what common failure modes must be
+suppressed.
+
+## Artifact Versioning And Cache Invalidation
+
+This cutover should invalidate the old heuristic Core artifacts rather than
+trying to read them forever.
+
+Required behavior:
+
+- introduce a Core extraction version such as `llm_v1`
+- treat old heuristic-produced artifacts as stale for Core semantic reads
+- force rebuild of Core artifacts when a collection only has the old version
+- do not keep dual readers for heuristic and LLM artifact shapes
+
+The backend may still reuse the same artifact filenames if the shape remains
+compatible, but the read path must reject stale semantic versions instead of
+quietly trusting them.
+
+## File Change Plan
+
+### Primary Runtime Areas
+
+- `backend/application/core/document_profile_service.py`
+- `backend/application/core/evidence_card_service.py`
+- `backend/application/core/comparison_service.py`
+- `backend/application/source/index_task_runner.py`
+- `backend/infra/`
+  new minimal OpenAI structured-calling seam
+
+### Suggested New Backend Files
+
+- `backend/infra/llm/openai_structured_client.py`
+- `backend/application/core/llm_extraction_models.py`
+- `backend/application/core/llm_extraction_prompts.py`
+
+These files should be permanent owning seams, not transitional wrappers.
+
+### Code Removal Requirement
+
+Delete the current heuristic extraction chain after cutover, including:
+
+- profile keyword-scoring as the primary semantic classifier
+- table-row variant guessing as the primary variant extractor
+- scalar value and unit regex guessing as the primary measurement extractor
+- baseline and test-condition inference fallbacks that survive only because the
+  LLM extractor was uncertain
+
+Small deterministic validators are still acceptable after cutover, but they may
+not become a second semantic extraction path.
+
+## Execution Order
+
+1. Add the minimal OpenAI structured client and extraction models.
+2. Hard-cut table-row extraction to LLM structured parsing.
+3. Hard-cut section evidence extraction to LLM structured parsing.
+4. Hard-cut document-profile classification to LLM structured parsing.
+5. Rebuild Core artifact versioning and stale-artifact invalidation.
+6. Remove the old heuristic extraction implementation.
+7. Lock in regression coverage on a representative benchmark corpus.
+
+This order keeps the highest-noise extraction surface first while preserving
+deterministic comparison assembly until the backbone artifacts improve.
+
+## Verification
+
+### Output Quality Verification
+
+- review-heavy collections no longer leak filenames into
+  `material_system_normalized`
+- year-like values no longer appear as `unit`
+- numbering artifacts no longer appear as variant axes or variant labels
+- table-row extraction rejects literature-summary rows that are not
+  comparison-worthy
+- `comparison_rows` become fewer but materially higher signal
+
+### Contract Verification
+
+- Source still terminates at structural artifacts only
+- Core remains the only stable fact producer
+- comparison APIs continue to serve deterministic collection-facing rows
+
+### Regression Verification
+
+- add benchmark fixtures covering experimental, mixed, and review-heavy papers
+- add regression assertions for known false positives:
+  - filename-as-material-system
+  - year-as-unit
+  - number-as-variant-axis
+  - document-level process over-merge
+- run targeted backend tests for profiles, evidence, comparison assembly, and
+  task-runner indexing flow
+
+## Risks And Guardrails
+
+- prompt design can quietly overfit to a few fixture papers unless the
+  benchmark set is deliberately mixed
+- schema-bound parsing reduces shape drift, but bad prompt scope can still
+  create semantically wrong null-versus-value decisions
+- if old heuristic code is not deleted, the system will regress into
+  dual-semantic ownership
+- if LLM extraction is placed in Source instead of Core, the layering boundary
+  will become weaker rather than stronger
+
+Guardrails:
+
+- no fallback to the old heuristic extractor
+- no adapter or compatibility layer between heuristic and LLM semantic outputs
+- no direct LLM emission of final `comparison_rows`
+- no Source-owned stable fact artifacts
+
+## Parent, Child, And Companion Relationships
+
+### Parent Docs
+
+- [`core-parsing-quality-hardening-plan.md`](core-parsing-quality-hardening-plan.md)
+  is the immediate parent execution plan. This page is the detailed child plan
+  for the hard cutover decision inside that quality wave.
+- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md)
+  remains the broader backend roadmap.
+
+### Companion Docs
+
+- [`minimal-core-domain-backfill-plan.md`](minimal-core-domain-backfill-plan.md)
+  remains the companion plan for moving stable Core semantics into explicit
+  domain ownership.
+- [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
+  remains the boundary authority for keeping stable research facts in Core.
+
+### Later Follow-Up Scope
+
+If later work adds benchmark operations, prompt-evaluation tooling, or a second
+wave of deterministic post-validation, record those as later child docs rather
+than expanding this page into an open-ended parser program.
+
+## Related Docs
+
+- [`core-parsing-quality-hardening-plan.md`](core-parsing-quality-hardening-plan.md)
+- [`minimal-core-domain-backfill-plan.md`](minimal-core-domain-backfill-plan.md)
+- [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
+- [`../backend-wide/goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md)

--- a/backend/docs/plans/core/core-parsing-quality-hardening-plan.md
+++ b/backend/docs/plans/core/core-parsing-quality-hardening-plan.md
@@ -20,6 +20,8 @@ For the broader roadmap, read
 [`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md).
 For the earlier Core seam work, read
 [`core-stabilization-and-seam-extraction-plan.md`](core-stabilization-and-seam-extraction-plan.md).
+For the LLM hard-cutover child execution plan under this wave, read
+[`core-llm-structured-extraction-hard-cutover-plan.md`](core-llm-structured-extraction-hard-cutover-plan.md).
 For the traceback/document-viewer vertical slice under this plan, read
 [`claim-traceback-navigation-implementation-plan.md`](claim-traceback-navigation-implementation-plan.md).
 
@@ -264,6 +266,7 @@ Exit criteria:
 - [`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md)
 - [`goal-core-source-contract-follow-up-plan.md`](../backend-wide/goal-core-source-contract-follow-up-plan.md)
 - [`core-stabilization-and-seam-extraction-plan.md`](core-stabilization-and-seam-extraction-plan.md)
+- [`core-llm-structured-extraction-hard-cutover-plan.md`](core-llm-structured-extraction-hard-cutover-plan.md)
 - [`claim-traceback-navigation-implementation-plan.md`](claim-traceback-navigation-implementation-plan.md)
 - [`source-collection-builder-normalization-plan.md`](../source/source-collection-builder-normalization-plan.md)
 - [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)

--- a/backend/domain/core/__init__.py
+++ b/backend/domain/core/__init__.py
@@ -9,7 +9,6 @@ from domain.core.comparison import (
 from domain.core.document_profile import (
     DocumentProfile,
     DocumentProfileSummary,
-    analyze_document_profile,
     summarize_document_profile_collection,
 )
 from domain.core.evidence_backbone import (
@@ -37,7 +36,6 @@ __all__ = [
     "SampleVariant",
     "StructureFeature",
     "TestCondition",
-    "analyze_document_profile",
     "evaluate_comparison_assessment",
     "summarize_document_profile_collection",
 ]

--- a/backend/domain/core/document_profile.py
+++ b/backend/domain/core/document_profile.py
@@ -2,87 +2,13 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import dataclass
-import math
-import re
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Iterable, Mapping
 
 from domain.shared.enums import (
-    DOC_TYPE_EXPERIMENTAL,
     DOC_TYPE_MIXED,
     DOC_TYPE_REVIEW,
     DOC_TYPE_UNCERTAIN,
-    DocumentType,
-    PROTOCOL_EXTRACTABLE_NO,
-    PROTOCOL_EXTRACTABLE_PARTIAL,
-    PROTOCOL_EXTRACTABLE_UNCERTAIN,
-    PROTOCOL_EXTRACTABLE_YES,
     PROTOCOL_SUITABLE_EXTRACTABILITY,
-    ProtocolExtractability,
-)
-
-_REVIEW_TITLE_PATTERNS = (
-    re.compile(r"\breview\b", re.IGNORECASE),
-    re.compile(r"\boverview\b", re.IGNORECASE),
-    re.compile(r"\bperspective\b", re.IGNORECASE),
-    re.compile(r"\bprogress\b", re.IGNORECASE),
-    re.compile(r"\brecent advances?\b", re.IGNORECASE),
-    re.compile(r"\bsurvey\b", re.IGNORECASE),
-    re.compile(r"\bmini[- ]?review\b", re.IGNORECASE),
-    re.compile(r"(综述|进展|评述)"),
-)
-
-_REVIEW_TEXT_HINTS = (
-    "this review",
-    "we review",
-    "recent advances",
-    "state of the art",
-    "in this perspective",
-    "this overview",
-    "综述",
-    "进展",
-    "评述",
-)
-
-_PROCEDURAL_HINTS = (
-    "stir",
-    "mix",
-    "dissolve",
-    "synthes",
-    "fabricat",
-    "prepare",
-    "hydrothermal",
-    "solvothermal",
-    "calcine",
-    "anneal",
-    "wash",
-    "dry",
-    "heat",
-    "cure",
-    "cast",
-    "filter",
-    "centrifug",
-    "加入",
-    "搅拌",
-    "溶解",
-    "制备",
-    "退火",
-    "烧结",
-    "洗涤",
-    "干燥",
-    "加热",
-)
-
-_CONDITION_PATTERNS = (
-    re.compile(r"\b\d+(?:\.\d+)?\s*(?:c|°c|k|f)\b", re.IGNORECASE),
-    re.compile(
-        r"\b\d+(?:\.\d+)?\s*(?:h|hr|hrs|hour|hours|min|mins|minute|minutes|s|sec|secs)\b",
-        re.IGNORECASE,
-    ),
-    re.compile(
-        r"\b\d+(?:\.\d+)?\s*(?:rpm|wt%|vol%|mol%|m|mm|um|μm|nm)\b",
-        re.IGNORECASE,
-    ),
-    re.compile(r"\b(?:under|in)\s+(?:air|argon|ar|nitrogen|n2|vacuum)\b", re.IGNORECASE),
 )
 
 
@@ -92,8 +18,8 @@ class DocumentProfile:
     collection_id: str
     title: str | None
     source_filename: str | None
-    doc_type: DocumentType
-    protocol_extractable: ProtocolExtractability
+    doc_type: str
+    protocol_extractable: str
     protocol_extractability_signals: tuple[str, ...]
     parsing_warnings: tuple[str, ...]
     confidence: float
@@ -106,9 +32,7 @@ class DocumentProfile:
             title=_normalize_optional_text(payload.get("title")),
             source_filename=_normalize_optional_text(payload.get("source_filename")),
             doc_type=str(payload.get("doc_type") or DOC_TYPE_UNCERTAIN),
-            protocol_extractable=str(
-                payload.get("protocol_extractable") or PROTOCOL_EXTRACTABLE_UNCERTAIN
-            ),
+            protocol_extractable=str(payload.get("protocol_extractable") or "uncertain"),
             protocol_extractability_signals=_normalize_string_tuple(
                 payload.get("protocol_extractability_signals")
             ),
@@ -146,126 +70,6 @@ class DocumentProfileSummary:
         }
 
 
-def analyze_document_profile(
-    *,
-    collection_id: str,
-    document_id: str,
-    title: str | None,
-    source_filename: str | None,
-    analysis_title: str,
-    text: str,
-    sections: Sequence[Mapping[str, Any]],
-) -> DocumentProfile:
-    lowered_text = str(text or "").lower()
-    normalized_sections = [
-        section for section in sections if isinstance(section, Mapping)
-    ]
-    method_sections = [
-        section
-        for section in normalized_sections
-        if str(section.get("section_type") or "") == "methods"
-    ]
-    characterization_sections = [
-        section
-        for section in normalized_sections
-        if str(section.get("section_type") or "") == "characterization"
-    ]
-    method_text = "\n".join(str(section.get("text") or "") for section in method_sections)
-
-    review_title_hits = sum(
-        1 for pattern in _REVIEW_TITLE_PATTERNS if pattern.search(str(analysis_title or ""))
-    )
-    review_text_hits = sum(1 for hint in _REVIEW_TEXT_HINTS if hint in lowered_text)
-    procedural_hits = _count_keyword_hits(method_text or lowered_text, _PROCEDURAL_HINTS)
-    condition_hits = _count_pattern_hits(method_text or text, _CONDITION_PATTERNS)
-
-    experimental_score = 0
-    review_score = 0
-    signals: list[str] = []
-    warnings: list[str] = []
-
-    if method_sections:
-        experimental_score += 2
-        signals.append("methods_section_detected")
-    else:
-        warnings.append("missing_methods_section")
-    if characterization_sections:
-        experimental_score += 1
-        signals.append("characterization_section_detected")
-    if procedural_hits >= 2:
-        experimental_score += 2
-        signals.append("procedural_actions_detected")
-    elif procedural_hits == 1:
-        experimental_score += 1
-        signals.append("limited_procedural_actions_detected")
-    if condition_hits >= 2:
-        experimental_score += 1
-        signals.append("condition_markers_detected")
-    elif condition_hits == 1:
-        signals.append("limited_condition_markers_detected")
-    else:
-        warnings.append("critical_parameters_incomplete")
-
-    if review_title_hits:
-        review_score += 2
-        signals.append("review_title_detected")
-    if review_text_hits:
-        review_score += 1
-        signals.append("review_language_detected")
-
-    if review_score >= 2 and experimental_score >= 2:
-        doc_type: DocumentType = DOC_TYPE_MIXED
-        warnings.append("review_contamination_detected")
-    elif review_score >= 2:
-        doc_type = DOC_TYPE_REVIEW
-    elif experimental_score >= 3:
-        doc_type = DOC_TYPE_EXPERIMENTAL
-    else:
-        doc_type = DOC_TYPE_UNCERTAIN
-        warnings.append("document_type_uncertain")
-
-    if not str(text or "").strip():
-        warnings.append("missing_document_text")
-    elif len(str(text or "").strip()) < 120:
-        warnings.append("limited_document_text")
-
-    protocol_extractable = _derive_protocol_extractable(
-        doc_type=doc_type,
-        method_sections_detected=bool(method_sections),
-        procedural_hits=procedural_hits,
-        condition_hits=condition_hits,
-        review_score=review_score,
-    )
-
-    if (
-        protocol_extractable
-        in {PROTOCOL_EXTRACTABLE_PARTIAL, PROTOCOL_EXTRACTABLE_UNCERTAIN}
-        and condition_hits == 0
-    ):
-        warnings.append("condition_context_weak")
-
-    confidence = _compute_confidence(
-        doc_type=doc_type,
-        protocol_extractable=protocol_extractable,
-        signal_count=len(set(signals)),
-        warning_count=len(set(warnings)),
-        review_score=review_score,
-        experimental_score=experimental_score,
-    )
-
-    return DocumentProfile(
-        document_id=document_id,
-        collection_id=collection_id,
-        title=title,
-        source_filename=source_filename,
-        doc_type=doc_type,
-        protocol_extractable=protocol_extractable,
-        protocol_extractability_signals=tuple(sorted(set(signals))),
-        parsing_warnings=tuple(sorted(set(warnings))),
-        confidence=confidence,
-    )
-
-
 def summarize_document_profile_collection(
     profiles: Iterable[DocumentProfile],
 ) -> DocumentProfileSummary:
@@ -280,7 +84,8 @@ def summarize_document_profile_collection(
 
     warnings: list[str] = []
     review_heavy_count = by_doc_type.get(DOC_TYPE_REVIEW, 0) + by_doc_type.get(
-        DOC_TYPE_MIXED, 0
+        DOC_TYPE_MIXED,
+        0,
     )
     if total_documents and review_heavy_count / total_documents >= 0.5:
         warnings.append(
@@ -302,76 +107,8 @@ def summarize_document_profile_collection(
     )
 
 
-def _derive_protocol_extractable(
-    *,
-    doc_type: DocumentType,
-    method_sections_detected: bool,
-    procedural_hits: int,
-    condition_hits: int,
-    review_score: int,
-) -> ProtocolExtractability:
-    if doc_type == DOC_TYPE_REVIEW:
-        return PROTOCOL_EXTRACTABLE_NO
-    if doc_type == DOC_TYPE_EXPERIMENTAL:
-        if method_sections_detected and procedural_hits >= 2 and condition_hits >= 2:
-            return PROTOCOL_EXTRACTABLE_YES
-        if method_sections_detected or procedural_hits > 0:
-            return PROTOCOL_EXTRACTABLE_PARTIAL
-        return PROTOCOL_EXTRACTABLE_UNCERTAIN
-    if doc_type == DOC_TYPE_MIXED:
-        if method_sections_detected or procedural_hits > 0:
-            return PROTOCOL_EXTRACTABLE_PARTIAL
-        return PROTOCOL_EXTRACTABLE_NO
-    if method_sections_detected or procedural_hits > 0:
-        return PROTOCOL_EXTRACTABLE_PARTIAL
-    if review_score > 0:
-        return PROTOCOL_EXTRACTABLE_NO
-    return PROTOCOL_EXTRACTABLE_UNCERTAIN
-
-
-def _count_keyword_hits(text: str, keywords: tuple[str, ...]) -> int:
-    lowered = str(text or "").lower()
-    return sum(1 for keyword in keywords if keyword in lowered)
-
-
-def _count_pattern_hits(text: str, patterns: tuple[re.Pattern[str], ...]) -> int:
-    source = str(text or "")
-    return sum(1 for pattern in patterns if pattern.search(source))
-
-
-def _compute_confidence(
-    *,
-    doc_type: DocumentType,
-    protocol_extractable: ProtocolExtractability,
-    signal_count: int,
-    warning_count: int,
-    review_score: int,
-    experimental_score: int,
-) -> float:
-    base = {
-        DOC_TYPE_EXPERIMENTAL: 0.82,
-        DOC_TYPE_MIXED: 0.72,
-        DOC_TYPE_REVIEW: 0.84,
-        DOC_TYPE_UNCERTAIN: 0.56,
-    }[doc_type]
-    if protocol_extractable == PROTOCOL_EXTRACTABLE_YES:
-        base += 0.06
-    elif protocol_extractable == PROTOCOL_EXTRACTABLE_PARTIAL:
-        base += 0.01
-    elif protocol_extractable == PROTOCOL_EXTRACTABLE_UNCERTAIN:
-        base -= 0.04
-
-    strength = min(signal_count, 4) * 0.02
-    noise = min(warning_count, 3) * 0.03
-    if review_score >= 2 and experimental_score >= 2:
-        noise += 0.03
-    return round(max(0.5, min(0.98, base + strength - noise)), 2)
-
-
 def _normalize_optional_text(value: Any) -> str | None:
     if value is None:
-        return None
-    if isinstance(value, float) and math.isnan(value):
         return None
     text = str(value).strip()
     return text or None
@@ -380,11 +117,15 @@ def _normalize_optional_text(value: Any) -> str | None:
 def _normalize_string_tuple(value: Any) -> tuple[str, ...]:
     if value is None:
         return ()
-    if hasattr(value, "tolist") and not isinstance(value, (str, bytes, bytearray)):
-        value = value.tolist()
+    if isinstance(value, str):
+        text = value.strip()
+        return (text,) if text else ()
     if isinstance(value, (list, tuple, set)):
-        items = [str(item).strip() for item in value if str(item).strip()]
-        return tuple(items)
+        return tuple(str(item) for item in value if str(item).strip())
+    if hasattr(value, "tolist") and not isinstance(value, (dict, bytes)):
+        converted = value.tolist()
+        if converted is not value:
+            return _normalize_string_tuple(converted)
     text = str(value).strip()
     return (text,) if text else ()
 
@@ -392,6 +133,5 @@ def _normalize_string_tuple(value: Any) -> tuple[str, ...]:
 __all__ = [
     "DocumentProfile",
     "DocumentProfileSummary",
-    "analyze_document_profile",
     "summarize_document_profile_collection",
 ]

--- a/backend/infra/llm/__init__.py
+++ b/backend/infra/llm/__init__.py
@@ -1,0 +1,5 @@
+"""LLM infrastructure seams for backend-owned structured extraction."""
+
+from infra.llm.openai_structured_client import OpenAIStructuredClient
+
+__all__ = ["OpenAIStructuredClient"]

--- a/backend/infra/llm/openai_structured_client.py
+++ b/backend/infra/llm/openai_structured_client.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+from typing import Type
+
+from openai import OpenAI
+from pydantic import BaseModel
+
+
+class OpenAIStructuredClient:
+    """Minimal OpenAI-compatible structured parsing client."""
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        api_key: str,
+        base_url: str | None = None,
+    ) -> None:
+        self.model = model
+        self.client = OpenAI(
+            api_key=api_key,
+            base_url=base_url or None,
+        )
+
+    def parse(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        response_model: Type[BaseModel],
+    ) -> BaseModel:
+        completion = self.client.beta.chat.completions.parse(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            response_format=response_model,
+        )
+        parsed = completion.choices[0].message.parsed
+        if parsed is None:
+            raise RuntimeError("structured extraction returned no parsed payload")
+        return parsed
+
+
+def build_openai_structured_client() -> OpenAIStructuredClient:
+    model = os.getenv("LLM_MODEL", "gpt-4o-mini").strip() or "gpt-4o-mini"
+    api_key = os.getenv("LLM_API_KEY", "").strip() or "not-needed"
+    base_url = os.getenv("LLM_BASE_URL", "").strip() or None
+    return OpenAIStructuredClient(
+        model=model,
+        api_key=api_key,
+        base_url=base_url,
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,7 +27,7 @@ def _parse_cors_allowed_origins() -> list[str]:
 def create_app() -> FastAPI:
     app = FastAPI(
         title="TsingAI-Lens API",
-        version="0.3.1",
+        version="0.3.3",
         docs_url=f"{PUBLIC_API_PREFIX}/docs",
         redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
         openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsingai-lens"
-version = "0.3.1"
+version = "0.3.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,29 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture(autouse=True)
+def _patch_core_llm_extractor(monkeypatch):
+    from application.core import comparison_service, document_profile_service, evidence_card_service
+    from tests.support.fake_core_llm_extractor import FakeCoreLLMStructuredExtractor
+
+    fake = FakeCoreLLMStructuredExtractor()
+    monkeypatch.setattr(
+        document_profile_service,
+        "build_default_core_llm_structured_extractor",
+        lambda: fake,
+    )
+    monkeypatch.setattr(
+        evidence_card_service,
+        "build_default_core_llm_structured_extractor",
+        lambda: fake,
+    )
+    monkeypatch.setattr(document_profile_service, "core_semantic_rebuild_required", lambda _base_dir: False)
+    monkeypatch.setattr(evidence_card_service, "core_semantic_rebuild_required", lambda _base_dir: False)
+    monkeypatch.setattr(comparison_service, "core_semantic_rebuild_required", lambda _base_dir: False)

--- a/backend/tests/support/fake_core_llm_extractor.py
+++ b/backend/tests/support/fake_core_llm_extractor.py
@@ -1,0 +1,536 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from application.core.llm_extraction_models import (
+    BaselineReferencePayload,
+    EvidenceAnchorPayload,
+    EvidenceCardPayload,
+    ExtractedTestConditionPayload,
+    MeasurementResultPayload,
+    MeasurementValuePayload,
+    SampleVariantPayload,
+    StructuredDocumentProfile,
+    StructuredExtractionBundle,
+)
+
+
+_PROPERTY_HINTS = (
+    ("yield strength", "yield_strength"),
+    ("tensile strength", "tensile_strength"),
+    ("flexural strength", "flexural_strength"),
+    ("fatigue life", "fatigue_life"),
+    ("retention", "retention"),
+    ("hardness", "hardness"),
+    ("conductivity", "conductivity"),
+    ("modulus", "modulus"),
+    ("elongation", "elongation"),
+    ("strength", "strength"),
+)
+_PROPERTY_UNIT_PATTERN = re.compile(r"\(([^)]+)\)")
+_FLOAT_PATTERN = re.compile(r"[-+]?\d+(?:\.\d+)?")
+_TEMP_PATTERN = re.compile(r"(\d+(?:\.\d+)?)\s*(?:c|°c)\b", re.IGNORECASE)
+_TIME_PATTERN = re.compile(
+    r"(\d+(?:\.\d+)?)\s*(h|hr|hrs|hour|hours|min|mins|minute|minutes|s|sec|secs)\b",
+    re.IGNORECASE,
+)
+_ATM_PATTERN = re.compile(r"\b(?:under|in)\s+(air|argon|ar|nitrogen|n2|vacuum)\b", re.IGNORECASE)
+_METHODS = ("XRD", "SEM", "TEM", "XPS", "Raman", "FTIR", "DSC", "TGA", "DMA")
+
+
+class FakeCoreLLMStructuredExtractor:
+    def extract_document_profile(self, payload: dict[str, Any]) -> StructuredDocumentProfile:
+        title = str(payload.get("title") or payload.get("analysis_title") or "").strip()
+        text = str(payload.get("representative_text") or "")
+        sections = payload.get("sections") if isinstance(payload.get("sections"), list) else []
+        lowered_title = title.lower()
+        lowered_text = text.lower()
+
+        has_methods = any(str(item.get("section_type") or "") == "methods" for item in sections)
+        has_characterization = any(
+            str(item.get("section_type") or "") == "characterization" for item in sections
+        )
+        review_hits = int("review" in lowered_title or "overview" in lowered_title) + int(
+            "this review" in lowered_text or "recent advances" in lowered_text
+        )
+        procedural_hits = sum(
+            token in lowered_text
+            for token in ("mix", "mixed", "stir", "anneal", "dried", "fabricated", "prepared")
+        )
+        condition_hits = len(_TEMP_PATTERN.findall(text)) + len(_TIME_PATTERN.findall(text))
+
+        signals: list[str] = []
+        warnings: list[str] = []
+        if has_methods:
+            signals.append("methods_section_detected")
+        else:
+            warnings.append("missing_methods_section")
+        if has_characterization:
+            signals.append("characterization_section_detected")
+        if procedural_hits:
+            signals.append("procedural_actions_detected")
+        if condition_hits:
+            signals.append("condition_markers_detected")
+        else:
+            warnings.append("critical_parameters_incomplete")
+
+        if review_hits and (has_methods or procedural_hits):
+            doc_type = "mixed"
+            protocol_extractable = "partial"
+            warnings.append("review_contamination_detected")
+        elif review_hits:
+            doc_type = "review"
+            protocol_extractable = "no"
+        elif has_methods and procedural_hits >= 2 and condition_hits >= 2:
+            doc_type = "experimental"
+            protocol_extractable = "yes"
+        elif has_methods or procedural_hits:
+            doc_type = "experimental"
+            protocol_extractable = "partial"
+        else:
+            doc_type = "uncertain"
+            protocol_extractable = "uncertain"
+            warnings.append("document_type_uncertain")
+
+        return StructuredDocumentProfile(
+            doc_type=doc_type,
+            protocol_extractable=protocol_extractable,
+            protocol_extractability_signals=sorted(set(signals)),
+            parsing_warnings=sorted(set(warnings)),
+            confidence=0.86 if doc_type == "experimental" else 0.82 if doc_type == "review" else 0.78,
+        )
+
+    def extract_section_bundle(self, payload: dict[str, Any]) -> StructuredExtractionBundle:
+        document_title = str(payload.get("document_title") or "")
+        document_profile = payload.get("document_profile") or {}
+        section = payload.get("section") or {}
+        section_type = str(section.get("section_type") or "")
+        text = str(section.get("text") or "")
+        section_id = str(section.get("section_id") or "") or None
+        text_unit_ids = section.get("text_unit_ids") if isinstance(section.get("text_unit_ids"), list) else []
+
+        if str(document_profile.get("doc_type") or "") == "review" and "experimental section" not in text.lower():
+            return StructuredExtractionBundle()
+
+        material_system = self._infer_material_system(document_title, text)
+        process_context = self._extract_process_context(text)
+        methods = self._extract_methods(text)
+        baseline_label = self._extract_baseline_label(text)
+
+        evidence_cards: list[EvidenceCardPayload] = []
+        sample_variants: list[SampleVariantPayload] = []
+        test_conditions: list[ExtractedTestConditionPayload] = []
+        baseline_references: list[BaselineReferencePayload] = []
+        measurement_results: list[MeasurementResultPayload] = []
+
+        if section_type == "methods":
+            sentence = self._first_statement(text)
+            if sentence:
+                evidence_cards.append(
+                    EvidenceCardPayload(
+                        claim_text=sentence,
+                        claim_type="process",
+                        evidence_source_type="method",
+                        material_system=material_system,
+                        condition_context={
+                            "process": process_context,
+                            "baseline": {"control": baseline_label},
+                            "test": {"methods": methods, "method": methods[0] if len(methods) == 1 else None},
+                        },
+                        anchors=[
+                            EvidenceAnchorPayload(
+                                quote=sentence,
+                                source_type="method",
+                                section_id=section_id,
+                                snippet_id=text_unit_ids[0] if text_unit_ids else None,
+                            )
+                        ],
+                        confidence=0.82,
+                    )
+                )
+
+        if section_type == "characterization" and methods:
+            evidence_cards.append(
+                EvidenceCardPayload(
+                    claim_text=f"The document reports characterization using {', '.join(methods)}.",
+                    claim_type="characterization",
+                    evidence_source_type="text",
+                    material_system=material_system,
+                    condition_context={
+                        "process": process_context,
+                        "baseline": {"control": baseline_label},
+                        "test": {"methods": methods, "method": methods[0] if len(methods) == 1 else None},
+                    },
+                    anchors=[
+                        EvidenceAnchorPayload(
+                            quote=self._first_statement(text) or text[:160],
+                            source_type="text",
+                            section_id=section_id,
+                            snippet_id=text_unit_ids[0] if text_unit_ids else None,
+                        )
+                    ],
+                    confidence=0.78,
+                )
+            )
+
+        property_sentences = [
+            sentence
+            for sentence in self._split_statements(text)
+            if "|" not in sentence
+            and not sentence.lower().startswith("table ")
+            and self._infer_property(sentence) is not None
+        ]
+        if property_sentences:
+            sample_variants.append(
+                SampleVariantPayload(
+                    variant_ref="default_variant",
+                    variant_label=self._default_variant_label(
+                        material_system.get("family"),
+                        document_title,
+                    ),
+                    host_material_system=material_system,
+                    composition=material_system.get("composition"),
+                    variable_axis_type=None,
+                    variable_value=None,
+                    process_context=process_context,
+                    confidence=0.66,
+                    epistemic_status="inferred_with_low_confidence",
+                    source_kind="section",
+                )
+            )
+
+        if property_sentences and (
+            methods
+            or process_context.get("temperatures_c")
+            or process_context.get("durations")
+        ):
+            property_name = self._infer_property(property_sentences[0]) or "qualitative"
+            test_conditions.append(
+                ExtractedTestConditionPayload(
+                    test_condition_ref="section_tc",
+                    property_type=property_name,
+                    condition_payload={
+                        "method": methods[0] if len(methods) == 1 else None,
+                        "methods": methods,
+                        "temperatures_c": process_context.get("temperatures_c") or [],
+                        "durations": process_context.get("durations") or [],
+                        "atmosphere": process_context.get("atmosphere"),
+                    },
+                    confidence=0.8,
+                )
+            )
+
+        if property_sentences and baseline_label:
+            baseline_references.append(
+                BaselineReferencePayload(
+                    baseline_ref="section_base",
+                    baseline_label=baseline_label,
+                    confidence=0.8,
+                    epistemic_status="normalized_from_evidence",
+                )
+            )
+
+        for index, sentence in enumerate(property_sentences, start=1):
+            parsed = self._parse_result_sentence(sentence)
+            if parsed is None:
+                continue
+            property_name = self._infer_property(sentence) or "qualitative"
+            result_type, value_payload, unit = parsed
+            measurement_results.append(
+                MeasurementResultPayload(
+                    result_ref=f"section_result_{index}",
+                    claim_text=sentence,
+                    property_normalized=property_name,
+                    result_type=result_type,
+                    value_payload=value_payload,
+                    unit=unit,
+                    variant_ref="default_variant",
+                    test_condition_ref="section_tc" if test_conditions else None,
+                    baseline_ref="section_base" if baseline_references else None,
+                    anchors=[
+                        EvidenceAnchorPayload(
+                            quote=sentence,
+                            source_type="text",
+                            section_id=section_id,
+                            snippet_id=text_unit_ids[0] if text_unit_ids else None,
+                        )
+                    ],
+                    confidence=0.84,
+                )
+            )
+
+        return StructuredExtractionBundle(
+            evidence_cards=evidence_cards,
+            sample_variants=sample_variants,
+            test_conditions=test_conditions,
+            baseline_references=baseline_references,
+            measurement_results=measurement_results,
+        )
+
+    def extract_table_row_bundle(self, payload: dict[str, Any]) -> StructuredExtractionBundle:
+        document_title = str(payload.get("document_title") or "")
+        document_profile = payload.get("document_profile") or {}
+        row = payload.get("table_row") or {}
+        nearby_context = payload.get("nearby_context") or {}
+        if str(document_profile.get("doc_type") or "") == "review":
+            return StructuredExtractionBundle()
+
+        table_id = str(row.get("table_id") or "") or None
+        row_summary = str(row.get("row_summary") or "")
+        cells = row.get("cells") if isinstance(row.get("cells"), list) else []
+        methods_text = str(nearby_context.get("methods_text") or "")
+        characterization_text = str(nearby_context.get("characterization_text") or "")
+
+        material_system = self._infer_material_system(document_title, methods_text or characterization_text)
+        process_context = self._extract_process_context(methods_text)
+        methods = self._extract_methods(characterization_text or methods_text)
+
+        sample_label = None
+        variable_axis_type = None
+        variable_value: str | int | float | None = None
+        baseline_label = None
+        property_cells: list[tuple[str, str, str | None]] = []
+
+        for cell in cells:
+            header = str(cell.get("header_path") or "")
+            value = str(cell.get("cell_text") or "").strip()
+            unit_hint = str(cell.get("unit_hint") or "").strip() or None
+            if not value:
+                continue
+            lowered_header = header.lower()
+            if any(token in lowered_header for token in ("sample", "group", "variant")):
+                sample_label = value
+                continue
+            if "baseline" in lowered_header or "control" in lowered_header or "reference" in lowered_header:
+                baseline_label = value
+                continue
+            property_name = self._infer_property(
+                f"{header} {row.get('table_id') or ''} {document_title}"
+            )
+            if property_name is not None:
+                property_cells.append((property_name, value, unit_hint or self._extract_unit(header)))
+                continue
+            if variable_axis_type is None:
+                variable_axis_type = self._normalize_axis(header)
+                variable_value = self._normalize_numeric_or_text(value)
+
+        if not property_cells:
+            return StructuredExtractionBundle()
+
+        variant_label = sample_label or self._default_variant_label(
+            material_system.get("family"),
+            document_title,
+        )
+        sample_variants = [
+            SampleVariantPayload(
+                variant_ref="table_variant",
+                variant_label=variant_label,
+                host_material_system=material_system,
+                composition=material_system.get("composition"),
+                variable_axis_type=variable_axis_type,
+                variable_value=variable_value,
+                process_context=process_context,
+                confidence=0.86,
+                epistemic_status="normalized_from_evidence",
+                source_kind="table_row",
+            )
+        ]
+
+        test_conditions = [
+            ExtractedTestConditionPayload(
+                test_condition_ref="table_tc",
+                property_type=property_cells[0][0],
+                condition_payload={
+                    "method": methods[0] if len(methods) == 1 else None,
+                    "methods": methods,
+                    "temperatures_c": process_context.get("temperatures_c") or [],
+                    "durations": process_context.get("durations") or [],
+                    "atmosphere": process_context.get("atmosphere"),
+                },
+                confidence=0.82,
+            )
+        ] if (
+            methods
+            or process_context.get("temperatures_c")
+            or process_context.get("durations")
+        ) else []
+
+        baseline_references = [
+            BaselineReferencePayload(
+                baseline_ref="table_base",
+                baseline_label=baseline_label,
+                confidence=0.82,
+                epistemic_status="normalized_from_evidence",
+            )
+        ] if baseline_label else []
+
+        measurement_results: list[MeasurementResultPayload] = []
+        for index, (property_name, value, unit) in enumerate(property_cells, start=1):
+            parsed_value = self._normalize_numeric_or_text(value)
+            if property_name == "retention":
+                value_payload = MeasurementValuePayload(
+                    retention_percent=float(parsed_value),
+                    statement=f"{property_name} of {parsed_value} {unit or '%'}".strip(),
+                )
+                result_type = "retention"
+                unit = unit or "%"
+            else:
+                value_payload = MeasurementValuePayload(
+                    value=float(parsed_value),
+                    statement=f"{property_name} of {parsed_value} {unit or ''}".strip(),
+                )
+                result_type = "scalar"
+            measurement_results.append(
+                MeasurementResultPayload(
+                    result_ref=f"table_result_{index}",
+                    claim_text=f"{variant_label} reported {property_name} of {parsed_value} {unit or ''}".strip(),
+                    property_normalized=property_name,
+                    result_type=result_type,
+                    value_payload=value_payload,
+                    unit=unit,
+                    variant_ref="table_variant",
+                    test_condition_ref="table_tc" if test_conditions else None,
+                    baseline_ref="table_base" if baseline_references else None,
+                    anchors=[
+                        EvidenceAnchorPayload(
+                            quote=row_summary,
+                            source_type="table",
+                            figure_or_table=table_id,
+                        )
+                    ],
+                    confidence=0.9,
+                )
+            )
+
+        return StructuredExtractionBundle(
+            sample_variants=sample_variants,
+            test_conditions=test_conditions,
+            baseline_references=baseline_references,
+            measurement_results=measurement_results,
+        )
+
+    def _infer_material_system(self, title: str, text: str):
+        lowered = f"{title}\n{text}".lower()
+        if "epoxy" in lowered:
+            family = "epoxy composite"
+        elif "ti alloy" in lowered or "titanium" in lowered:
+            family = "Ti alloy"
+        elif "ceramic" in lowered:
+            family = "ceramic"
+        elif "coating" in lowered:
+            family = "coating"
+        elif "composite" in lowered:
+            family = "composite"
+        else:
+            family = "unspecified material system"
+        return {"family": family, "composition": None}
+
+    def _default_variant_label(self, family: str | None, title: str) -> str:
+        if family and family != "unspecified material system":
+            return family
+        return title.strip() or "document sample"
+
+    def _extract_process_context(self, text: str):
+        temperatures = [float(match.group(1)) for match in _TEMP_PATTERN.finditer(text)]
+        durations = [match.group(0) for match in _TIME_PATTERN.finditer(text)]
+        atmosphere_match = _ATM_PATTERN.search(text)
+        return {
+            "temperatures_c": temperatures,
+            "durations": durations,
+            "atmosphere": atmosphere_match.group(1) if atmosphere_match else None,
+        }
+
+    def _extract_methods(self, text: str) -> list[str]:
+        lowered = text.lower()
+        return [method for method in _METHODS if method.lower() in lowered]
+
+    def _extract_baseline_label(self, text: str) -> str | None:
+        lowered = text.lower()
+        if "as-built" in lowered:
+            return "as-built"
+        if "as-prepared" in lowered:
+            return "as-prepared"
+        if "untreated baseline" in lowered:
+            return "untreated baseline"
+        match = re.search(r"relative to the ([^.]+)", text, re.IGNORECASE)
+        if match:
+            return match.group(1).strip(" .")
+        return None
+
+    def _infer_property(self, text: str) -> str | None:
+        lowered = str(text or "").lower()
+        if "yield strength" in lowered:
+            return "yield_strength"
+        if "tensile strength" in lowered:
+            return "tensile_strength"
+        if "flexural strength" in lowered:
+            return "flexural_strength"
+        if "strength" in lowered:
+            return "tensile_strength"
+        for token, normalized in _PROPERTY_HINTS:
+            if token in lowered:
+                return normalized
+        return None
+
+    def _parse_result_sentence(
+        self,
+        sentence: str,
+    ) -> tuple[str, MeasurementValuePayload, str | None] | None:
+        property_name = self._infer_property(sentence)
+        if property_name is None:
+            return None
+        unit = self._extract_unit(sentence)
+        numbers = [float(match.group(0)) for match in _FLOAT_PATTERN.finditer(sentence)]
+        if not numbers:
+            return None
+        numeric_value = numbers[-1]
+        if property_name == "retention":
+            return (
+                "retention",
+                MeasurementValuePayload(
+                    retention_percent=numeric_value,
+                    statement=sentence,
+                ),
+                unit or "%",
+            )
+        return (
+            "scalar",
+            MeasurementValuePayload(
+                value=numeric_value,
+                statement=sentence,
+            ),
+            unit,
+        )
+
+    def _extract_unit(self, text: str) -> str | None:
+        match = _PROPERTY_UNIT_PATTERN.search(text)
+        if match:
+            return match.group(1).strip()
+        explicit = re.search(r"\b(MPa|GPa|Pa|%|S/cm|mS/cm|W/mK)\b", text, re.IGNORECASE)
+        if explicit:
+            return explicit.group(1)
+        return None
+
+    def _split_statements(self, text: str) -> list[str]:
+        parts = re.split(r"[\n。]+|(?<=[.?!])\s+", text)
+        return [part.strip() for part in parts if part.strip()]
+
+    def _first_statement(self, text: str) -> str | None:
+        statements = self._split_statements(text)
+        return statements[0] if statements else None
+
+    def _normalize_axis(self, header: str) -> str | None:
+        lowered = header.lower()
+        if "current" in lowered:
+            return "induction_current"
+        normalized = re.sub(r"[^a-z0-9]+", "_", lowered).strip("_")
+        return normalized or None
+
+    def _normalize_numeric_or_text(self, value: Any) -> str | int | float:
+        text = str(value).strip()
+        if re.fullmatch(r"[-+]?\d+", text):
+            return int(text)
+        if re.fullmatch(r"[-+]?\d+(?:\.\d+)?", text):
+            return float(text)
+        return text

--- a/backend/tests/unit/domains/test_document_profile_domain.py
+++ b/backend/tests/unit/domains/test_document_profile_domain.py
@@ -1,128 +1,61 @@
 from __future__ import annotations
 
 from domain.core.document_profile import (
-    analyze_document_profile,
+    DocumentProfile,
     summarize_document_profile_collection,
 )
 from domain.shared.enums import (
     DOC_TYPE_EXPERIMENTAL,
-    DOC_TYPE_MIXED,
     DOC_TYPE_REVIEW,
     DOC_TYPE_UNCERTAIN,
     PROTOCOL_EXTRACTABLE_NO,
-    PROTOCOL_EXTRACTABLE_PARTIAL,
     PROTOCOL_EXTRACTABLE_UNCERTAIN,
     PROTOCOL_EXTRACTABLE_YES,
 )
 
 
-def test_analyze_document_profile_classifies_experimental_document() -> None:
-    profile = analyze_document_profile(
-        collection_id="col-1",
-        document_id="doc-exp",
-        title="Composite Processing Study",
-        source_filename=None,
-        analysis_title="Composite Processing Study",
-        text=(
-            "Experimental Section\n"
-            "Powders were mixed in ethanol, stirred for 2 h, dried at 80 C, "
-            "and annealed at 600 C under argon.\n"
-            "Characterization\n"
-            "XRD and SEM were used to characterize the resulting powders."
-        ),
-        sections=[
-            {
-                "section_type": "methods",
-                "text": (
-                    "Powders were mixed in ethanol, stirred for 2 h, dried at 80 C, "
-                    "and annealed at 600 C under argon."
-                ),
-            },
-            {
-                "section_type": "characterization",
-                "text": "XRD and SEM were used to characterize the resulting powders.",
-            },
-        ],
+def test_document_profile_from_mapping_normalizes_identity_and_lists() -> None:
+    profile = DocumentProfile.from_mapping(
+        {
+            "document_id": "doc-exp",
+            "collection_id": "col-1",
+            "title": "Composite Processing Study",
+            "source_filename": "paper.txt",
+            "doc_type": "experimental",
+            "protocol_extractable": "yes",
+            "protocol_extractability_signals": ["methods_section_detected", "condition_markers_detected"],
+            "parsing_warnings": [],
+            "confidence": 0.91,
+        }
     )
 
+    assert profile.document_id == "doc-exp"
+    assert profile.title == "Composite Processing Study"
+    assert profile.source_filename == "paper.txt"
     assert profile.doc_type == DOC_TYPE_EXPERIMENTAL
     assert profile.protocol_extractable == PROTOCOL_EXTRACTABLE_YES
-    assert "methods_section_detected" in profile.protocol_extractability_signals
-    assert "characterization_section_detected" in profile.protocol_extractability_signals
-    assert "procedural_actions_detected" in profile.protocol_extractability_signals
-    assert "condition_markers_detected" in profile.protocol_extractability_signals
-
-
-def test_analyze_document_profile_classifies_review_document() -> None:
-    profile = analyze_document_profile(
-        collection_id="col-1",
-        document_id="doc-review",
-        title="A Review of Conductive Ceramic Fillers",
-        source_filename=None,
-        analysis_title="A Review of Conductive Ceramic Fillers",
-        text=(
-            "This review summarizes recent advances in conductive ceramic fillers "
-            "and discusses the state of the art across epoxy systems."
-        ),
-        sections=[],
+    assert profile.protocol_extractability_signals == (
+        "methods_section_detected",
+        "condition_markers_detected",
     )
-
-    assert profile.doc_type == DOC_TYPE_REVIEW
-    assert profile.protocol_extractable == PROTOCOL_EXTRACTABLE_NO
-    assert "review_title_detected" in profile.protocol_extractability_signals
-    assert "review_language_detected" in profile.protocol_extractability_signals
-    assert "missing_methods_section" in profile.parsing_warnings
-
-
-def test_analyze_document_profile_classifies_mixed_document() -> None:
-    profile = analyze_document_profile(
-        collection_id="col-1",
-        document_id="doc-mixed",
-        title="Review and Experimental Notes on Coatings",
-        source_filename=None,
-        analysis_title="Review and Experimental Notes on Coatings",
-        text=(
-            "This review also reports a validation study.\n"
-            "Experimental Section\n"
-            "Solutions were mixed and heated at 90 C for 4 h.\n"
-            "Characterization\n"
-            "SEM was used to inspect the coating."
-        ),
-        sections=[
-            {
-                "section_type": "methods",
-                "text": "Solutions were mixed and heated at 90 C for 4 h.",
-            },
-            {
-                "section_type": "characterization",
-                "text": "SEM was used to inspect the coating.",
-            },
-        ],
-    )
-
-    assert profile.doc_type == DOC_TYPE_MIXED
-    assert profile.protocol_extractable == PROTOCOL_EXTRACTABLE_PARTIAL
-    assert "review_contamination_detected" in profile.parsing_warnings
 
 
 def test_summarize_document_profile_collection_emits_collection_warnings() -> None:
-    review_profile = analyze_document_profile(
-        collection_id="col-1",
-        document_id="doc-review",
-        title="A Review of Cathode Stability",
-        source_filename=None,
-        analysis_title="A Review of Cathode Stability",
-        text="This review summarizes recent advances in cycle stability studies.",
-        sections=[],
+    review_profile = DocumentProfile.from_mapping(
+        {
+            "document_id": "doc-review",
+            "collection_id": "col-1",
+            "doc_type": DOC_TYPE_REVIEW,
+            "protocol_extractable": PROTOCOL_EXTRACTABLE_NO,
+        }
     )
-    uncertain_profile = analyze_document_profile(
-        collection_id="col-1",
-        document_id="doc-uncertain",
-        title="Cathode Stability Note",
-        source_filename=None,
-        analysis_title="Cathode Stability Note",
-        text="A short note about cathode stability trends.",
-        sections=[],
+    uncertain_profile = DocumentProfile.from_mapping(
+        {
+            "document_id": "doc-uncertain",
+            "collection_id": "col-1",
+            "doc_type": DOC_TYPE_UNCERTAIN,
+            "protocol_extractable": PROTOCOL_EXTRACTABLE_UNCERTAIN,
+        }
     )
 
     summary = summarize_document_profile_collection([review_profile, uncertain_profile])

--- a/backend/tests/unit/services/test_core_semantic_version.py
+++ b/backend/tests/unit/services/test_core_semantic_version.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+
+from application.core.core_semantic_version import (
+    CURRENT_CORE_SEMANTIC_VERSION,
+    core_semantic_rebuild_required,
+    write_core_semantic_manifest,
+)
+
+
+def test_core_semantic_version_requires_rebuild_when_structural_inputs_exist_without_manifest(
+    tmp_path,
+) -> None:
+    output_dir = tmp_path / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "documents.parquet").write_text("placeholder", encoding="utf-8")
+    (output_dir / "sections.parquet").write_text("placeholder", encoding="utf-8")
+
+    assert core_semantic_rebuild_required(output_dir) is True
+
+
+def test_core_semantic_version_is_current_after_manifest_write(tmp_path) -> None:
+    output_dir = tmp_path / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "documents.parquet").write_text("placeholder", encoding="utf-8")
+
+    write_core_semantic_manifest(output_dir)
+
+    manifest = json.loads((output_dir / "core_semantic_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == CURRENT_CORE_SEMANTIC_VERSION
+    assert core_semantic_rebuild_required(output_dir) is False

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -4701,7 +4701,7 @@ wheels = [
 
 [[package]]
 name = "tsingai-lens"
-version = "0.3.1"
+version = "0.3.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -1,6 +1,6 @@
 services:
   backend:
-    image: ${LENS_BACKEND_IMAGE:-jeanphilo/tsingai-lens-backend}:${LENS_VERSION:-v0.3.1}
+    image: ${LENS_BACKEND_IMAGE:-jeanphilo/tsingai-lens-backend}:${LENS_VERSION:-v0.3.3}
     env_file:
       - ./backend/.env
     volumes:
@@ -10,7 +10,7 @@ services:
     restart: unless-stopped
 
   frontend:
-    image: ${LENS_FRONTEND_IMAGE:-jeanphilo/tsingai-lens-frontend}:${LENS_VERSION:-v0.3.1}
+    image: ${LENS_FRONTEND_IMAGE:-jeanphilo/tsingai-lens-frontend}:${LENS_VERSION:-v0.3.3}
     ports:
       - "${LENS_HTTP_PORT:-8080}:80"
     depends_on:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "0.3.1",
+	"version": "0.3.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "0.3.1",
+			"version": "0.3.3",
 			"dependencies": {
 				"cytoscape": "^3.33.2",
 				"cytoscape-fcose": "^2.2.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.3.1",
+	"version": "0.3.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## Summary
- promote the current `develop` branch to `main`
- hard-cut Core semantic extraction from heuristic profile/evidence guessing to backend-owned LLM structured extraction with a `llm_v1` semantic manifest
- rebuild stale Core semantic artifacts when structural inputs exist but the semantic manifest is missing or outdated
- record the Core LLM structured extraction cutover plan in the Core docs path
- align backend, frontend, and release image defaults on `0.3.3`

## Testing
- `./.venv/bin/pytest -q tests/unit/services/test_core_semantic_version.py tests/unit/domains/test_document_profile_domain.py`
- `pytest backend/tests/unit/domains/test_document_profile_domain.py backend/tests/unit/services/test_document_profile_service.py backend/tests/unit/services/test_evidence_backbone_services.py backend/tests/unit/services/test_core_semantic_version.py backend/tests/integration/services/test_task_runner.py -q`
- `pytest backend/tests/unit/services/test_graph_core_projection.py backend/tests/unit/services/test_core_report_service.py -q`
- `pytest backend/tests/unit/routers/test_documents_api.py backend/tests/unit/routers/test_evidence_api.py backend/tests/unit/routers/test_comparisons_api.py -q` (3 skipped: `fastapi` not installed)
- `python3 scripts/check_docs_governance.py`
