### PR TITLE
release: promote develop to main for v0.4.0

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -34,7 +34,7 @@ def _parse_cors_allowed_origins() -> list[str]:
 def create_app() -> FastAPI:
     app = FastAPI(
         title="TsingAI-Lens API",
-        version="0.3.4",
+        version="0.4.0",
         docs_url=f"{PUBLIC_API_PREFIX}/docs",
         redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
         openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsingai-lens"
-version = "0.3.4"
+version = "0.4.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -1,6 +1,6 @@
 services:
   backend:
-    image: ${LENS_BACKEND_IMAGE:-jeanphilo/tsingai-lens-backend}:${LENS_VERSION:-v0.3.4}
+    image: ${LENS_BACKEND_IMAGE:-jeanphilo/tsingai-lens-backend}:${LENS_VERSION:-v0.4.0}
     env_file:
       - ./backend/.env
     volumes:
@@ -10,7 +10,7 @@ services:
     restart: unless-stopped
 
   frontend:
-    image: ${LENS_FRONTEND_IMAGE:-jeanphilo/tsingai-lens-frontend}:${LENS_VERSION:-v0.3.4}
+    image: ${LENS_FRONTEND_IMAGE:-jeanphilo/tsingai-lens-frontend}:${LENS_VERSION:-v0.4.0}
     ports:
       - "${LENS_HTTP_PORT:-8080}:80"
     depends_on:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.3.4",
+	"version": "0.4.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## Summary
- promote the current `develop` branch to `main` for `v0.4.0`
- align backend package version, FastAPI app version, frontend package version, and release compose defaults on `0.4.0`
- roll the unpublished `v0.3.4` tag state forward into the hosted `v0.4.0` release

## Testing
- `git diff --check`
- `rg -n 'version = "0\.4\.0"|version="0\.4\.0"|"version": "0\.4\.0"|LENS_VERSION:-v0\.4\.0' backend/pyproject.toml backend/main.py frontend/package.json docker-compose.release.yml`
