### PR TITLE
docs(contracts): align evidence chain documentation

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -59,7 +59,7 @@ Operations:
   Backend plan-family landing page for active waves and retained lineage
 
 If you are already inside an active backend change wave, use
-[`docs/plans/backend-wide/current-api-surface-migration-checklist.md`](docs/plans/backend-wide/current-api-surface-migration-checklist.md)
+[`docs/plans/backend-wide/api-surface-migration/current-state.md`](docs/plans/backend-wide/api-surface-migration/current-state.md)
 as the current-state page, then choose the owning plan family from
 [`docs/plans/README.md`](docs/plans/README.md) rather than starting from a
 flat file list.
@@ -83,6 +83,7 @@ uv sync
 export LLM_BASE_URL=http://localhost:11434/v1
 export LLM_MODEL=qwen1.5-8b-chat
 export LLM_API_KEY=sk-local
+export CORE_EXTRACTION_MAX_CONCURRENCY=4
 
 uvicorn main:app --reload --port 8010
 ```
@@ -99,6 +100,8 @@ uvicorn main:app --reload --port 8010
   frontend integration.
 - Run backend tests with `uv run pytest` or `./.venv/bin/python -m pytest` so
   the backend-local FastAPI/test dependencies are available during verification.
+- `CORE_EXTRACTION_MAX_CONCURRENCY` is an optional Core extraction tuning knob;
+  when unset, the backend uses `4`.
 - The active backend cleanup direction is to keep the
   `goal / source / core / derived` split explicit in `controllers/`,
   `application/`, and `infra/`, keep Source runtime under `infra/source/*`,

--- a/backend/application/README.md
+++ b/backend/application/README.md
@@ -33,7 +33,7 @@ Inside it, business responsibilities are now grouped as:
 
 - [`docs/application-layer-one-shot-cutover-plan.md`](docs/application-layer-one-shot-cutover-plan.md)
   Historical application cutover background
-- [`../docs/plans/goal-source-core-business-layer-alignment-plan.md`](../docs/plans/backend-wide/goal-source-core-business-layer-alignment-plan.md)
+- [`../docs/plans/goal-source-core-business-layer-alignment-plan.md`](../docs/plans/backend-wide/goal-source-core-layering/proposal.md)
   Active backend-wide package-alignment plan for Goal, Source, Core, and
   Derived
 

--- a/backend/application/core/semantic_build/README.md
+++ b/backend/application/core/semantic_build/README.md
@@ -11,5 +11,6 @@ artifacts.
   conditions, baselines, and measurement results
 - `core_semantic_version.py`
   manifest-based invalidation for Core semantic artifacts
-- `llm/`
-  Core-owned prompt, schema, and extraction orchestration contracts
+- [`llm/README.md`](llm/README.md)
+  Core-owned prompt, schema, extractor, and structured-extraction plan
+  contracts

--- a/backend/application/core/semantic_build/llm/README.md
+++ b/backend/application/core/semantic_build/llm/README.md
@@ -1,0 +1,28 @@
+# Core Semantic Build LLM
+
+This package owns the Core-side LLM contract for semantic build.
+
+It defines the prompt text, structured schemas, and extractor orchestration
+used to turn Source structural artifacts into Core semantic extraction inputs
+for `document_profiles` and `paper_facts`.
+
+It does not own:
+
+- Source structural artifact production
+- Core artifact materialization, deduplication, or persistence
+- downstream comparison, report, graph, or protocol projection
+
+## Local Components
+
+- `prompts.py`
+  prompt builders for document-profile, text-window, and table-row extraction
+- `schemas.py`
+  structured response models for the Core extraction contract
+- `extractor.py`
+  provider call orchestration and response parsing for the Core extraction path
+
+## Local Docs
+
+- [`docs/structured-extraction/README.md`](docs/structured-extraction/README.md)
+  live plan family for the structured-extraction cutover, boundary cleanup,
+  and prompt-hardening work under this package

--- a/backend/application/core/semantic_build/llm/docs/structured-extraction/README.md
+++ b/backend/application/core/semantic_build/llm/docs/structured-extraction/README.md
@@ -1,0 +1,33 @@
+# Core LLM Structured Extraction
+
+This topic family keeps the live LLM-specific plan lineage for the Core
+semantic-build extraction contract under
+`application/core/semantic_build/llm/`.
+
+These pages are node-local because they describe the owned prompt, schema, and
+extractor boundary for this package, not a repo-wide planning bucket.
+
+## Start Here
+
+- [`../../README.md`](../../README.md)
+  Node entry for package ownership and local file responsibilities
+
+## Reading Order
+
+- [`hard-cutover.md`](hard-cutover.md)
+  Primary cutover plan for replacing heuristic Core extraction with
+  schema-bound LLM structured extraction
+- [`id-boundary.md`](id-boundary.md)
+  Boundary-cleanup plan for removing backend and Source identifiers from the
+  model-facing contract
+- [`prompt-hardening-and-extraction-mode.md`](prompt-hardening-and-extraction-mode.md)
+  Production prompt-hardening and temporary extraction-mode comparison plan
+
+## Related Docs
+
+- [`../../../../../../docs/plans/core/core-parsing-quality-hardening-plan.md`](../../../../../../docs/plans/core/core-parsing-quality-hardening-plan.md)
+  Parent Core quality wave
+- [`../../../../../../docs/plans/core/core-text-window-atomic-mentions-plan.md`](../../../../../../docs/plans/core/core-text-window-atomic-mentions-plan.md)
+  Later text-window narrowing plan that extends this family
+- [`../../../../../../docs/plans/core/core-benchmark-script-consolidation-plan.md`](../../../../../../docs/plans/core/core-benchmark-script-consolidation-plan.md)
+  Canonical benchmark surface used to evaluate this extraction contract

--- a/backend/application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md
+++ b/backend/application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md
@@ -13,7 +13,7 @@ It is a Core child plan inside the corrected Lens v1 Core flow:
 
 Read this plan with the accepted paper-facts RFC:
 
-- [`../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md`](../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md)
+- [`../../../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md`](../../../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md)
 
 The purpose of this cutover is straightforward:
 
@@ -24,12 +24,12 @@ The purpose of this cutover is straightforward:
   artifacts
 
 For the broader backend roadmap, read
-[`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md).
+[`../../../../../../docs/plans/backend-wide/goal-source-core-layering/implementation-plan.md`](../../../../../../docs/plans/backend-wide/goal-source-core-layering/implementation-plan.md).
 For the immediate parent quality wave, read
-[`core-parsing-quality-hardening-plan.md`](core-parsing-quality-hardening-plan.md).
+[`../../../../../../docs/plans/core/core-parsing-quality-hardening-plan.md`](../../../../../../docs/plans/core/core-parsing-quality-hardening-plan.md).
 For the layering rule that keeps stable research facts in Core rather than in
 Source, read
-[`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md).
+[`../../../../../../docs/architecture/goal-core-source-layering.md`](../../../../../../docs/architecture/goal-core-source-layering.md).
 
 ## Why This Child Plan Exists
 
@@ -199,7 +199,7 @@ derived-view projection slice above it.
 ### Slice 1: Document Profile Extraction
 
 The current narrowed execution plan for this slice is recorded in
-[`document-profile-lightweight-triage-plan.md`](document-profile-lightweight-triage-plan.md).
+[`../../../../../../docs/plans/core/document-profile-lightweight-triage-plan.md`](../../../../../../docs/plans/core/document-profile-lightweight-triage-plan.md).
 
 Input:
 
@@ -456,18 +456,18 @@ Guardrails:
 
 ### Parent Docs
 
-- [`core-parsing-quality-hardening-plan.md`](core-parsing-quality-hardening-plan.md)
+- [`../../../../../../docs/plans/core/core-parsing-quality-hardening-plan.md`](../../../../../../docs/plans/core/core-parsing-quality-hardening-plan.md)
   is the immediate parent execution plan. This page is the detailed child plan
   for the hard cutover decision inside that quality wave.
-- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md)
+- [`../../../../../../docs/plans/backend-wide/goal-source-core-layering/implementation-plan.md`](../../../../../../docs/plans/backend-wide/goal-source-core-layering/implementation-plan.md)
   remains the broader backend roadmap.
 
 ### Companion Docs
 
-- [`minimal-core-domain-backfill-plan.md`](minimal-core-domain-backfill-plan.md)
+- [`../../../../../../docs/plans/core/minimal-core-domain-backfill-plan.md`](../../../../../../docs/plans/core/minimal-core-domain-backfill-plan.md)
   remains the companion plan for moving stable Core semantics into explicit
   domain ownership.
-- [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
+- [`../../../../../../docs/architecture/goal-core-source-layering.md`](../../../../../../docs/architecture/goal-core-source-layering.md)
   remains the boundary authority for keeping stable research facts in Core.
 
 ### Later Follow-Up Scope
@@ -478,8 +478,8 @@ than expanding this page into an open-ended parser program.
 
 ## Related Docs
 
-- [`core-parsing-quality-hardening-plan.md`](core-parsing-quality-hardening-plan.md)
-- [`core-llm-structured-extraction-id-boundary-plan.md`](core-llm-structured-extraction-id-boundary-plan.md)
-- [`minimal-core-domain-backfill-plan.md`](minimal-core-domain-backfill-plan.md)
-- [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
-- [`../backend-wide/goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md)
+- [`../../../../../../docs/plans/core/core-parsing-quality-hardening-plan.md`](../../../../../../docs/plans/core/core-parsing-quality-hardening-plan.md)
+- [`id-boundary.md`](id-boundary.md)
+- [`../../../../../../docs/plans/core/minimal-core-domain-backfill-plan.md`](../../../../../../docs/plans/core/minimal-core-domain-backfill-plan.md)
+- [`../../../../../../docs/architecture/goal-core-source-layering.md`](../../../../../../docs/architecture/goal-core-source-layering.md)
+- [`../../../../../../docs/plans/backend-wide/goal-source-core-layering/implementation-plan.md`](../../../../../../docs/plans/backend-wide/goal-source-core-layering/implementation-plan.md)

--- a/backend/application/core/semantic_build/llm/docs/structured-extraction/id-boundary.md
+++ b/backend/application/core/semantic_build/llm/docs/structured-extraction/id-boundary.md
@@ -17,8 +17,8 @@ latency fix from prompt cleanup alone. The target is narrower:
 This plan sits under the existing Core structured-extraction cutover wave and
 works with the new semantic-build package boundary:
 
-- [`core-llm-structured-extraction-hard-cutover-plan.md`](core-llm-structured-extraction-hard-cutover-plan.md)
-- [`core-semantic-build-packaging-alignment-plan.md`](core-semantic-build-packaging-alignment-plan.md)
+- [`hard-cutover.md`](hard-cutover.md)
+- [`../../../../../../docs/plans/core/core-semantic-build-packaging-alignment-plan.md`](../../../../../../docs/plans/core/core-semantic-build-packaging-alignment-plan.md)
 
 ## Why This Child Plan Exists
 
@@ -323,6 +323,6 @@ Suggested verification commands:
 
 ## Related Docs
 
-- [`core-llm-structured-extraction-hard-cutover-plan.md`](core-llm-structured-extraction-hard-cutover-plan.md)
-- [`core-semantic-build-packaging-alignment-plan.md`](core-semantic-build-packaging-alignment-plan.md)
-- [`../../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
+- [`hard-cutover.md`](hard-cutover.md)
+- [`../../../../../../docs/plans/core/core-semantic-build-packaging-alignment-plan.md`](../../../../../../docs/plans/core/core-semantic-build-packaging-alignment-plan.md)
+- [`../../../../../../docs/architecture/goal-core-source-layering.md`](../../../../../../docs/architecture/goal-core-source-layering.md)

--- a/backend/application/core/semantic_build/llm/docs/structured-extraction/prompt-hardening-and-extraction-mode.md
+++ b/backend/application/core/semantic_build/llm/docs/structured-extraction/prompt-hardening-and-extraction-mode.md
@@ -1,0 +1,273 @@
+# Core LLM Prompt Hardening And Extraction Mode Plan
+
+## Summary
+
+This document records a focused Core child implementation plan for stabilizing
+production LLM extraction after the benchmark-script cutover.
+
+The immediate target is narrow:
+
+- move the benchmark-proven JSON compliance guidance into the production Core
+  extraction prompts
+- keep one Core extractor while allowing one temporary provider-mode switch
+  between text JSON validation and provider-native structured parsing
+- measure both modes through the same prompt, payload, and schema path before
+  making a permanent cutover decision
+
+This is a Core child plan under the active parsing-quality wave. It does not
+introduce a new runtime layer and it does not justify two parallel extractor
+implementations.
+
+For the parent quality wave, read
+[`../../../../../../docs/plans/core/core-parsing-quality-hardening-plan.md`](../../../../../../docs/plans/core/core-parsing-quality-hardening-plan.md).
+For the earlier structured-extraction cutover direction, read
+[`hard-cutover.md`](hard-cutover.md).
+For the canonical benchmark surface used to justify this wave, read
+[`../../../../../../docs/plans/core/core-benchmark-script-consolidation-plan.md`](../../../../../../docs/plans/core/core-benchmark-script-consolidation-plan.md).
+
+## Why This Child Plan Exists
+
+The new benchmark surface made one production problem explicit:
+
+the current provider is reachable and fast enough for single-call work, but the
+production prompt and response contract still allow too many schema-invalid
+outputs to reach local `model_validate_json(...)` validation on the text-window
+`StructuredTextWindowMentions` contract or the table-row
+`StructuredExtractionBundle` contract.
+
+The benchmark evidence collected on April 24, 2026 showed:
+
+- provider connectivity stayed normal at sub-second latency
+- the same text-window payload returned in about 8.66 seconds in plain
+  `raw_text` mode
+- the same payload returned in about 43.64 seconds in
+  `provider_structured_parse` mode
+- the original `raw_text_plus_validate` benchmark failed on schema-invalid
+  shapes such as:
+  - list fields returned as `null`
+  - required nested objects returned as `null`
+  - extra top-level keys such as `keywords`
+  - misplaced `unit` fields inside `value_payload`
+
+After adding explicit JSON compliance rules and positive and negative examples
+to the benchmark prompt, the same sample text window improved materially:
+
+- `raw_text_plus_validate` passed in about 6.69 seconds
+- `provider_structured_parse` still passed in about 39.26 seconds
+
+That result is strong enough to justify a production child wave focused on
+prompt hardening first, with a tightly bounded temporary mode switch for
+measuring the production tradeoff.
+
+## Decision
+
+Production Core extraction should keep one extractor implementation and one
+shared prompt path, but allow one temporary extraction-mode switch through an
+environment variable.
+
+The mode switch should be narrow:
+
+- one extractor class
+- one prompt builder family
+- one payload shape
+- one response schema
+- one branch point inside the Core extractor response path
+
+The temporary mode values should be:
+
+- `json_text`
+- `provider_parse`
+
+The default should remain `json_text` until production collection benchmarks
+show that `provider_parse` is worth the latency cost.
+
+This plan explicitly rejects:
+
+- a second extractor service or client layer
+- separate prompt families for different modes
+- compatibility wrappers around the current Core extractor
+- silently relaxing the production schema just to accept bad shapes
+
+## Scope
+
+This child plan covers:
+
+- production prompt hardening for text-window and table-row extraction
+- one environment-variable switch for the two extraction modes
+- targeted extractor logging so mode-specific failures are attributable
+- unit tests for the production prompt and extractor mode branch
+- production benchmark reruns against one real collection after the change
+
+This child plan does not cover:
+
+- changing the public API
+- changing Source structural artifacts
+- adding a second production extraction service
+- committing to provider-native structured parsing as the permanent default
+- broad schema redesign
+
+## Proposed Change
+
+### Shared Prompt Hardening
+
+Move the benchmark-proven JSON compliance guidance into
+`application/core/semantic_build/llm/prompts.py` for:
+
+- `build_text_window_extraction_prompt(...)`
+- `build_table_row_extraction_prompt(...)`
+
+The production prompt guidance should explicitly state:
+
+- output must use exactly the schema keys and no extras
+- array fields must stay arrays and use `[]` when empty
+- required nested objects must stay objects and must not be `null`
+- `unit` belongs at `measurement_results[*].unit`
+- uncertainty should resolve to empty arrays and null scalar leaves, not to
+  invalid object shapes
+
+The production prompt should also include:
+
+- one short valid example
+- two or three short invalid counterexamples that mirror the real observed
+  failure patterns
+
+### One Extractor, Two Temporary Modes
+
+Keep `CoreLLMStructuredExtractor` as the single production extractor in
+`application/core/semantic_build/llm/extractor.py`.
+
+Add one environment variable:
+
+- `CORE_LLM_EXTRACTION_MODE`
+
+Supported values:
+
+- `json_text`
+  - call `chat.completions.create(...)`
+  - coerce message content into text
+  - extract the JSON object
+  - validate locally with `model_validate_json(...)`
+- `provider_parse`
+  - call `beta.chat.completions.parse(...)`
+  - parse against the same response model
+  - keep the same prompt, payload, and schema contract
+
+The branch should live only inside the internal response-parsing path. Callers
+such as `extract_text_window_mentions(...)` and
+`extract_table_row_bundle(...)` should stay unchanged.
+
+### Mode Invariants
+
+The two temporary modes are valid only if they share the same:
+
+- system prompt
+- user prompt
+- payload
+- response model
+- model name
+- temperature
+
+This plan should not allow mode-specific prompt drift.
+
+### Logging And Attribution
+
+The production extractor should log enough detail to compare the modes on real
+collections:
+
+- extraction mode
+- model name
+- response model
+- elapsed seconds
+- validation failure marker
+
+That logging should stay at the extractor seam rather than being duplicated in
+multiple callers.
+
+## Execution Order
+
+1. Move the JSON compliance guidance into production prompt builders.
+2. Add the mode switch to the Core extractor with `json_text` as the default.
+3. Add targeted unit coverage for the prompt content and extractor mode
+   selection.
+4. Rerun the canonical text-window benchmarks against both modes.
+5. Rerun the collection benchmark against one real collection with both modes.
+6. Decide whether prompt hardening alone is sufficient or whether one smaller
+   follow-on sanitation wave is still needed.
+
+## File Change Plan
+
+### Primary Code Areas
+
+- `application/core/semantic_build/llm/prompts.py`
+- `application/core/semantic_build/llm/extractor.py`
+
+### Primary Test Areas
+
+- `tests/unit/services/test_core_llm_extractor.py`
+- one new prompt-focused test file if that keeps prompt assertions clearer than
+  extending the extractor test file
+
+### Possible Companion Updates
+
+- `.env.example` if the new environment variable is adopted
+- `docs/runbooks/backend-ops.md` if the mode switch becomes an operator-facing
+  runtime control
+
+## Verification
+
+### Focused Verification
+
+Run at least:
+
+```bash
+cd backend
+python3 -m py_compile application/core/semantic_build/llm/prompts.py application/core/semantic_build/llm/extractor.py
+uv run pytest tests/unit/services/test_core_llm_extractor.py
+python3 scripts/benchmarks/text_window_probe.py --mode raw_text_plus_validate --repeat 3
+python3 scripts/benchmarks/text_window_probe.py --mode provider_structured_parse --repeat 3
+```
+
+### Collection Verification
+
+Run the same real collection under both modes:
+
+```bash
+cd backend
+CORE_LLM_EXTRACTION_MODE=json_text uv run python scripts/benchmarks/paper_facts_collection_benchmark.py --collection-id <collection_id>
+CORE_LLM_EXTRACTION_MODE=provider_parse uv run python scripts/benchmarks/paper_facts_collection_benchmark.py --collection-id <collection_id>
+```
+
+Compare:
+
+- success versus failure rate
+- per-unit timing
+- whole-collection timing
+- failure taxonomy
+
+## Deferred Fallback
+
+If prompt hardening alone still leaves frequent schema-invalid responses on the
+collection benchmark, the follow-on wave should be a very thin deterministic
+sanitizer before local validation.
+
+That fallback should remain bounded to mechanical repair only:
+
+- `null` list fields to `[]`
+- `null` required objects to empty default objects
+- removal of known extra top-level fields
+- relocation of misplaced `value_payload.unit` to outer `unit`
+
+That sanitizer should be recorded and delivered as a separate wave so prompt
+hardening and deterministic repair are measured independently.
+
+## Exit Criteria
+
+This child plan is done only when:
+
+- production prompt builders include the JSON compliance guidance
+- `CORE_LLM_EXTRACTION_MODE` switches the production extractor between the two
+  temporary paths without changing callers
+- the default mode remains explicit and documented
+- production benchmark reruns can compare the two modes on the same collection
+- the backend has enough evidence to decide whether the dual-mode period
+  should continue or be closed

--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -31,7 +31,7 @@ authority page, current-state page, or implementation lineage.
 - Backend plan-family landing page:
   [`plans/README.md`](plans/README.md)
 - Current backend migration and execution state:
-  [`plans/backend-wide/current-api-surface-migration-checklist.md`](plans/backend-wide/current-api-surface-migration-checklist.md)
+  [`plans/backend-wide/api-surface-migration/current-state.md`](plans/backend-wide/api-surface-migration/current-state.md)
 
 ## Backend-Wide Authority
 
@@ -57,7 +57,7 @@ Start with:
 
 - [`plans/README.md`](plans/README.md)
   Backend-local plans landing page, reading paths, and placement rules
-- [`plans/backend-wide/current-api-surface-migration-checklist.md`](plans/backend-wide/current-api-surface-migration-checklist.md)
+- [`plans/backend-wide/api-surface-migration/current-state.md`](plans/backend-wide/api-surface-migration/current-state.md)
   Canonical current-state page for backend API migration and local reading
   order
 

--- a/backend/docs/architecture/core-comparison/current-state.md
+++ b/backend/docs/architecture/core-comparison/current-state.md
@@ -107,4 +107,4 @@ reading path.
 - [`decision.md`](decision.md)
 - [`../../specs/api.md`](../../specs/api.md)
 - [`../overview.md`](../overview.md)
-- [`../../plans/backend-wide/current-api-surface-migration-checklist.md`](../../plans/backend-wide/current-api-surface-migration-checklist.md)
+- [`../../plans/backend-wide/api-surface-migration/current-state.md`](../../plans/backend-wide/api-surface-migration/current-state.md)

--- a/backend/docs/architecture/goal-core-source-layering.md
+++ b/backend/docs/architecture/goal-core-source-layering.md
@@ -199,7 +199,7 @@ Readiness semantics remain Core-owned:
 
 The active child execution plan for this freeze is:
 
-- [`../plans/goal-core-source-contract-follow-up-plan.md`](../plans/backend-wide/goal-core-source-contract-follow-up-plan.md)
+- [`../plans/goal-core-source-contract-follow-up-plan.md`](../plans/backend-wide/goal-source-core-layering/contract-follow-up.md)
 
 ## Current Backend Mapping
 
@@ -288,8 +288,8 @@ Controller implications:
 
 ## Related Docs
 
-- [`../plans/goal-core-source-implementation-plan.md`](../plans/backend-wide/goal-core-source-implementation-plan.md)
-- [`../plans/goal-core-source-contract-follow-up-plan.md`](../plans/backend-wide/goal-core-source-contract-follow-up-plan.md)
+- [`../plans/goal-core-source-implementation-plan.md`](../plans/backend-wide/goal-source-core-layering/implementation-plan.md)
+- [`../plans/goal-core-source-contract-follow-up-plan.md`](../plans/backend-wide/goal-source-core-layering/contract-follow-up.md)
 - [`overview.md`](overview.md)
 - [`domain-architecture.md`](domain-architecture.md)
 - [`core-comparison/README.md`](core-comparison/README.md)

--- a/backend/docs/architecture/overview.md
+++ b/backend/docs/architecture/overview.md
@@ -115,7 +115,7 @@ larger flat service bag.
 For active backend migration state, implementation sequencing, or retained plan
 lineage, go back to [`../README.md`](../README.md), then use
 [`../plans/README.md`](../plans/README.md) and start from
-[`../plans/backend-wide/current-api-surface-migration-checklist.md`](../plans/backend-wide/current-api-surface-migration-checklist.md)
+[`../plans/backend-wide/api-surface-migration/current-state.md`](../plans/backend-wide/api-surface-migration/current-state.md)
 rather than treating this architecture page as a flat plan index.
 
 For the current comparison-semantic center and comparable-result substrate, use

--- a/backend/docs/plans/README.md
+++ b/backend/docs/plans/README.md
@@ -7,10 +7,14 @@ Use [../README.md](../README.md) for the backend formal-doc landing page.
 Use this subtree only when you are already inside backend change work and need
 wave sequencing, execution lineage, or a business-layer-local plan family.
 
+Shared frontend/backend authority does not live here. Keep shared product
+meaning, cross-module contract freeze work, and repository-level delivery
+order in root `docs/`.
+
 ## Plan Families
 
 - [`backend-wide/README.md`](backend-wide/README.md)
-  Cross-layer plans, current-state checkpoints, and backend-wide contract or
+  Cross-layer topic families, current-state checkpoints, and backend-wide
   rollout waves
 - [`source/README.md`](source/README.md)
   Collection construction, Source runtime, parser, and Source-retirement waves
@@ -23,17 +27,20 @@ wave sequencing, execution lineage, or a business-layer-local plan family.
 
 ## Start Here
 
-- [`backend-wide/current-api-surface-migration-checklist.md`](backend-wide/current-api-surface-migration-checklist.md)
+- [`backend-wide/api-surface-migration/current-state.md`](backend-wide/api-surface-migration/current-state.md)
   Canonical backend current-state entry point
-- [`backend-wide/goal-source-core-business-layer-alignment-plan.md`](backend-wide/goal-source-core-business-layer-alignment-plan.md)
-  Current package-alignment authority for the `goal / source / core / derived`
-  business-layer split
+- [`backend-wide/goal-source-core-layering/README.md`](backend-wide/goal-source-core-layering/README.md)
+  Topic-family entry for the `goal / source / core / derived` layering wave
+- [`backend-wide/evidence-chain-product-surface/README.md`](backend-wide/evidence-chain-product-surface/README.md)
+  Backend-owned implementation family for the evidence-chain product surface
 
 ## Reading Paths By Intent
 
 - Backend-wide migration state:
-  start at [`backend-wide/current-api-surface-migration-checklist.md`](backend-wide/current-api-surface-migration-checklist.md),
+  start at [`backend-wide/api-surface-migration/current-state.md`](backend-wide/api-surface-migration/current-state.md),
   then move to [`backend-wide/README.md`](backend-wide/README.md)
+- Backend-wide evidence-chain delivery:
+  start at [`backend-wide/evidence-chain-product-surface/README.md`](backend-wide/evidence-chain-product-surface/README.md)
 - Source runtime and parser work:
   start at [`source/README.md`](source/README.md)
 - Core quality, traceback, and domain semantics:
@@ -48,6 +55,9 @@ wave sequencing, execution lineage, or a business-layer-local plan family.
 - Put a plan in the lowest backend-local family that fully owns the wave.
 - Use `backend-wide/` only when the wave spans multiple business layers or
   freezes backend-wide contracts.
+- Inside `backend-wide/`, prefer one topic directory per subject and let child
+  filenames express role, such as `proposal.md`, `current-state.md`, or
+  `implementation-plan.md`.
 - Use `historical/` only for pages that are intentionally retained lineage and
   are no longer the current execution entry point.
 - Keep stable contracts in `../specs/`, stable architecture in

--- a/backend/docs/plans/backend-wide/README.md
+++ b/backend/docs/plans/backend-wide/README.md
@@ -1,39 +1,55 @@
 # Backend-Wide Plans
 
-This family owns backend plans whose lowest common ancestor is the backend
-module itself rather than one business layer.
+This family owns backend-local plan topics whose lowest common ancestor is the
+backend module itself rather than `source/`, `core/`, or `derived/`.
 
-Use this family for:
+Use this family when the work is still backend-owned but spans multiple
+business layers, records backend-wide current state, or coordinates one
+backend-local rollout wave across several seams.
 
-- current-state checkpoints
-- cross-layer contract freeze work
-- package-alignment waves
-- backend-wide closure waves
-- product-surface or contract cleanup that spans Source, Core, and Derived
+Shared frontend/backend authority does not belong here. Put cross-module
+product meaning, shared contract freeze work, and repository-level delivery
+order in root `docs/`.
 
-## Reading Order
+## Topic Families
 
-- [`current-api-surface-migration-checklist.md`](current-api-surface-migration-checklist.md)
-  Canonical current-state entry
-- [`goal-source-core-business-layer-alignment-plan.md`](goal-source-core-business-layer-alignment-plan.md)
-  Current code-tree alignment plan for `goal / source / core / derived`
-- [`goal-core-source-implementation-plan.md`](goal-core-source-implementation-plan.md)
-  Parent five-layer rollout roadmap
-- [`goal-core-source-contract-follow-up-plan.md`](goal-core-source-contract-follow-up-plan.md)
-  Contract-freeze follow-up across the five-layer model
-- [`materials-comparison-v2-plan.md`](materials-comparison-v2-plan.md)
-  Backend-wide contract and closure page for the materials comparison backbone
-- [`core-first-product-surface-cutover-plan.md`](core-first-product-surface-cutover-plan.md)
-  Backend-wide closure page for the Core-first graph/report/product-surface cut
-- [`frontend-facing-contract-cleanup-plan.md`](frontend-facing-contract-cleanup-plan.md)
-  Backend-wide frontend-contract cleanup lineage
-- [`index-to-build-contract-cutover-plan.md`](index-to-build-contract-cutover-plan.md)
-  Coordinated backend/frontend hard-cut plan for renaming collection
-  processing from `index` to `build`
-- [`backend-request-id-and-extraction-observability-plan.md`](backend-request-id-and-extraction-observability-plan.md)
-  Backend-wide request correlation and Core extraction diagnostics plan
+- [`api-surface-migration/README.md`](api-surface-migration/README.md)
+  Backend-local API migration current-state family
+- [`goal-source-core-layering/README.md`](goal-source-core-layering/README.md)
+  Proposal, rollout, and contract follow-up family for explicit
+  `goal / source / core / derived` layering
+- [`evidence-chain-product-surface/README.md`](evidence-chain-product-surface/README.md)
+  Backend implementation family for dossier, chain, and series delivery on
+  the current semantic backbone
+- [`core-first-product-surface/README.md`](core-first-product-surface/README.md)
+  Backend-local cutover family for the Core-first product surface shift
+- [`frontend-facing-contract-cleanup/README.md`](frontend-facing-contract-cleanup/README.md)
+  Backend-owned cleanup family for frontend-consumed contract semantics
+- [`index-to-build-contract/README.md`](index-to-build-contract/README.md)
+  Backend implementation family for the `index` to `build` vocabulary cut
+- [`materials-comparison-v2/README.md`](materials-comparison-v2/README.md)
+  Backend-local materials comparison direction and closure family
+- [`request-id-and-extraction-observability/README.md`](request-id-and-extraction-observability/README.md)
+  Backend-wide request correlation and extraction diagnostics family
+
+## Reading Paths
+
+- Backend migration state:
+  start at [`api-surface-migration/current-state.md`](api-surface-migration/current-state.md)
+- Backend layering and package alignment:
+  start at [`goal-source-core-layering/README.md`](goal-source-core-layering/README.md)
+- Backend evidence-chain delivery:
+  start at [`evidence-chain-product-surface/README.md`](evidence-chain-product-surface/README.md)
+- Backend-local materials comparison direction:
+  start at [`materials-comparison-v2/README.md`](materials-comparison-v2/README.md)
 
 ## Boundary Rule
 
-If a plan mainly belongs to Source, Core, or Derived, keep it in that family
-even when it has some neighboring impact.
+- If a plan mainly belongs to `source/`, `core/`, or `derived/`, keep it in
+  that family even when it has neighboring impact.
+- If the topic needs both frontend and backend to follow one shared contract,
+  keep the authority in root `docs/` and let this family hold only the
+  backend-owned companion material.
+- Inside `backend-wide/`, prefer one topic directory per subject and let child
+  filenames express role, such as `proposal.md`, `current-state.md`, or
+  `implementation-plan.md`.

--- a/backend/docs/plans/backend-wide/api-surface-migration/README.md
+++ b/backend/docs/plans/backend-wide/api-surface-migration/README.md
@@ -1,0 +1,27 @@
+# API Surface Migration
+
+## Purpose
+
+This topic family records the backend-local current state for `/api/v1/*`
+surface migration as Lens v1 converges on the Core-first evidence/comparison
+backbone.
+
+## Authority Boundary
+
+- [`../../../specs/api.md`](../../../specs/api.md) owns the backend API
+  contract
+- [`../../../architecture/overview.md`](../../../architecture/overview.md) and
+  [`../../../architecture/domain-architecture.md`](../../../architecture/domain-architecture.md)
+  own stable backend architecture
+- this family records migration status and next work; it does not redefine the
+  public contract
+
+## Reading Order
+
+- [`current-state.md`](current-state.md)
+  Canonical backend-local migration checkpoint and next-step guide
+
+## Related Docs
+
+- [`../goal-source-core-layering/README.md`](../goal-source-core-layering/README.md)
+- [`../core-first-product-surface/README.md`](../core-first-product-surface/README.md)

--- a/backend/docs/plans/backend-wide/api-surface-migration/current-state.md
+++ b/backend/docs/plans/backend-wide/api-surface-migration/current-state.md
@@ -24,10 +24,10 @@ effective implementation status inside `backend/`.
 It does not attempt to restate frontend requirements in full and it does not
 replace:
 
-- [`../specs/api.md`](../../specs/api.md)
-- [`../architecture/domain-architecture.md`](../../architecture/domain-architecture.md)
+- [`../specs/api.md`](../../../specs/api.md)
+- [`../architecture/domain-architecture.md`](../../../architecture/domain-architecture.md)
 
-It supersedes [`v1-api-migration-notes.md`](../historical/v1-api-migration-notes.md) as the
+It supersedes [`v1-api-migration-notes.md`](../../historical/v1-api-migration-notes.md) as the
 current migration entry point while that note is retained as historical bridge
 context.
 
@@ -211,14 +211,14 @@ semantic center of Core.
 
 ## Related Docs
 
-- [`../specs/api.md`](../../specs/api.md)
-- [`../architecture/overview.md`](../../architecture/overview.md)
-- [`../architecture/domain-architecture.md`](../../architecture/domain-architecture.md)
-- [`../architecture/core-comparison/README.md`](../../architecture/core-comparison/README.md)
-- [`core-stabilization-and-seam-extraction-plan.md`](../core/core-stabilization-and-seam-extraction-plan.md)
-- [`goal-core-source-implementation-plan.md`](goal-core-source-implementation-plan.md)
-- [`graph-surface-plan.md`](../derived/graph-surface-plan.md)
-- [`core-first-product-surface-cutover-plan.md`](core-first-product-surface-cutover-plan.md)
-- [`../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md`](../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md)
-- [`v1-api-migration-notes.md`](../historical/v1-api-migration-notes.md)
-- [`evidence-first-parsing-plan.md`](../historical/evidence-first-parsing-plan.md)
+- [`../specs/api.md`](../../../specs/api.md)
+- [`../architecture/overview.md`](../../../architecture/overview.md)
+- [`../architecture/domain-architecture.md`](../../../architecture/domain-architecture.md)
+- [`../architecture/core-comparison/README.md`](../../../architecture/core-comparison/README.md)
+- [`core-stabilization-and-seam-extraction-plan.md`](../../core/core-stabilization-and-seam-extraction-plan.md)
+- [`goal-core-source-implementation-plan.md`](../goal-source-core-layering/implementation-plan.md)
+- [`graph-surface-plan.md`](../../derived/graph-surface-plan.md)
+- [`core-first-product-surface-cutover-plan.md`](../core-first-product-surface/implementation-plan.md)
+- [`../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md`](../../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md)
+- [`v1-api-migration-notes.md`](../../historical/v1-api-migration-notes.md)
+- [`evidence-first-parsing-plan.md`](../../historical/evidence-first-parsing-plan.md)

--- a/backend/docs/plans/backend-wide/core-first-product-surface/README.md
+++ b/backend/docs/plans/backend-wide/core-first-product-surface/README.md
@@ -1,0 +1,26 @@
+# Core-First Product Surface
+
+## Purpose
+
+This topic family records the backend-local cutover work for making the
+Core-first product surface the operational center for graph, report, and other
+downstream reads.
+
+## Authority Boundary
+
+- root `docs/` owns shared product boundary
+- [`../../../specs/api.md`](../../../specs/api.md) owns the backend HTTP
+  contract
+- this family owns the backend-local cutover plan and follow-through for the
+  Core-first surface shift
+
+## Reading Order
+
+- [`implementation-plan.md`](implementation-plan.md)
+  Main backend-local cutover and cleanup plan
+
+## Related Docs
+
+- [`../goal-source-core-layering/implementation-plan.md`](../goal-source-core-layering/implementation-plan.md)
+- [`../../derived/core-derived-graph-follow-up-plan.md`](../../derived/core-derived-graph-follow-up-plan.md)
+- [`../../derived/graph-surface-plan.md`](../../derived/graph-surface-plan.md)

--- a/backend/docs/plans/backend-wide/core-first-product-surface/implementation-plan.md
+++ b/backend/docs/plans/backend-wide/core-first-product-surface/implementation-plan.md
@@ -43,22 +43,22 @@ The five-layer backend architecture already states that:
 
 That architecture now has concrete code movement behind it:
 
-- [`../../../application/derived/graph_service.py`](../../../application/derived/graph_service.py)
+- [`../../../application/derived/graph_service.py`](../../../../application/derived/graph_service.py)
   reads
   only `document_profiles.parquet`, `evidence_cards.parquet`, and
   `comparison_rows.parquet`
-- [`../../../application/derived/report_service.py`](../../../application/derived/report_service.py)
+- [`../../../application/derived/report_service.py`](../../../../application/derived/report_service.py)
   derives pattern-group style report payloads from Core artifacts
-- [`../../../application/source/artifact_registry_service.py`](../../../application/source/artifact_registry_service.py)
+- [`../../../application/source/artifact_registry_service.py`](../../../../application/source/artifact_registry_service.py)
   computes `graph_generated` and `graph_ready` from Core graph inputs rather
   than GraphRAG entity artifacts
-- [`../../../application/source/task_service.py`](../../../application/source/task_service.py)
+- [`../../../application/source/task_service.py`](../../../../application/source/task_service.py)
   and
-  [`../../../controllers/schemas/source/task.py`](../../../controllers/schemas/source/task.py)
+  [`../../../controllers/schemas/source/task.py`](../../../../controllers/schemas/source/task.py)
   expose `source_index_*` stage names
 - public `query` surface and its application/Source runtime chain are retired
 - GraphML rendering for the product graph surface now lives under
-  [`../../../infra/derived/graph/graphml.py`](../../../infra/derived/graph/graphml.py)
+  [`../../../infra/derived/graph/graphml.py`](../../../../infra/derived/graph/graphml.py)
 
 The architecture risk has therefore changed.
 
@@ -277,7 +277,7 @@ Goal:
 Primary changes:
 
 - update graph/report/task wording in
-  [`../specs/api.md`](../../specs/api.md)
+  [`../specs/api.md`](../../../specs/api.md)
 - update retained plan docs whose old text still assumes dual-path or
   GraphRAG-first product semantics
 - keep five-layer wording consistent with current code
@@ -348,17 +348,17 @@ Exit criteria:
 
 ## Recommended Reading Order
 
-1. [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
-2. [`goal-core-source-contract-follow-up-plan.md`](goal-core-source-contract-follow-up-plan.md)
-3. [`core-derived-graph-follow-up-plan.md`](../derived/core-derived-graph-follow-up-plan.md)
-4. [`core-derived-graph-cutover-implementation-plan.md`](../derived/core-derived-graph-cutover-implementation-plan.md)
+1. [`../architecture/goal-core-source-layering.md`](../../../architecture/goal-core-source-layering.md)
+2. [`goal-core-source-contract-follow-up-plan.md`](../goal-source-core-layering/contract-follow-up.md)
+3. [`core-derived-graph-follow-up-plan.md`](../../derived/core-derived-graph-follow-up-plan.md)
+4. [`core-derived-graph-cutover-implementation-plan.md`](../../derived/core-derived-graph-cutover-implementation-plan.md)
 5. this cutover-closure plan
 
 ## Related Docs
 
-- [`goal-core-source-implementation-plan.md`](goal-core-source-implementation-plan.md)
-- [`goal-core-source-contract-follow-up-plan.md`](goal-core-source-contract-follow-up-plan.md)
-- [`core-derived-graph-follow-up-plan.md`](../derived/core-derived-graph-follow-up-plan.md)
-- [`core-derived-graph-cutover-implementation-plan.md`](../derived/core-derived-graph-cutover-implementation-plan.md)
-- [`graph-surface-plan.md`](../derived/graph-surface-plan.md)
-- [`../specs/api.md`](../../specs/api.md)
+- [`goal-core-source-implementation-plan.md`](../goal-source-core-layering/implementation-plan.md)
+- [`goal-core-source-contract-follow-up-plan.md`](../goal-source-core-layering/contract-follow-up.md)
+- [`core-derived-graph-follow-up-plan.md`](../../derived/core-derived-graph-follow-up-plan.md)
+- [`core-derived-graph-cutover-implementation-plan.md`](../../derived/core-derived-graph-cutover-implementation-plan.md)
+- [`graph-surface-plan.md`](../../derived/graph-surface-plan.md)
+- [`../specs/api.md`](../../../specs/api.md)

--- a/backend/docs/plans/backend-wide/evidence-chain-product-surface/README.md
+++ b/backend/docs/plans/backend-wide/evidence-chain-product-surface/README.md
@@ -1,0 +1,29 @@
+# Evidence-Chain Product Surface
+
+## Purpose
+
+This topic family records the backend-owned implementation wave for exposing
+variant dossiers, result chains, and result-series read models over the
+current semantic backbone.
+
+## Authority Boundary
+
+- [`../../../../../docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md`](../../../../../docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md)
+  owns the shared delivery order and acceptance ladder
+- [`../../../../../docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md`](../../../../../docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md)
+  owns the shared additive drilldown contract
+- [`../../../specs/api.md`](../../../specs/api.md) remains the long-lived
+  backend API authority after the routes land
+- this family owns only the backend implementation companion, not the shared
+  proposal or contract freeze
+
+## Reading Order
+
+- [`backend-implementation-plan.md`](backend-implementation-plan.md)
+  Backend file areas, phases, verification, and backend-local acceptance
+
+## Related Docs
+
+- [`../../core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md`](../../core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md)
+- [`../../../../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md`](../../../../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md)
+- [`../../../specs/api.md`](../../../specs/api.md)

--- a/backend/docs/plans/backend-wide/evidence-chain-product-surface/backend-implementation-plan.md
+++ b/backend/docs/plans/backend-wide/evidence-chain-product-surface/backend-implementation-plan.md
@@ -1,0 +1,323 @@
+# Evidence-Chain Product Surface Backend Implementation Plan
+
+## Summary
+
+This plan records the backend-owned implementation wave for turning the
+current paper-facts and comparable-result backbone into dossier-, chain-, and
+series-ready read models.
+
+It is the backend implementation companion to the shared evidence-chain
+roadmap and contract freeze. It does not replace those shared docs.
+
+## Authority Boundary
+
+- [`../../../../../docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md`](../../../../../docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md)
+  owns the shared delivery order and acceptance ladder
+- [`../../../../../docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md`](../../../../../docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md)
+  owns the shared additive contract for document and result drilldown
+- [`../../../specs/api.md`](../../../specs/api.md) remains the long-lived
+  backend API authority after the routes land
+- this page owns backend file changes, backend verification, and backend-local
+  doc sync for the wave
+
+## Purpose
+
+The backend should make one narrow vertical readable as:
+
+- one document with several variant dossiers
+- one dossier with several result chains or result-series rows
+- one result detail payload that explains one full evidence chain
+
+The first proving slice remains the current narrow PBF-metal direction.
+
+## Read This With
+
+- [`../../../../../docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md`](../../../../../docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md)
+- [`../../../../../docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md`](../../../../../docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md)
+- [`../../core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md`](../../core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md)
+- [`../../../specs/api.md`](../../../specs/api.md)
+- [`../../../../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md`](../../../../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md)
+
+## Non-Goals
+
+This backend wave should not:
+
+- add `variant_dossiers.parquet`, `result_chains.parquet`, or
+  `result_series.parquet`
+- introduce a second semantic backbone
+- make the frontend the owner of semantic grouping rules
+- broaden the first delivery wave beyond the narrow proving vertical
+- treat downstream experiment-planning generation as trustworthy before
+  evidence-chain reconstruction is stable
+
+## Delivery Rule
+
+The backend implementation order is strict:
+
+1. thicken backend facts
+2. tighten backend comparability and grouped drilldown semantics
+3. sync backend-owned API and plan docs to the landed contract
+
+Frontend should consume additive grouped payloads only after these backend
+phases make the semantics explicit.
+
+## Phase 1: Backend Fact Thickening
+
+### Goal
+
+Make `sample_variants`, `test_conditions`, and `measurement_results` thick
+enough to support one stable evidence chain.
+
+### Files To Change
+
+Backend Core extraction and persistence:
+
+- `backend/application/core/semantic_build/llm/schemas.py`
+- `backend/application/core/semantic_build/llm/prompts.py`
+- `backend/application/core/semantic_build/paper_facts_service.py`
+- `backend/domain/core/evidence_backbone.py`
+
+Backend extraction test support:
+
+- `backend/tests/support/fake_core_llm_extractor.py`
+- `backend/tests/unit/services/test_core_llm_extractor.py`
+- `backend/tests/unit/services/test_paper_facts_services.py`
+
+### Expected Changes
+
+`schemas.py`
+
+- expand `ProcessContextPayload`
+- expand `TestConditionPayloadModel`
+- add value-provenance fields to measurement payloads
+- keep condition types such as `rate` and `direction` representable and
+  consumable
+
+`prompts.py`
+
+- tighten extraction instructions so process temperature, test temperature, and
+  characterization temperature are not merged
+- ask for provenance fields only when evidence supports them
+
+`paper_facts_service.py`
+
+- bind condition mentions such as `rate` and `direction`
+- materialize thicker process and test payloads
+- preserve value origin, source text, unit text, and derivation details
+
+`evidence_backbone.py`
+
+- persist the new fact thickness without adding a new top-level artifact
+  family
+
+### Minimum Field Additions
+
+Process and sample state:
+
+- `laser_power_w`
+- `scan_speed_mm_s`
+- `layer_thickness_um`
+- `hatch_spacing_um`
+- `energy_density_j_mm3`
+- `energy_density_origin`
+- `scan_strategy`
+- `build_orientation`
+- `preheat_temperature_c`
+- `shielding_gas`
+- `oxygen_level_ppm`
+- `powder_size_distribution_um`
+- `post_treatment_summary`
+
+Test condition:
+
+- `test_temperature_c`
+- `strain_rate_s-1`
+- `loading_direction`
+- `sample_orientation`
+- `environment`
+- `frequency_hz`
+- `specimen_geometry`
+- `surface_state`
+
+Value provenance:
+
+- `value_origin`
+- `source_value_text`
+- `source_unit_text`
+- `derivation_formula`
+- `derivation_inputs`
+
+### Verification
+
+```bash
+cd backend
+uv run pytest tests/unit/services/test_core_llm_extractor.py
+uv run pytest tests/unit/services/test_paper_facts_services.py
+```
+
+### Exit Criteria
+
+- process, test, and characterization temperature are clearly separated
+- current-work measurement results persist provenance fields
+- missing rate, direction, and provenance fields stay missing instead of being
+  guessed
+
+## Phase 2: Backend Comparability And Public Drilldown
+
+### Goal
+
+Teach the comparable-result layer how to use the thicker facts and carry them
+into product-facing read models.
+
+### Files To Change
+
+Backend comparison semantics:
+
+- `backend/domain/core/comparison.py`
+- `backend/application/core/comparison_assembly.py`
+- `backend/application/core/comparison_service.py`
+
+Backend public schemas and controllers:
+
+- `backend/controllers/schemas/core/documents.py`
+- `backend/controllers/schemas/core/results.py`
+- `backend/controllers/core/documents.py`
+- `backend/controllers/core/results.py`
+
+Backend verification:
+
+- `backend/tests/unit/domains/test_comparison_domain.py`
+- `backend/tests/unit/services/test_paper_facts_services.py`
+- `backend/tests/integration/test_app_layer_api.py`
+
+### Expected Changes
+
+`comparison.py`
+
+- add PBF-metal missingness rules for orientation, strain rate, baseline type,
+  and derived-value provenance
+
+`comparison_assembly.py`
+
+- carry thicker variant, test, and provenance context into
+  `ComparableResult`
+- keep `claim_scope == current_work` as the default gate for comparison-ready
+  paths
+
+`comparison_service.py`
+
+- build grouped document drilldown projections from existing semantic truth
+- enrich result detail with parent dossier and chain context
+
+`controllers/schemas/core/documents.py`
+
+- add additive grouped dossier, series, and chain response models
+- keep the existing flat `items` list intact
+
+`controllers/schemas/core/results.py`
+
+- add additive result-chain fields such as dossier summary, chain context,
+  provenance, and sibling-series navigation
+
+`controllers/core/documents.py`
+
+- expose grouped document comparison semantics through additive query or
+  payload fields without breaking the current route
+
+`controllers/core/results.py`
+
+- expose the enriched result detail contract without changing the route family
+
+### Verification
+
+```bash
+cd backend
+uv run pytest tests/unit/domains/test_comparison_domain.py
+uv run pytest tests/unit/services/test_paper_facts_services.py
+uv run pytest tests/integration/test_app_layer_api.py
+```
+
+### Exit Criteria
+
+- document drilldown can return grouped dossier and series structure
+- result detail can explain one full chain in one payload
+- comparability warnings reflect orientation, strain-rate, baseline, and
+  provenance gaps
+
+## Phase 3: Backend Contract And Doc Sync
+
+### Goal
+
+Update backend-owned docs once the additive grouped drilldown payloads land.
+
+### Files To Change
+
+- `backend/docs/specs/api.md`
+- `backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md`
+- this family `README.md` and `backend-implementation-plan.md` if ownership or
+  reading-path wording changed during delivery
+
+### Expected Changes
+
+- freeze the additive document and result payload in the backend API spec
+- keep the narrow PBF-metal plan aligned with the landed backend payload shape
+- keep this backend-wide family aligned with the current ownership boundary and
+  reading path
+
+### Verification
+
+```bash
+python3 scripts/check_docs_governance.py
+```
+
+### Exit Criteria
+
+- backend API spec points to the landed additive payload
+- backend-local topic docs point back to the shared authorities instead of
+  duplicating them
+
+## File Order
+
+The recommended backend implementation order is:
+
+1. `backend/application/core/semantic_build/llm/schemas.py`
+2. `backend/application/core/semantic_build/llm/prompts.py`
+3. `backend/application/core/semantic_build/paper_facts_service.py`
+4. `backend/domain/core/evidence_backbone.py`
+5. `backend/domain/core/comparison.py`
+6. `backend/application/core/comparison_assembly.py`
+7. `backend/application/core/comparison_service.py`
+8. `backend/controllers/schemas/core/documents.py`
+9. `backend/controllers/schemas/core/results.py`
+10. `backend/controllers/core/documents.py`
+11. `backend/controllers/core/results.py`
+12. `backend/docs/specs/api.md`
+13. `backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md`
+14. backend-wide family docs if the reader path changed during delivery
+
+This order keeps the backend truth ahead of frontend consumption and keeps the
+backend doc sync at the end of the code cut.
+
+## Acceptance Checklist
+
+The wave should be considered complete only when all of the following are
+true.
+
+- one paper can be projected into stable variant dossiers and result chains
+- grouped drilldown can distinguish process temperature, test temperature, and
+  characterization temperature
+- result detail exposes provenance for reported versus derived values
+- comparability warnings reflect orientation, strain-rate, baseline, and
+  provenance missingness
+- backend document detail and result detail both preserve one-click source
+  recovery through anchors
+- backend API spec reflects the additive grouped drilldown contract
+- no new permanent dossier or chain artifact family was added
+
+## Related Docs
+
+- [`../../../../../docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md`](../../../../../docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md)
+- [`../../../../../docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md`](../../../../../docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md)
+- [`../../core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md`](../../core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md)
+- [`../../../../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md`](../../../../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md)
+- [`../../../specs/api.md`](../../../specs/api.md)

--- a/backend/docs/plans/backend-wide/frontend-facing-contract-cleanup/README.md
+++ b/backend/docs/plans/backend-wide/frontend-facing-contract-cleanup/README.md
@@ -1,0 +1,24 @@
+# Frontend-Facing Contract Cleanup
+
+## Purpose
+
+This topic family records backend-owned cleanup work for contract semantics
+that the frontend consumes but should not have to reinterpret.
+
+## Authority Boundary
+
+- shared cross-module contract freeze work belongs in root `docs/`
+- [`../../../specs/api.md`](../../../specs/api.md) owns the backend API
+  contract after cleanup lands
+- this family records the backend-local cleanup lineage and rollout details
+
+## Reading Order
+
+- [`implementation-plan.md`](implementation-plan.md)
+  Backend-owned cleanup plan for frontend-consumed semantics
+
+## Related Docs
+
+- [`../index-to-build-contract/implementation-plan.md`](../index-to-build-contract/implementation-plan.md)
+- [`../api-surface-migration/current-state.md`](../api-surface-migration/current-state.md)
+- [`../goal-source-core-layering/contract-follow-up.md`](../goal-source-core-layering/contract-follow-up.md)

--- a/backend/docs/plans/backend-wide/frontend-facing-contract-cleanup/implementation-plan.md
+++ b/backend/docs/plans/backend-wide/frontend-facing-contract-cleanup/implementation-plan.md
@@ -37,15 +37,15 @@ The current API still leaks internal execution choices into public contracts.
 
 Current leakage points include:
 
-- [`../../../controllers/schemas/source/collection.py`](../../../controllers/schemas/source/collection.py)
+- [`../../../controllers/schemas/source/collection.py`](../../../../controllers/schemas/source/collection.py)
   exposes `default_method`
-- [`../../../controllers/schemas/source/task.py`](../../../controllers/schemas/source/task.py)
+- [`../../../controllers/schemas/source/task.py`](../../../../controllers/schemas/source/task.py)
   exposes `method` and `is_update_run`
-- [`../../../application/source/collection_service.py`](../../../application/source/collection_service.py)
+- [`../../../application/source/collection_service.py`](../../../../application/source/collection_service.py)
   persists `default_method` as collection metadata
-- [`../../../application/source/collection_build_task_runner.py`](../../../application/source/collection_build_task_runner.py)
+- [`../../../application/source/collection_build_task_runner.py`](../../../../application/source/collection_build_task_runner.py)
   accepts a caller-provided indexing method
-- [`../../../infra/source/config/pipeline_mode.py`](../../../infra/source/config/pipeline_mode.py)
+- [`../../../infra/source/config/pipeline_mode.py`](../../../../infra/source/config/pipeline_mode.py)
   defines `IndexingMethod.Standard` and `IndexingMethod.Fast` as engine-level
   execution options
 
@@ -205,7 +205,7 @@ Task responses should not gain engine-mode echo fields.
 
 Frontend should drive most UI state from:
 
-- [`../../../controllers/schemas/core/workspace.py`](../../../controllers/schemas/core/workspace.py)
+- [`../../../controllers/schemas/core/workspace.py`](../../../../controllers/schemas/core/workspace.py)
 
 Primary frontend decisions should come from:
 
@@ -222,7 +222,7 @@ engine configuration.
 
 Frontend may continue consuming:
 
-- [`../../../controllers/schemas/goal/intake.py`](../../../controllers/schemas/goal/intake.py)
+- [`../../../controllers/schemas/goal/intake.py`](../../../../controllers/schemas/goal/intake.py)
 
 In particular:
 
@@ -259,8 +259,8 @@ Backend decides whether to:
 
 The current mode-selection and downgrade policy now lives across:
 
-- [`../../../application/source/collection_build_task_runner.py`](../../../application/source/collection_build_task_runner.py)
-- [`../../../infra/source/config/pipeline_mode.py`](../../../infra/source/config/pipeline_mode.py)
+- [`../../../application/source/collection_build_task_runner.py`](../../../../application/source/collection_build_task_runner.py)
+- [`../../../infra/source/config/pipeline_mode.py`](../../../../infra/source/config/pipeline_mode.py)
 
 That logic should remain backend-owned rather than frontend-owned.
 
@@ -385,8 +385,8 @@ stable across rebuilds until evidence ids become deterministic.
 
 ## Related Docs
 
-- [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
-- [`goal-core-source-contract-follow-up-plan.md`](goal-core-source-contract-follow-up-plan.md)
-- [`goal-core-source-implementation-plan.md`](goal-core-source-implementation-plan.md)
-- [`current-api-surface-migration-checklist.md`](current-api-surface-migration-checklist.md)
-- [`core-first-product-surface-cutover-plan.md`](core-first-product-surface-cutover-plan.md)
+- [`../architecture/goal-core-source-layering.md`](../../../architecture/goal-core-source-layering.md)
+- [`goal-core-source-contract-follow-up-plan.md`](../goal-source-core-layering/contract-follow-up.md)
+- [`goal-core-source-implementation-plan.md`](../goal-source-core-layering/implementation-plan.md)
+- [`current-api-surface-migration-checklist.md`](../api-surface-migration/current-state.md)
+- [`core-first-product-surface-cutover-plan.md`](../core-first-product-surface/implementation-plan.md)

--- a/backend/docs/plans/backend-wide/goal-source-core-layering/README.md
+++ b/backend/docs/plans/backend-wide/goal-source-core-layering/README.md
@@ -1,0 +1,30 @@
+# Goal Source Core Layering
+
+## Purpose
+
+This topic family records the backend-local work for making the
+`goal / source / core / derived` business layering explicit in code structure,
+delivery order, and contract follow-up.
+
+## Authority Boundary
+
+- [`../../../architecture/goal-core-source-layering.md`](../../../architecture/goal-core-source-layering.md)
+  owns the stable backend layering description
+- root `docs/` owns shared product boundary and cross-module contracts
+- this family owns backend-local proposal, rollout, and follow-up material for
+  the layering cut
+
+## Reading Order
+
+- [`proposal.md`](proposal.md)
+  Why the explicit business-layer split is needed
+- [`implementation-plan.md`](implementation-plan.md)
+  Main backend rollout plan for the layering wave
+- [`contract-follow-up.md`](contract-follow-up.md)
+  Backend contract cleanup and freeze follow-up after the main cut
+
+## Related Docs
+
+- [`../api-surface-migration/current-state.md`](../api-surface-migration/current-state.md)
+- [`../core-first-product-surface/implementation-plan.md`](../core-first-product-surface/implementation-plan.md)
+- [`../../../architecture/goal-core-source-layering.md`](../../../architecture/goal-core-source-layering.md)

--- a/backend/docs/plans/backend-wide/goal-source-core-layering/contract-follow-up.md
+++ b/backend/docs/plans/backend-wide/goal-source-core-layering/contract-follow-up.md
@@ -190,7 +190,7 @@ Goal:
 
 Current child execution entrypoint:
 
-- [`source-collection-builder-normalization-plan.md`](../source/source-collection-builder-normalization-plan.md)
+- [`source-collection-builder-normalization-plan.md`](../../source/source-collection-builder-normalization-plan.md)
 
 Primary changes:
 
@@ -229,7 +229,7 @@ Goal:
 
 Current child execution entrypoint:
 
-- [`core-first-product-surface-cutover-plan.md`](core-first-product-surface-cutover-plan.md)
+- [`core-first-product-surface-cutover-plan.md`](../core-first-product-surface/implementation-plan.md)
 
 Primary changes:
 
@@ -318,16 +318,16 @@ Exit criteria:
 
 ## Recommended Reading Order
 
-1. [`goal-core-source-implementation-plan.md`](goal-core-source-implementation-plan.md)
-2. [`core-stabilization-and-seam-extraction-plan.md`](../core/core-stabilization-and-seam-extraction-plan.md)
-3. [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
+1. [`goal-core-source-implementation-plan.md`](../goal-source-core-layering/implementation-plan.md)
+2. [`core-stabilization-and-seam-extraction-plan.md`](../../core/core-stabilization-and-seam-extraction-plan.md)
+3. [`../architecture/goal-core-source-layering.md`](../../../architecture/goal-core-source-layering.md)
 4. this follow-up plan
-5. [`core-derived-graph-follow-up-plan.md`](../derived/core-derived-graph-follow-up-plan.md)
+5. [`core-derived-graph-follow-up-plan.md`](../../derived/core-derived-graph-follow-up-plan.md)
 
 ## Related Docs
 
-- [`goal-core-source-implementation-plan.md`](goal-core-source-implementation-plan.md)
-- [`core-stabilization-and-seam-extraction-plan.md`](../core/core-stabilization-and-seam-extraction-plan.md)
-- [`core-derived-graph-follow-up-plan.md`](../derived/core-derived-graph-follow-up-plan.md)
-- [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
-- [`../specs/api.md`](../../specs/api.md)
+- [`goal-core-source-implementation-plan.md`](../goal-source-core-layering/implementation-plan.md)
+- [`core-stabilization-and-seam-extraction-plan.md`](../../core/core-stabilization-and-seam-extraction-plan.md)
+- [`core-derived-graph-follow-up-plan.md`](../../derived/core-derived-graph-follow-up-plan.md)
+- [`../architecture/goal-core-source-layering.md`](../../../architecture/goal-core-source-layering.md)
+- [`../specs/api.md`](../../../specs/api.md)

--- a/backend/docs/plans/backend-wide/goal-source-core-layering/implementation-plan.md
+++ b/backend/docs/plans/backend-wide/goal-source-core-layering/implementation-plan.md
@@ -6,7 +6,7 @@ shorthand.
 
 It should also be read through the paper-facts primary-domain-model decision
 recorded in
-[`../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md`](../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md).
+[`../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md`](../../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md).
 
 ## Summary
 
@@ -27,7 +27,7 @@ Core backbone.
 ## Context
 
 The architecture proposal in
-[`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
+[`../architecture/goal-core-source-layering.md`](../../../architecture/goal-core-source-layering.md)
 now defines five layers rather than a single pre-Core Goal layer.
 
 The most important correction is:
@@ -103,7 +103,7 @@ Goal:
 
 Current child execution entrypoint:
 
-- [`core-parsing-quality-hardening-plan.md`](../core/core-parsing-quality-hardening-plan.md)
+- [`core-parsing-quality-hardening-plan.md`](../../core/core-parsing-quality-hardening-plan.md)
 
 Primary changes:
 
@@ -191,7 +191,7 @@ Goal:
 
 Current child execution entrypoint:
 
-- [`goal-core-source-contract-follow-up-plan.md`](goal-core-source-contract-follow-up-plan.md)
+- [`goal-core-source-contract-follow-up-plan.md`](../goal-source-core-layering/contract-follow-up.md)
 
 Primary changes:
 
@@ -226,7 +226,7 @@ Goal:
 
 Current child execution entrypoint:
 
-- [`source-collection-builder-normalization-plan.md`](../source/source-collection-builder-normalization-plan.md)
+- [`source-collection-builder-normalization-plan.md`](../../source/source-collection-builder-normalization-plan.md)
 
 Primary changes:
 
@@ -281,7 +281,7 @@ Goal:
 
 Current child execution entrypoint:
 
-- [`core-first-product-surface-cutover-plan.md`](core-first-product-surface-cutover-plan.md)
+- [`core-first-product-surface-cutover-plan.md`](../core-first-product-surface/implementation-plan.md)
 
 Primary changes:
 
@@ -389,12 +389,12 @@ Exit criteria:
 
 ## Related Docs
 
-- [`current-api-surface-migration-checklist.md`](current-api-surface-migration-checklist.md)
-- [`core-stabilization-and-seam-extraction-plan.md`](../core/core-stabilization-and-seam-extraction-plan.md)
-- [`goal-core-source-contract-follow-up-plan.md`](goal-core-source-contract-follow-up-plan.md)
-- [`core-derived-graph-follow-up-plan.md`](../derived/core-derived-graph-follow-up-plan.md)
-- [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
-- [`../architecture/domain-architecture.md`](../../architecture/domain-architecture.md)
-- [`../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md`](../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md)
-- [`evidence-first-parsing-plan.md`](../historical/evidence-first-parsing-plan.md)
-- [`v1-api-migration-notes.md`](../historical/v1-api-migration-notes.md)
+- [`current-api-surface-migration-checklist.md`](../api-surface-migration/current-state.md)
+- [`core-stabilization-and-seam-extraction-plan.md`](../../core/core-stabilization-and-seam-extraction-plan.md)
+- [`goal-core-source-contract-follow-up-plan.md`](../goal-source-core-layering/contract-follow-up.md)
+- [`core-derived-graph-follow-up-plan.md`](../../derived/core-derived-graph-follow-up-plan.md)
+- [`../architecture/goal-core-source-layering.md`](../../../architecture/goal-core-source-layering.md)
+- [`../architecture/domain-architecture.md`](../../../architecture/domain-architecture.md)
+- [`../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md`](../../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md)
+- [`evidence-first-parsing-plan.md`](../../historical/evidence-first-parsing-plan.md)
+- [`v1-api-migration-notes.md`](../../historical/v1-api-migration-notes.md)

--- a/backend/docs/plans/backend-wide/goal-source-core-layering/proposal.md
+++ b/backend/docs/plans/backend-wide/goal-source-core-layering/proposal.md
@@ -17,9 +17,9 @@ organization.
 
 Read this plan with:
 
-- [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
-- [`../architecture/application-layer-boundary.md`](../../architecture/application-layer-boundary.md)
-- [`../../application/docs/application-layer-one-shot-cutover-plan.md`](../../../application/docs/application-layer-one-shot-cutover-plan.md)
+- [`../architecture/goal-core-source-layering.md`](../../../architecture/goal-core-source-layering.md)
+- [`../architecture/application-layer-boundary.md`](../../../architecture/application-layer-boundary.md)
+- [`../../application/docs/application-layer-one-shot-cutover-plan.md`](../../../../application/docs/application-layer-one-shot-cutover-plan.md)
 
 ## Status
 
@@ -429,7 +429,7 @@ Runtime checks:
 ## Relationship To Existing Plans
 
 This plan is not a duplicate of
-[`../../application/docs/application-layer-one-shot-cutover-plan.md`](../../../application/docs/application-layer-one-shot-cutover-plan.md).
+[`../../application/docs/application-layer-one-shot-cutover-plan.md`](../../../../application/docs/application-layer-one-shot-cutover-plan.md).
 
 The earlier application-layer plan cleaned flat application shims and clarified
 domain-packaged imports.

--- a/backend/docs/plans/backend-wide/index-to-build-contract/README.md
+++ b/backend/docs/plans/backend-wide/index-to-build-contract/README.md
@@ -1,0 +1,25 @@
+# Index To Build Contract
+
+## Purpose
+
+This topic family records the backend-owned implementation wave for replacing
+remaining product-facing `index` vocabulary with `build` vocabulary.
+
+## Authority Boundary
+
+- [`../../../specs/api.md`](../../../specs/api.md) owns the backend route and
+  payload contract after the cut lands
+- root `docs/` owns shared product wording and cross-module contract freeze
+  decisions
+- this family owns the backend implementation companion for the vocabulary cut
+
+## Reading Order
+
+- [`implementation-plan.md`](implementation-plan.md)
+  Backend-local rollout plan for the `index` to `build` cut
+
+## Related Docs
+
+- [`../frontend-facing-contract-cleanup/implementation-plan.md`](../frontend-facing-contract-cleanup/implementation-plan.md)
+- [`../api-surface-migration/current-state.md`](../api-surface-migration/current-state.md)
+- [`../../../specs/api.md`](../../../specs/api.md)

--- a/backend/docs/plans/backend-wide/index-to-build-contract/implementation-plan.md
+++ b/backend/docs/plans/backend-wide/index-to-build-contract/implementation-plan.md
@@ -26,10 +26,10 @@ not allow a long-lived compatibility route family.
 
 Read this plan with:
 
-- [`frontend-facing-contract-cleanup-plan.md`](frontend-facing-contract-cleanup-plan.md)
-- [`current-api-surface-migration-checklist.md`](current-api-surface-migration-checklist.md)
-- [`../../specs/api.md`](../../specs/api.md)
-- [`../../../../frontend/docs/frontend-plan.md`](../../../../frontend/docs/frontend-plan.md)
+- [`frontend-facing-contract-cleanup-plan.md`](../frontend-facing-contract-cleanup/implementation-plan.md)
+- [`current-api-surface-migration-checklist.md`](../api-surface-migration/current-state.md)
+- [`../../specs/api.md`](../../../specs/api.md)
+- [`../../../../frontend/docs/frontend-plan.md`](../../../../../frontend/docs/frontend-plan.md)
 
 ## Why This Wave Is Needed
 
@@ -58,15 +58,15 @@ That means:
 
 Current frontend code still expects outdated contract pieces:
 
-- [`../../../../frontend/src/routes/_shared/tasks.ts`](../../../../frontend/src/routes/_shared/tasks.ts)
+- [`../../../../frontend/src/routes/_shared/tasks.ts`](../../../../../frontend/src/routes/_shared/tasks.ts)
   still types `graphrag_index_started` and `graphrag_index_completed`
 - the same file still calls
   `POST /api/v1/collections/{collection_id}/tasks/index`
-- [`../../../../frontend/src/routes/_shared/workspace.ts`](../../../../frontend/src/routes/_shared/workspace.ts)
+- [`../../../../frontend/src/routes/_shared/workspace.ts`](../../../../../frontend/src/routes/_shared/workspace.ts)
   still expects `sections_ready` and `graphml_ready`
-- [`../../../../frontend/src/routes/collections/[id]/+layout.svelte`](../../../../frontend/src/routes/collections/[id]/+layout.svelte)
+- [`../../../../frontend/src/routes/collections/[id]/+layout.svelte`](../../../../../frontend/src/routes/collections/[id]/+layout.svelte)
   still treats `graphml_ready` as a graph visibility signal
-- [`../../../../frontend/src/routes/_shared/i18n.ts`](../../../../frontend/src/routes/_shared/i18n.ts)
+- [`../../../../frontend/src/routes/_shared/i18n.ts`](../../../../../frontend/src/routes/_shared/i18n.ts)
   still renders GraphRAG-era stage labels
 
 This means the next vocabulary cleanup should not be treated as a backend-only
@@ -287,17 +287,17 @@ Target frontend contract rules:
 Primary backend changes:
 
 - rename the route in
-  [`../../../controllers/source/tasks.py`](../../../controllers/source/tasks.py)
+  [`../../../controllers/source/tasks.py`](../../../../controllers/source/tasks.py)
   from `/tasks/index` to `/tasks/build`
 - rename request/handler symbols from `IndexTask*` / `create_index_task` to
   `BuildTask*` / `create_build_task`
 - change task creation in
-  [`../../../application/source/task_service.py`](../../../application/source/task_service.py)
+  [`../../../application/source/task_service.py`](../../../../application/source/task_service.py)
   from `task_type="index"` to `task_type="build"`
 - update
-  [`../../../controllers/schemas/source/task.py`](../../../controllers/schemas/source/task.py)
+  [`../../../controllers/schemas/source/task.py`](../../../../controllers/schemas/source/task.py)
   to the new task-stage enum
-- update [`../../specs/api.md`](../../specs/api.md) to the new route and stage
+- update [`../../specs/api.md`](../../../specs/api.md) to the new route and stage
   vocabulary
 
 Exit criteria:
@@ -311,7 +311,7 @@ Exit criteria:
 Primary backend changes:
 
 - rename
-  [`../../../application/source/collection_build_task_runner.py`](../../../application/source/collection_build_task_runner.py)
+  [`../../../application/source/collection_build_task_runner.py`](../../../../application/source/collection_build_task_runner.py)
   to a build-oriented name such as `collection_build_task_runner.py`
 - rename `IndexTaskRunner` to `CollectionBuildTaskRunner`
 - rename `run_index_task()` to `run_build_task()`
@@ -337,7 +337,7 @@ the naming correction.
 
 Primary backend changes:
 
-- rename [`../../../infra/source/runtime/build_source_artifacts.py`](../../../infra/source/runtime/build_source_artifacts.py)
+- rename [`../../../infra/source/runtime/build_source_artifacts.py`](../../../../infra/source/runtime/build_source_artifacts.py)
   to a build-oriented runtime entry such as `build_source_artifacts.py` or
   `run_source_pipeline.py`
 - rename `build_index()` to a name that describes the current runtime job
@@ -355,14 +355,14 @@ Exit criteria:
 
 Frontend files that need direct contract updates:
 
-- [`../../../../frontend/src/routes/_shared/tasks.ts`](../../../../frontend/src/routes/_shared/tasks.ts)
-- [`../../../../frontend/src/routes/_shared/workspace.ts`](../../../../frontend/src/routes/_shared/workspace.ts)
-- [`../../../../frontend/src/routes/_shared/i18n.ts`](../../../../frontend/src/routes/_shared/i18n.ts)
-- [`../../../../frontend/src/routes/+page.svelte`](../../../../frontend/src/routes/+page.svelte)
-- [`../../../../frontend/src/routes/collections/[id]/+page.svelte`](../../../../frontend/src/routes/collections/[id]/+page.svelte)
-- [`../../../../frontend/src/routes/collections/[id]/+layout.svelte`](../../../../frontend/src/routes/collections/[id]/+layout.svelte)
-- [`../../../../frontend/src/routes/collections/lens-v1-interface-spec.md`](../../../../frontend/src/routes/collections/lens-v1-interface-spec.md)
-- [`../../../../frontend/docs/frontend-plan.md`](../../../../frontend/docs/frontend-plan.md)
+- [`../../../../frontend/src/routes/_shared/tasks.ts`](../../../../../frontend/src/routes/_shared/tasks.ts)
+- [`../../../../frontend/src/routes/_shared/workspace.ts`](../../../../../frontend/src/routes/_shared/workspace.ts)
+- [`../../../../frontend/src/routes/_shared/i18n.ts`](../../../../../frontend/src/routes/_shared/i18n.ts)
+- [`../../../../frontend/src/routes/+page.svelte`](../../../../../frontend/src/routes/+page.svelte)
+- [`../../../../frontend/src/routes/collections/[id]/+page.svelte`](../../../../../frontend/src/routes/collections/[id]/+page.svelte)
+- [`../../../../frontend/src/routes/collections/[id]/+layout.svelte`](../../../../../frontend/src/routes/collections/[id]/+layout.svelte)
+- [`../../../../frontend/src/routes/collections/lens-v1-interface-spec.md`](../../../../../frontend/src/routes/collections/lens-v1-interface-spec.md)
+- [`../../../../frontend/docs/frontend-plan.md`](../../../../../frontend/docs/frontend-plan.md)
 
 ### Frontend Required Changes
 
@@ -452,8 +452,8 @@ This plan is complete when:
 
 ## Related Docs
 
-- [`frontend-facing-contract-cleanup-plan.md`](frontend-facing-contract-cleanup-plan.md)
-- [`current-api-surface-migration-checklist.md`](current-api-surface-migration-checklist.md)
-- [`../../specs/api.md`](../../specs/api.md)
-- [`../../../../frontend/docs/frontend-plan.md`](../../../../frontend/docs/frontend-plan.md)
-- [`../../../../frontend/src/routes/collections/lens-v1-interface-spec.md`](../../../../frontend/src/routes/collections/lens-v1-interface-spec.md)
+- [`frontend-facing-contract-cleanup-plan.md`](../frontend-facing-contract-cleanup/implementation-plan.md)
+- [`current-api-surface-migration-checklist.md`](../api-surface-migration/current-state.md)
+- [`../../specs/api.md`](../../../specs/api.md)
+- [`../../../../frontend/docs/frontend-plan.md`](../../../../../frontend/docs/frontend-plan.md)
+- [`../../../../frontend/src/routes/collections/lens-v1-interface-spec.md`](../../../../../frontend/src/routes/collections/lens-v1-interface-spec.md)

--- a/backend/docs/plans/backend-wide/materials-comparison-v2/README.md
+++ b/backend/docs/plans/backend-wide/materials-comparison-v2/README.md
@@ -1,0 +1,27 @@
+# Materials Comparison V2
+
+## Purpose
+
+This topic family records the backend-local direction and closure work for the
+materials comparison backbone as it shifts from claim-centric comparison
+toward sample- and measurement-centric semantics.
+
+## Authority Boundary
+
+- root `docs/` owns shared product identity and cross-module evidence-chain
+  direction
+- this family is backend-local direction material, not shared product
+  authority
+- narrow proving-slice semantics for PBF-metal stay with the owning Core topic
+  family
+
+## Reading Order
+
+- [`implementation-plan.md`](implementation-plan.md)
+  Backend-local implementation and closure plan for the materials comparison
+  backbone
+
+## Related Docs
+
+- [`../../core/pbf-metal-extraction-and-comparison-validation/README.md`](../../core/pbf-metal-extraction-and-comparison-validation/README.md)
+- [`../../../../../docs/decisions/rfc-comparable-result-substrate-and-materials-database-direction.md`](../../../../../docs/decisions/rfc-comparable-result-substrate-and-materials-database-direction.md)

--- a/backend/docs/plans/backend-wide/materials-comparison-v2/implementation-plan.md
+++ b/backend/docs/plans/backend-wide/materials-comparison-v2/implementation-plan.md
@@ -31,9 +31,9 @@ baseline -> comparability support` problem.
 
 Read this plan after:
 
-- [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
-- [`source-collection-builder-normalization-plan.md`](../source/source-collection-builder-normalization-plan.md)
-- [`born-digital-source-parser-first-plan.md`](../source/born-digital-source-parser-first-plan.md)
+- [`../architecture/goal-core-source-layering.md`](../../../architecture/goal-core-source-layering.md)
+- [`source-collection-builder-normalization-plan.md`](../../source/source-collection-builder-normalization-plan.md)
+- [`born-digital-source-parser-first-plan.md`](../../source/born-digital-source-parser-first-plan.md)
 
 ## Status
 

--- a/backend/docs/plans/backend-wide/request-id-and-extraction-observability/README.md
+++ b/backend/docs/plans/backend-wide/request-id-and-extraction-observability/README.md
@@ -1,0 +1,25 @@
+# Request ID And Extraction Observability
+
+## Purpose
+
+This topic family records backend-wide request correlation and Core extraction
+diagnostics work so failures can be traced across collection processing and
+semantic build steps.
+
+## Authority Boundary
+
+- this family is backend-owned observability and diagnostics material
+- it does not own the public API contract or shared product meaning
+- operational context stays here, while shared contract or product decisions
+  stay in root `docs/`
+
+## Reading Order
+
+- [`implementation-plan.md`](implementation-plan.md)
+  Backend request correlation and extraction diagnostics plan
+
+## Related Docs
+
+- [`../api-surface-migration/current-state.md`](../api-surface-migration/current-state.md)
+- [`../goal-source-core-layering/proposal.md`](../goal-source-core-layering/proposal.md)
+- [`../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)

--- a/backend/docs/plans/backend-wide/request-id-and-extraction-observability/implementation-plan.md
+++ b/backend/docs/plans/backend-wide/request-id-and-extraction-observability/implementation-plan.md
@@ -321,7 +321,7 @@ This wave is complete when all of the following are true:
 
 ## Related Docs
 
-- [`current-api-surface-migration-checklist.md`](current-api-surface-migration-checklist.md)
-- [`goal-source-core-business-layer-alignment-plan.md`](goal-source-core-business-layer-alignment-plan.md)
-- [`../core/core-llm-structured-extraction-hard-cutover-plan.md`](../core/core-llm-structured-extraction-hard-cutover-plan.md)
-- [`../../specs/api.md`](../../specs/api.md)
+- [`current-api-surface-migration-checklist.md`](../api-surface-migration/current-state.md)
+- [`goal-source-core-business-layer-alignment-plan.md`](../goal-source-core-layering/proposal.md)
+- [`../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)
+- [`../../specs/api.md`](../../../specs/api.md)

--- a/backend/docs/plans/core/README.md
+++ b/backend/docs/plans/core/README.md
@@ -10,16 +10,21 @@ domain-semantic backfill.
   Earlier stabilization wave for the shared parsing seam
 - [`core-parsing-quality-hardening-plan.md`](core-parsing-quality-hardening-plan.md)
   Current Core quality hardening wave
-- [`core-llm-structured-extraction-hard-cutover-plan.md`](core-llm-structured-extraction-hard-cutover-plan.md)
-  Child implementation plan for hard-cutting Core semantic extraction to
-  schema-bound LLM parsing
+- [`pbf-metal-extraction-and-comparison-validation/README.md`](pbf-metal-extraction-and-comparison-validation/README.md)
+  Topic family for the PBF-metal validation wave, including the proposal,
+  parameter-registry and report-scope note, and executable implementation plan
+- [`../../../application/core/semantic_build/llm/docs/structured-extraction/README.md`](../../../application/core/semantic_build/llm/docs/structured-extraction/README.md)
+  Node-local LLM structured-extraction plan family for cutover, boundary
+  cleanup, and prompt hardening under the owning Core package
 - [`core-semantic-build-packaging-alignment-plan.md`](core-semantic-build-packaging-alignment-plan.md)
   Child implementation plan for packaging the Source-to-Core semantic build
   slice into one explicit Core-owned submodule
-- [`core-llm-structured-extraction-id-boundary-plan.md`](core-llm-structured-extraction-id-boundary-plan.md)
-  Child implementation plan for removing backend/internal identifiers from the
-  Core LLM extraction contract and moving identity resolution back into the
-  backend
+- [`core-text-window-atomic-mentions-plan.md`](core-text-window-atomic-mentions-plan.md)
+  Child implementation plan for narrowing text-window extraction to atomic
+  mentions plus deterministic backend binding
+- [`core-benchmark-script-consolidation-plan.md`](core-benchmark-script-consolidation-plan.md)
+  Child implementation plan for moving Core benchmark probes into one
+  repo-owned backend benchmark directory
 - [`document-profile-lightweight-triage-plan.md`](document-profile-lightweight-triage-plan.md)
   Child plan for narrowing `document_profiles` to lightweight triage with
   enum-stable routing outputs

--- a/backend/docs/plans/core/claim-traceback-navigation-implementation-plan.md
+++ b/backend/docs/plans/core/claim-traceback-navigation-implementation-plan.md
@@ -15,7 +15,7 @@ by giving the user a deterministic way to move from structured claims back to
 document context.
 
 For the broader five-layer roadmap, read
-[`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md).
+[`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md).
 For the current parent execution wave, read
 [`core-parsing-quality-hardening-plan.md`](core-parsing-quality-hardening-plan.md).
 
@@ -84,7 +84,7 @@ from the Core-owned evidence/document path.
   is the immediate parent execution plan. This traceback slice is one concrete
   child implementation wave under its evidence-quality and traceback-quality
   scope.
-- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md)
+- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md)
   is the broader backend roadmap. This traceback slice helps complete the Core
   before Source expansion or Goal Consumer work resumes.
 - [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
@@ -257,7 +257,7 @@ Required checks for this slice:
 ## Related Docs
 
 - [`core-parsing-quality-hardening-plan.md`](core-parsing-quality-hardening-plan.md)
-- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md)
+- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md)
 - [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
 - [`../specs/api.md`](../../specs/api.md)
 - [`../../../frontend/src/routes/collections/claim-traceback-navigation-contract.md`](../../../../frontend/src/routes/collections/claim-traceback-navigation-contract.md)

--- a/backend/docs/plans/core/core-benchmark-script-consolidation-plan.md
+++ b/backend/docs/plans/core/core-benchmark-script-consolidation-plan.md
@@ -1,0 +1,251 @@
+# Core Benchmark Script Consolidation Plan
+
+## Summary
+
+This plan consolidates Core extraction benchmark work into repo-owned backend
+scripts instead of ad hoc date-folder probes.
+
+The immediate goal is not new extraction behavior. It is a stable benchmark
+surface that can measure the current Core path without path-sensitive imports,
+hard-coded env-file assumptions, or mode drift between scripts.
+
+## Why This Wave Exists
+
+Current benchmark scripts are useful for diagnosis, but they are not durable
+enough to support repeatable before-and-after comparisons.
+
+The current problems are structural:
+
+- some scripts assume a sibling `../backend` path and fail outside one local
+  directory layout
+- some scripts default to loading one fixed `backend/.env` path and fail even
+  when explicit runtime inputs are available
+- raw text, local parse, and provider-native structured parsing are currently
+  measured by different script implementations rather than one controlled
+  benchmark surface
+- collection-level extraction cost is still harder to compare than single-call
+  latency
+
+## Target Outcome
+
+The backend should own one canonical benchmark directory:
+
+- `scripts/benchmarks/`
+
+That directory should expose three stable benchmark entrypoints:
+
+- `llm_connectivity_probe.py`
+- `text_window_probe.py`
+- `paper_facts_collection_benchmark.py`
+
+Together they should answer four distinct questions:
+
+1. is the provider reachable and responsive at all
+2. how long does one raw text response take for the exact prompt and payload
+3. how much extra time comes from local JSON validation
+4. how much extra time comes from provider-native structured parsing compared
+   with the current Core path
+
+## Benchmark Modes
+
+The text-window benchmark should support one fixed payload and prompt path with
+multiple execution modes:
+
+- `connectivity`
+  Minimal health and small chat-completion timing
+- `raw_text`
+  Plain `chat.completions.create` timing with raw text capture only
+- `raw_text_plus_validate`
+  Same request as `raw_text`, plus local `model_validate_json`
+- `provider_structured_parse`
+  Provider-native structured parsing kept only as a diagnostic baseline
+
+The benchmark is valid only if these modes share the same:
+
+- payload
+- system prompt
+- user prompt
+- model
+- base URL
+- temperature
+- token budget
+
+## Runtime Contract
+
+All benchmark scripts in this wave should use the same runtime rules:
+
+- no implicit `../backend` import assumptions
+- no required fixed `backend/.env` lookup
+- support explicit CLI overrides for:
+  - `--backend-root`
+  - `--env-file`
+  - `--base-url`
+  - `--model`
+  - `--api-key`
+- resolve runtime inputs in this precedence order:
+  - CLI argument
+  - environment variable
+  - optional env-file
+  - bounded default only where safe
+
+## Script Responsibilities
+
+### `llm_connectivity_probe.py`
+
+Own only provider connectivity and small chat latency.
+
+It should not import backend application modules.
+
+It should report:
+
+- resolved model
+- resolved base URL
+- models-list timing when enabled
+- minimal chat timing when enabled
+
+### `text_window_probe.py`
+
+Own one-payload prompt benchmarking for Core extraction prompts.
+
+It should support:
+
+- built-in sample payloads
+- explicit `--payload-file`
+- exact prompt echoing for debug work
+- comparable output across all benchmark modes
+
+It should report:
+
+- selected mode
+- prompt and payload metadata
+- run count
+- per-run elapsed time
+- p50, p95, min, max, and average timing
+- optional raw response capture path
+
+### `paper_facts_collection_benchmark.py`
+
+Own collection-level extraction cost measurement.
+
+It should use the real Core build path so it can expose where time is spent.
+
+It should report:
+
+- document count
+- raw text-window count
+- selected text-window count
+- raw table-row count
+- selected table-row count
+- per-unit timing aggregates
+- whole-document and whole-collection elapsed time
+
+## Delivery Slices
+
+### Slice 1: Directory And Shared Runtime Contract
+
+Create `scripts/benchmarks/` and define the shared runtime and output rules.
+
+Owned file areas:
+
+- `scripts/benchmarks/README.md`
+- `scripts/benchmarks/_common.py` only if shared runtime parsing is needed by
+  more than one script
+
+Exit criteria:
+
+- benchmark entrypoints no longer depend on a caller-specific directory layout
+- explicit runtime overrides work without a fixed local env-file
+
+### Slice 2: Connectivity Probe Cutover
+
+Replace the current one-off connectivity benchmark with a repo-owned script.
+
+Owned file areas:
+
+- `scripts/benchmarks/llm_connectivity_probe.py`
+
+Exit criteria:
+
+- a user can benchmark provider connectivity from any working directory with
+  explicit runtime inputs
+
+### Slice 3: Text-Window Mode Unification
+
+Replace separate raw/parse probes with one canonical text-window benchmark.
+
+Owned file areas:
+
+- `scripts/benchmarks/text_window_probe.py`
+
+Exit criteria:
+
+- `raw_text`, `raw_text_plus_validate`, and `provider_structured_parse` share
+  one prompt and payload path
+- timing deltas can be interpreted as mode cost rather than script drift
+
+### Slice 4: Collection Benchmark Cutover
+
+Create a collection benchmark that uses the actual Core extraction path.
+
+Owned file areas:
+
+- `scripts/benchmarks/paper_facts_collection_benchmark.py`
+
+Exit criteria:
+
+- the benchmark can show extraction unit counts and end-to-end document timing
+  on one real collection
+
+### Slice 5: External Probe Deprecation
+
+Deprecate the date-folder scripts once the repo-owned scripts produce matching
+or better diagnostic output.
+
+Exit criteria:
+
+- the repo has one canonical benchmark path
+- operator guidance no longer points to the ad hoc local probes as the primary
+  measurement surface
+
+## Verification
+
+This wave should verify both usability and measurement integrity.
+
+Run checks like:
+
+```bash
+cd backend
+python3 ../scripts/check_docs_governance.py
+python scripts/benchmarks/llm_connectivity_probe.py --help
+python scripts/benchmarks/text_window_probe.py --help
+python scripts/benchmarks/paper_facts_collection_benchmark.py --help
+```
+
+Manual acceptance should confirm:
+
+- the same payload can be benchmarked in `raw_text`,
+  `raw_text_plus_validate`, and `provider_structured_parse`
+- explicit `--base-url --model --api-key` inputs are enough to run the scripts
+  without `backend/.env`
+- collection-level benchmarks expose selected-versus-raw extraction-unit counts
+
+## Non-Goals
+
+Do not use this wave to:
+
+- redesign Core extraction semantics
+- add a second production extraction path
+- keep adding one-off benchmark files outside the repository
+- broaden `scripts/benchmarks/` into a generic operations directory
+
+## Acceptance Standard
+
+This wave is done only when:
+
+- repo-owned benchmark scripts exist under `scripts/benchmarks/`
+- text-window benchmarking can compare raw text, local validation, and
+  provider-native structured parsing under one shared prompt path
+- collection-level extraction cost can be measured without hand-editing local
+  script paths
+- operator guidance points to the repo-owned scripts as the canonical benchmark
+  surface

--- a/backend/docs/plans/core/core-parsing-quality-hardening-plan.md
+++ b/backend/docs/plans/core/core-parsing-quality-hardening-plan.md
@@ -17,11 +17,13 @@ Core-owned path across `application/documents/`, `application/evidence/`, and
 `application/comparisons/`.
 
 For the broader roadmap, read
-[`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md).
+[`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md).
 For the earlier Core seam work, read
 [`core-stabilization-and-seam-extraction-plan.md`](core-stabilization-and-seam-extraction-plan.md).
+For the narrow PBF-metal validation wave under this quality plan, read
+[`pbf-metal-extraction-and-comparison-validation/README.md`](pbf-metal-extraction-and-comparison-validation/README.md).
 For the LLM hard-cutover child execution plan under this wave, read
-[`core-llm-structured-extraction-hard-cutover-plan.md`](core-llm-structured-extraction-hard-cutover-plan.md).
+[`../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md).
 For the traceback/document-viewer vertical slice under this plan, read
 [`claim-traceback-navigation-implementation-plan.md`](claim-traceback-navigation-implementation-plan.md).
 
@@ -269,10 +271,10 @@ Exit criteria:
 
 ## Related Docs
 
-- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md)
-- [`goal-core-source-contract-follow-up-plan.md`](../backend-wide/goal-core-source-contract-follow-up-plan.md)
+- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md)
+- [`goal-core-source-contract-follow-up-plan.md`](../backend-wide/goal-source-core-layering/contract-follow-up.md)
 - [`core-stabilization-and-seam-extraction-plan.md`](core-stabilization-and-seam-extraction-plan.md)
-- [`core-llm-structured-extraction-hard-cutover-plan.md`](core-llm-structured-extraction-hard-cutover-plan.md)
+- [`../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)
 - [`claim-traceback-navigation-implementation-plan.md`](claim-traceback-navigation-implementation-plan.md)
 - [`source-collection-builder-normalization-plan.md`](../source/source-collection-builder-normalization-plan.md)
 - [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)

--- a/backend/docs/plans/core/core-semantic-build-packaging-alignment-plan.md
+++ b/backend/docs/plans/core/core-semantic-build-packaging-alignment-plan.md
@@ -12,7 +12,7 @@ semantic-extraction concern across unrelated `application/core/*` files.
 
 This plan sits under the existing Core structured-extraction cutover wave:
 
-- [`core-llm-structured-extraction-hard-cutover-plan.md`](core-llm-structured-extraction-hard-cutover-plan.md)
+- [`../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)
 
 It is intentionally narrower than that parent wave. The parent wave decides
 that Core semantic extraction should hard-cut to schema-bound LLM parsing.
@@ -85,8 +85,8 @@ This plan covers:
   semantic-build path
 - preserving the current `Source -> Core -> derived` ownership direction while
   making the Source-to-Core handoff seam more legible
-- keeping the OpenAI-compatible transport implementation inside the owning Core
-  extractor path unless a later wave explicitly re-separates that seam
+- keeping the OpenAI transport implementation inside the owning Core extractor
+  path unless a later wave explicitly re-separates that seam
 
 This plan does not cover:
 
@@ -189,9 +189,8 @@ than co-owning extraction internals:
 
 ### Infra
 
-`infra/llm/` should continue to own only the external-transport seam.
-
-It should not absorb:
+If a separate transport seam is reintroduced later, it should stay narrow and
+must not absorb:
 
 - Core prompt text
 - Core extraction schema definitions
@@ -255,7 +254,7 @@ It should not absorb:
 
 ## Related Docs
 
-- [`core-llm-structured-extraction-hard-cutover-plan.md`](core-llm-structured-extraction-hard-cutover-plan.md)
+- [`../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)
 - [`../../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
 - [`../../architecture/overview.md`](../../architecture/overview.md)
 - [`../../../application/core/README.md`](../../../application/core/README.md)

--- a/backend/docs/plans/core/core-stabilization-and-seam-extraction-plan.md
+++ b/backend/docs/plans/core/core-stabilization-and-seam-extraction-plan.md
@@ -18,9 +18,9 @@ extraction. The current near-term Core quality priority is now recorded in
 [`core-parsing-quality-hardening-plan.md`](core-parsing-quality-hardening-plan.md).
 
 For the current HTTP and route migration state, read
-[`current-api-surface-migration-checklist.md`](../backend-wide/current-api-surface-migration-checklist.md).
+[`current-api-surface-migration-checklist.md`](../backend-wide/api-surface-migration/current-state.md).
 For the broader future-wave roadmap, read
-[`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md).
+[`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md).
 
 ## Context
 
@@ -250,8 +250,8 @@ Expected result:
 
 ## Related Docs
 
-- [`current-api-surface-migration-checklist.md`](../backend-wide/current-api-surface-migration-checklist.md)
-- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md)
+- [`current-api-surface-migration-checklist.md`](../backend-wide/api-surface-migration/current-state.md)
+- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md)
 - [`evidence-first-parsing-plan.md`](../historical/evidence-first-parsing-plan.md)
 - [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
 - [`../architecture/domain-architecture.md`](../../architecture/domain-architecture.md)

--- a/backend/docs/plans/core/core-text-window-atomic-mentions-plan.md
+++ b/backend/docs/plans/core/core-text-window-atomic-mentions-plan.md
@@ -1,0 +1,395 @@
+# Core Text-Window Atomic Mentions Plan
+
+## Summary
+
+This document records a focused Core child implementation plan for replacing
+the current text-window "one prompt emits the final bundle" extraction shape
+with a narrower two-step design:
+
+- the text-window LLM prompt emits observation-layer atomic mentions only
+- deterministic backend code binds those mentions into the existing Core
+  backbone artifacts
+
+The immediate target is the text-window extraction slice in
+`application/core/semantic_build/`. This is not a table-row redesign, not a
+new compatibility layer, and not a second model-binding stage.
+
+The narrow goal is to improve extraction precision where the current bundle
+shape is still coupling too many jobs into one model response:
+
+- methods, materials, variants, conditions, baselines, and results are still
+  being extracted in one highly coupled pass
+- the model still emits `anchors` even though anchor locator recovery already
+  belongs to the backend
+- prior-work or literature-summary claims can still contaminate
+  `measurement_results`
+- characterization methods can still be mistaken for `test_conditions`
+- baselines can still be invented from treatment presence rather than explicit
+  comparator language
+
+This plan works under the existing Core extraction wave and should be read
+with:
+
+- [`../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)
+- [`../../../application/core/semantic_build/llm/docs/structured-extraction/id-boundary.md`](../../../application/core/semantic_build/llm/docs/structured-extraction/id-boundary.md)
+- [`pbf-metal-extraction-and-comparison-validation/README.md`](pbf-metal-extraction-and-comparison-validation/README.md)
+
+## Why This Child Plan Exists
+
+The current text-window path still asks one schema-bound prompt to do too much
+in one pass. The model is expected to emit final-domain objects such as:
+
+- `method_facts`
+- `sample_variants`
+- `test_conditions`
+- `baseline_references`
+- `measurement_results`
+
+That shape is brittle because some of those outputs are direct observations and
+some are binding products that depend on other fields already being right.
+
+In practice, that creates five recurring failure modes:
+
+1. one window tries to do extraction, normalization, relation binding, and
+   evidence packaging all at once
+2. result objects can absorb background numbers such as prior-work summary
+   percentages
+3. characterization methods are easy to over-promote into test-condition
+   payloads
+4. baseline fields are easy to over-fill from implied control logic that the
+   paper did not state explicitly
+5. the model is still asked to emit `anchors` even though backend code already
+   owns quote matching and locator reconstruction
+
+The backend already contains the right permanent owner for the second half of
+the job:
+
+- anchor ids, locators, and `char_range` recovery are deterministic backend
+  work
+- result-to-variant, result-to-baseline, and result-to-condition linking is
+  already handled locally
+- final artifact materialization already happens in `paper_facts_service.py`
+
+The missing change is to narrow what the text-window prompt is responsible for.
+
+## Decision
+
+The Core text-window extraction path should switch from final-bundle emission
+to atomic mention extraction plus deterministic backend binding.
+
+That means:
+
+- the text-window LLM schema should emit observation-layer mentions rather than
+  final paper-fact artifacts
+- the model should emit exact `evidence_quote` values instead of `anchors`
+- `claim_scope` should be explicit on every extracted result claim
+- only `current_work` claims that are explicitly eligible should become
+  `measurement_results`
+- backend code should bind mentions into the existing Core artifact tables
+  without adding a compatibility shim
+
+This plan also fixes one naming decision for the backend:
+
+- use the existing repo-level scope vocabulary
+  `current_work | prior_work | literature_summary | review_summary | unclear`
+  instead of introducing a second parallel enum such as `current_study`
+
+This plan explicitly rejects:
+
+- a new adapter between atomic mentions and the real Core artifacts
+- a temporary dual-path text-window parser
+- model-generated locators, ids, or backend-facing anchors
+- moving table-row extraction into the same redesign wave by default
+- introducing a second LLM stage before deterministic binding has been tried
+
+## Scope
+
+This plan covers:
+
+- text-window LLM schema changes under
+  `application/core/semantic_build/llm/schemas.py`
+- text-window prompt changes under
+  `application/core/semantic_build/llm/prompts.py`
+- text-window parse entry changes under
+  `application/core/semantic_build/llm/extractor.py`
+- deterministic binding from atomic mentions into the existing Core artifact
+  bundle inside `application/core/semantic_build/paper_facts_service.py`
+- propagation of `claim_scope` into Core measurement-result materialization
+- targeted fake-extractor and unit-test updates for the new text-window path
+
+This plan does not cover:
+
+- table-row schema redesign in the same change set
+- replacing deterministic binding with a second model call
+- renaming stored artifact filenames
+- broad comparison-domain redesign beyond the minimum `claim_scope` gate
+- doc-family reshaping for the existing Core structured-extraction plan lineage
+
+## Target Shape
+
+### Text-Window Model Output
+
+The text-window prompt should return one observation-layer object with these
+collections:
+
+- `method_mentions`
+- `material_mentions`
+- `variant_mentions`
+- `condition_mentions`
+- `baseline_mentions`
+- `result_claims`
+
+The important boundary rule is that this stage records what the bounded text
+window explicitly says, not the final database objects the backend hopes to
+store.
+
+### Evidence Boundary
+
+The text-window model contract should stop emitting `anchors`.
+
+Instead, each emitted mention or claim should carry one exact
+`evidence_quote`, or multiple exact `evidence_quotes` if the field genuinely
+needs more than one supporting span.
+
+For text-window extraction, `evidence_quote` must satisfy all of these rules:
+
+- copied exactly from `text_window.text`
+- contiguous in the source text
+- not paraphrased
+- not shortened with ellipses
+- not merged from multiple disjoint spans
+
+The backend should remain the only owner of:
+
+- `page`
+- `source_type`
+- `document_id`
+- `section_id`
+- `block_id`
+- `snippet_id`
+- `char_range`
+- `bbox`
+- `deep_link`
+
+### Claim Scope And Result Eligibility
+
+Every `result_claim` should carry:
+
+- `claim_scope`
+- `eligible_for_measurement_result`
+
+The first extraction stage should classify claims into:
+
+- `current_work`
+- `prior_work`
+- `literature_summary`
+- `review_summary`
+- `unclear`
+
+Only `current_work` claims that remain explicitly eligible should become
+`measurement_results` in the default backend path.
+
+### Backend-Owned Binding
+
+The backend should turn atomic mentions into the current stored artifacts:
+
+- `method_facts`
+- `sample_variants`
+- `test_conditions`
+- `baseline_references`
+- `measurement_results`
+
+Binding should follow narrow deterministic rules:
+
+- bind only when the relation is explicit in the same evidence quote or is the
+  single unambiguous local candidate
+- do not invent baselines from treatment presence alone
+- do not convert characterization methods into test conditions
+- if relation binding is ambiguous, keep the field `null`
+
+## Execution Slices
+
+### Slice 1: Replace Text-Window Anchors With Exact Evidence Quotes
+
+Update the text-window schema so the model emits exact evidence quotes instead
+of `anchors`.
+
+Primary changes:
+
+- remove text-window `anchors` from the text-window LLM response model
+- add exact `evidence_quote` fields to text-window mention and claim payloads
+- update prompt rules so the model is told not to emit `anchors`
+- keep local anchor materialization backend-owned by matching quotes back to
+  the current text window
+
+Expected file areas:
+
+- `application/core/semantic_build/llm/schemas.py`
+- `application/core/semantic_build/llm/prompts.py`
+- `application/core/semantic_build/paper_facts_service.py`
+- `tests/unit/services/test_paper_facts_services.py`
+- `tests/support/fake_core_llm_extractor.py`
+
+Acceptance:
+
+- text-window prompts no longer ask the model for `anchors`
+- quote matching still produces stored `evidence_anchors`
+- traceback surfaces still recover `char_range` when the quote is found
+
+### Slice 2: Introduce Observation-Layer Text-Window Mentions
+
+Replace direct text-window final-bundle emission with an observation-layer
+schema.
+
+Primary changes:
+
+- add a text-window mention schema with method, material, variant, condition,
+  baseline, and result-claim collections
+- keep the current final artifact names for stored Core tables
+- make the prompt describe this stage as observation extraction rather than
+  final object assembly
+- require `claim_scope` on every result claim
+
+Expected file areas:
+
+- `application/core/semantic_build/llm/schemas.py`
+- `application/core/semantic_build/llm/prompts.py`
+- `application/core/semantic_build/llm/extractor.py`
+- `tests/support/fake_core_llm_extractor.py`
+
+Acceptance:
+
+- text-window parse accepts only the new mention-level shape
+- prompt examples no longer use `confidence: 0.0`
+- prior-work result statements can be represented without becoming final
+  `measurement_results`
+
+### Slice 3: Bind Atomic Mentions Into Existing Core Artifacts
+
+Add one deterministic backend binding pass that converts text-window mentions
+into the current Core artifact bundle.
+
+Primary changes:
+
+- create a narrow backend helper inside `paper_facts_service.py` that binds the
+  text-window mentions into the existing artifact payloads
+- keep all binding backend-owned and local to the real materialization path
+- avoid new wrapper classes or compatibility layers
+- keep table-row extraction on the current path until it is handled in a later
+  wave
+
+Binding rules:
+
+- `method_mentions` become `method_facts`
+- `material_mentions` and `variant_mentions` are combined into
+  `sample_variants` only when the relation is explicit or locally unique
+- `condition_mentions` become `test_conditions` only when they describe a
+  property-measurement environment, rate, temperature, duration, atmosphere,
+  loading case, or comparison condition
+- `baseline_mentions` become `baseline_references` only when comparator
+  language is explicit
+- `result_claims` become `measurement_results` only when they survive the
+  scope gate and relation binding
+
+Expected file areas:
+
+- `application/core/semantic_build/paper_facts_service.py`
+- `tests/unit/services/test_paper_facts_services.py`
+
+Acceptance:
+
+- text-window extraction no longer requires the model to emit final
+  `measurement_results`
+- variant, baseline, and condition fields are left empty rather than guessed
+  when binding is ambiguous
+- the current stored artifact filenames and read paths stay unchanged
+
+### Slice 4: Carry Claim Scope Into Measurement Results And Comparison Gating
+
+Preserve claim provenance after binding so downstream comparison logic can keep
+background claims out of the default comparison substrate.
+
+Primary changes:
+
+- add `claim_scope` to the stored Core `measurement_results` record shape
+- materialize the scope into the parquet output
+- block non-`current_work` results from the default comparison path
+
+Expected file areas:
+
+- `domain/core/evidence_backbone.py`
+- `application/core/semantic_build/paper_facts_service.py`
+- `application/core/comparison_assembly.py`
+- `tests/unit/services/test_paper_facts_services.py`
+
+Acceptance:
+
+- prior-work and literature-summary result claims no longer feed default
+  comparison rows
+- current-work claims keep the existing comparison flow when their other
+  required context is present
+
+### Slice 5: Leave Table-Row Redesign As A Follow-Up Wave
+
+Do not merge text-window redesign and table-row redesign into one first pass.
+
+The table-row path can stay on the current bundle shape in the first
+implementation wave because:
+
+- row cells already carry stronger local structure than text windows
+- text-window failures are the current prompt-coupling hotspot
+- splitting both paths at once would increase rollout risk and test churn
+
+This follow-up should revisit:
+
+- whether row extraction also moves from `anchors` to `evidence_quote`
+- whether row extraction benefits from the same observation-layer schema
+- whether any table-specific deterministic binder is needed
+
+## Verification
+
+When implementation begins, the minimum verification set should include:
+
+- text-window quote matching still reconstructs stored evidence anchors
+- prior-work claims do not become `measurement_results`
+- characterization methods such as contour method or neutron diffraction do
+  not become `test_conditions`
+- treatment-only statements do not invent baselines without explicit
+  comparator language
+- locally ambiguous variant or baseline relations stay unbound
+
+Targeted commands:
+
+```bash
+cd backend
+uv run pytest tests/unit/services/test_paper_facts_services.py
+```
+
+If comparison gating changes in the same wave, add the smallest relevant
+comparison test slice as well.
+
+## File Areas
+
+The first implementation wave should stay tightly scoped to:
+
+- `backend/application/core/semantic_build/llm/schemas.py`
+- `backend/application/core/semantic_build/llm/prompts.py`
+- `backend/application/core/semantic_build/llm/extractor.py`
+- `backend/application/core/semantic_build/paper_facts_service.py`
+- `backend/domain/core/evidence_backbone.py`
+- `backend/application/core/comparison_assembly.py` only if the
+  `claim_scope` gate lands immediately
+- `backend/tests/support/fake_core_llm_extractor.py`
+- `backend/tests/unit/services/test_paper_facts_services.py`
+
+## Related Docs
+
+- [`core-parsing-quality-hardening-plan.md`](core-parsing-quality-hardening-plan.md)
+  Parent Core quality wave
+- [`../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)
+  Earlier Core extraction cutover plan
+- [`../../../application/core/semantic_build/llm/docs/structured-extraction/id-boundary.md`](../../../application/core/semantic_build/llm/docs/structured-extraction/id-boundary.md)
+  Prompt and schema boundary cleanup that this plan extends
+- [`pbf-metal-extraction-and-comparison-validation/proposal.md`](pbf-metal-extraction-and-comparison-validation/proposal.md)
+  Proposal page for the narrow PBF-metal validation wave that exposed the
+  prompt-coupling and claim-scope problems more clearly

--- a/backend/docs/plans/core/document-profile-lightweight-triage-plan.md
+++ b/backend/docs/plans/core/document-profile-lightweight-triage-plan.md
@@ -19,13 +19,13 @@ It does not justify expanding scope into `evidence_cards`, comparison
 assembly, Source restructuring, or API-wide contract cleanup.
 
 For the broader backend roadmap, read
-[`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md).
+[`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md).
 For the shared domain-model correction, read
 [`../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md`](../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md).
 For the parent Core quality wave, read
 [`core-parsing-quality-hardening-plan.md`](core-parsing-quality-hardening-plan.md).
 For the broader Core LLM cutover plan, read
-[`core-llm-structured-extraction-hard-cutover-plan.md`](core-llm-structured-extraction-hard-cutover-plan.md).
+[`../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md).
 
 ## Why This Child Plan Exists
 

--- a/backend/docs/plans/core/minimal-core-domain-backfill-plan.md
+++ b/backend/docs/plans/core/minimal-core-domain-backfill-plan.md
@@ -21,8 +21,8 @@ Read this plan with:
 - [`../architecture/domain-architecture.md`](../../architecture/domain-architecture.md)
 - [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
 - [`../architecture/core-comparison/README.md`](../../architecture/core-comparison/README.md)
-- [`goal-source-core-business-layer-alignment-plan.md`](../backend-wide/goal-source-core-business-layer-alignment-plan.md)
-- [`materials-comparison-v2-plan.md`](../backend-wide/materials-comparison-v2-plan.md)
+- [`goal-source-core-business-layer-alignment-plan.md`](../backend-wide/goal-source-core-layering/proposal.md)
+- [`materials-comparison-v2-plan.md`](../backend-wide/materials-comparison-v2/implementation-plan.md)
 - [`../historical/comparable-result/core-comparable-result-domain-model-plan.md`](../historical/comparable-result/core-comparable-result-domain-model-plan.md)
 - [`../historical/comparable-result/core-comparable-result-evolution-roadmap-plan.md`](../historical/comparable-result/core-comparable-result-evolution-roadmap-plan.md)
 
@@ -454,9 +454,9 @@ directly in each wave.
 
 This plan follows, but does not replace:
 
-- [`goal-source-core-business-layer-alignment-plan.md`](../backend-wide/goal-source-core-business-layer-alignment-plan.md)
+- [`goal-source-core-business-layer-alignment-plan.md`](../backend-wide/goal-source-core-layering/proposal.md)
   which made the business-layer split visible in package layout
-- [`materials-comparison-v2-plan.md`](../backend-wide/materials-comparison-v2-plan.md)
+- [`materials-comparison-v2-plan.md`](../backend-wide/materials-comparison-v2/implementation-plan.md)
   which established the stronger sample/result Core backbone
 - [`../../architecture/core-comparison/decision.md`](../../architecture/core-comparison/decision.md)
   which is the current authority for `ComparableResult` as the semantic center

--- a/backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/README.md
+++ b/backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/README.md
@@ -1,0 +1,53 @@
+# PBF-Metal Extraction And Comparison Validation
+
+This topic family records the Core execution wave for validating the Lens
+comparison backbone on a narrow PBF-metal corpus.
+
+This is a narrow Core topic-proof family. It does not own the shared
+evidence-chain contract and it does not replace the backend-wide implementation
+family for product-surface cutover.
+
+The family keeps three live pages because this local subject now needs:
+
+- a proposal page that explains why this wave exists, what semantic center it
+  protects, and what outcomes it is trying to prove
+- a scope page that narrows the long metal-AM parameter ontology into a
+  first-version parameter registry boundary and Material Variant Report surface
+- a backend drilldown plan that explains how Core should expose variant
+  dossiers, result chains, and result-series projections without adding a new
+  top-level artifact family
+- an implementation plan that turns that direction into executable delivery
+  slices, file areas, and verification commands
+
+## Reading Order
+
+- [`proposal.md`](proposal.md)
+  Why the current extraction path, Core schema, and comparability rules need a
+  narrow PBF-metal validation wave
+- [`parameter-registry-and-variant-report-scope.md`](parameter-registry-and-variant-report-scope.md)
+  Narrow the long LPBF and EB-PBF parameter ontology into a backend registry
+  boundary and first-version Material Variant Report field set
+- [`variant-dossier-and-result-chain-backend-plan.md`](variant-dossier-and-result-chain-backend-plan.md)
+  Narrow backend plan for dossier, chain, and series projections over the
+  existing Core semantic backbone
+- [`implementation-plan.md`](implementation-plan.md)
+  Delivery slices, owned file areas, verification commands, and acceptance
+  gates for the execution wave
+
+## Related Docs
+
+- [`../../../../../docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md`](../../../../../docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md)
+  Shared cross-module roadmap and overall planning entry point for this wave
+- [`../../../../../docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md`](../../../../../docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md)
+  Shared additive contract freeze for document and result drilldown
+- [`../../backend-wide/evidence-chain-product-surface/README.md`](../../backend-wide/evidence-chain-product-surface/README.md)
+  Backend-wide implementation companion for the evidence-chain product surface
+- [`../core-parsing-quality-hardening-plan.md`](../core-parsing-quality-hardening-plan.md)
+  Parent Core quality wave
+- [`../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)
+  Earlier structured-extraction cutover plan that this wave narrows and
+  hardens
+- [`../../../architecture/core-comparison/current-state.md`](../../../architecture/core-comparison/current-state.md)
+  Current implemented comparison-semantic substrate
+- [`../../backend-wide/materials-comparison-v2/implementation-plan.md`](../../backend-wide/materials-comparison-v2/implementation-plan.md)
+  Broader backend-local materials comparison backbone direction

--- a/backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/implementation-plan.md
+++ b/backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/implementation-plan.md
@@ -1,0 +1,393 @@
+# PBF-Metal Extraction And Comparison Validation Implementation Plan
+
+## Summary
+
+This document turns the PBF-metal validation proposal into an executable Core
+delivery plan.
+
+The plan keeps one rule fixed throughout execution:
+
+`document_profiles -> paper facts family -> comparable_results -> collection_comparable_results -> row projection`
+
+This wave should not expand the architecture. It should tighten the current
+Core path until it is fast enough and precise enough to support PBF-metal
+comparison work on a small fixed corpus.
+
+Read this plan with:
+
+- [`../../../../../docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md`](../../../../../docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md)
+- [`README.md`](README.md)
+- [`proposal.md`](proposal.md)
+- [`parameter-registry-and-variant-report-scope.md`](parameter-registry-and-variant-report-scope.md)
+- [`variant-dossier-and-result-chain-backend-plan.md`](variant-dossier-and-result-chain-backend-plan.md)
+- [`../core-parsing-quality-hardening-plan.md`](../core-parsing-quality-hardening-plan.md)
+- [`../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)
+
+## Delivery Shape
+
+This wave should ship in four implementation slices plus one acceptance slice.
+
+1. Freeze the semantic center and benchmark baseline.
+2. Reduce extraction cost on the current Core path.
+3. Add the narrow PBF-metal semantic extension.
+4. Tighten comparable-result assembly and comparability rules.
+5. Lock the wave against the fixed PBF-metal gold corpus.
+
+Each slice should be independently reviewable and verifiable.
+
+## Slice 1: Baseline And Semantic-Center Freeze
+
+### Goal
+
+Start the wave from one fixed semantic contract and one measurable extraction
+baseline.
+
+### Changes
+
+- align shared and backend docs so they describe the same semantic backbone
+- preserve the current known-slow collection as a benchmark reference
+- define the initial PBF-metal corpus manifest and failure taxonomy
+- identify which extraction units are currently being sent to the model on the
+  known slow path
+
+### Owned file areas
+
+- `README.md`
+- `docs/contracts/lens-v1-definition.md`
+- `docs/contracts/lens-core-artifact-contracts.md`
+- `backend/docs/architecture/overview.md`
+- `backend/docs/architecture/core-comparison/current-state.md`
+- `backend/docs/specs/api.md`
+- `backend/tests/fixtures/` or a nearby backend-local fixture subtree for the
+  PBF-metal corpus manifest
+- `tests/unit/services/test_paper_facts_services.py`
+
+### Verification
+
+Run:
+
+```bash
+cd backend
+python3 ../scripts/check_docs_governance.py
+uv run pytest tests/unit/services/test_paper_facts_services.py
+```
+
+Record before-change measurements for:
+
+- extraction unit count per document
+- average text-window call time
+- average table-row call time
+- whole-document extraction time on the known slow collection
+
+### Exit criteria
+
+- active docs point to one semantic center
+- the benchmark corpus and failure taxonomy are fixed enough to compare later
+  slices
+- current latency and call-count numbers are written down before changing the
+  extraction path
+
+## Slice 2: Extraction Cost Reduction
+
+### Goal
+
+Cut the number and cost of Core extraction calls before adding more vertical
+schema detail.
+
+### Changes
+
+- add deterministic candidate pruning in
+  `application/core/semantic_build/paper_facts_service.py`
+- skip clearly low-value blocks such as references, acknowledgements, and
+  most introduction-only history windows
+- make table rows the default parameter-first extraction unit for PBF-metal
+  papers
+- reduce text windows to supporting context for method or result enrichment
+- replace provider-native strict structured output with JSON text plus local
+  Pydantic validation in `application/core/semantic_build/llm/extractor.py`
+- add bounded concurrency for extraction calls while keeping
+  `_materialize_bundle()` ordered and deterministic
+
+### Owned file areas
+
+- `application/core/semantic_build/llm/extractor.py`
+- `application/core/semantic_build/llm/prompts.py`
+- `application/core/semantic_build/llm/schemas.py`
+- `application/core/semantic_build/paper_facts_service.py`
+- `tests/support/fake_core_llm_extractor.py`
+- `tests/unit/services/test_paper_facts_services.py`
+
+### Verification
+
+Run:
+
+```bash
+cd backend
+uv run pytest tests/unit/services/test_paper_facts_services.py
+uv run pytest tests/integration/services/test_task_runner.py
+```
+
+Then rerun the benchmark collection and compare:
+
+- extraction unit count
+- average call time
+- whole-document extraction time
+
+### Exit criteria
+
+- the known slow collection no longer sends exhaustive low-value windows to the
+  model
+- the per-call path returns on a seconds-scale budget rather than the current
+  tens-of-seconds structured-output path
+- ordered materialization still produces stable artifact shapes
+
+## Slice 3: Narrow PBF-Metal Semantic Extension
+
+### Goal
+
+Add only the PBF-metal fields needed for reliable comparison, without creating
+another permanent module tree yet.
+
+The first-version field boundary for this slice is defined in
+[`parameter-registry-and-variant-report-scope.md`](parameter-registry-and-variant-report-scope.md).
+
+### Changes
+
+- extend `MethodFact`, `SampleVariant`, `TestCondition`, or
+  `MeasurementResult` payloads only where PBF-metal structure is needed
+- add explicit support for process parameters such as:
+  - `laser_power_w`
+  - `scan_speed_mm_s`
+  - `layer_thickness_um`
+  - `hatch_spacing_um`
+  - `spot_size_um`
+  - `energy_density_j_mm3`
+  - `scan_strategy`
+  - `build_orientation`
+  - `preheat_temperature_c`
+  - `shielding_gas`
+  - `oxygen_level_ppm`
+  - `powder_size_distribution_um`
+- normalize PBF-metal result/property identities for:
+  - `relative_density_percent`
+  - `porosity_percent`
+  - `residual_stress_mpa`
+  - `yield_strength_mpa`
+  - `ultimate_tensile_strength_mpa`
+  - `elongation_percent`
+  - `hardness_hv`
+  - `surface_roughness_ra_um`
+- add `claim_scope` and `value_origin` support to `measurement_results`
+- preserve `source_value_text`, `source_unit_text`, and `derivation_formula`
+  when a value is not directly reported
+
+### Owned file areas
+
+- `application/core/semantic_build/llm/schemas.py`
+- `application/core/semantic_build/llm/prompts.py`
+- `domain/core/evidence_backbone.py`
+- `application/core/semantic_build/paper_facts_service.py`
+- `tests/support/fake_core_llm_extractor.py`
+- `tests/unit/services/test_paper_facts_services.py`
+
+### Verification
+
+Run:
+
+```bash
+cd backend
+uv run pytest tests/unit/services/test_paper_facts_services.py
+uv run pytest tests/unit/services/test_workspace_service.py
+```
+
+Manual acceptance should confirm:
+
+- table-derived LPBF parameters land in explicit structured fields
+- introduction or prior-work text no longer produces comparison-ready current
+  results
+- derived energy density can be distinguished from a reported energy density
+
+### Exit criteria
+
+- process parameters are not collapsing into generic free-text payloads when
+  strong evidence exists
+- `claim_scope` and `value_origin` survive storage and restore paths
+
+## Slice 4: Comparable-Result Assembly And PBF Comparability Rules
+
+### Goal
+
+Make comparable-result assembly and collection overlays reflect PBF-metal
+missingness and provenance rather than only generic row readiness.
+
+### Changes
+
+- gate comparable-result assembly on `claim_scope == current_work`
+- keep prior-work and review-summary measurements outside the default
+  comparable-result path
+- extend `evaluate_comparison_assessment()` with narrow PBF rules:
+  - missing `build_orientation` for orientation-sensitive properties ->
+    `limited`
+  - missing baseline on improvement-style claims -> `insufficient`
+  - derived energy density with missing source parameters -> `insufficient`
+  - missing test orientation for tensile or residual-stress style results ->
+    `limited`
+- update row-facing warnings only when the extra fields are needed in
+  comparison displays
+
+### Owned file areas
+
+- `application/core/comparison_assembly.py`
+- `domain/core/comparison.py`
+- `application/core/comparison_projection.py` only if projection payloads need
+  new warnings
+- `tests/unit/domains/test_comparison_domain.py`
+- `tests/unit/services/test_paper_facts_services.py`
+- `tests/integration/test_app_layer_api.py`
+
+### Verification
+
+Run:
+
+```bash
+cd backend
+uv run pytest tests/unit/domains/test_comparison_domain.py
+uv run pytest tests/unit/services/test_paper_facts_services.py
+uv run pytest tests/integration/test_app_layer_api.py
+```
+
+### Exit criteria
+
+- `comparable`, `limited`, `insufficient`, and `not_comparable` track the
+  obvious PBF review constraints better than the generic baseline
+- collection-facing rows still project cleanly from semantic and scope
+  artifacts
+
+## Slice 5: Gold-Corpus Lock And Acceptance
+
+### Goal
+
+Finish the wave with repeatable evidence, not only local examples.
+
+### Changes
+
+- freeze the first 30-paper PBF-metal corpus
+- annotate the minimum fields needed by this wave:
+  - alloy and material system
+  - powder condition when reported
+  - process parameters
+  - post-processing history
+  - target property, value, and unit
+  - baseline relationship
+  - test condition
+  - `claim_scope`
+  - `value_origin`
+  - source anchors
+  - final comparability status
+- extend existing Core tests to assert against the fixed corpus
+- record benchmark deltas against the slice-1 baseline
+
+### Owned file areas
+
+- `tests/fixtures/` or another owned backend-local test-data subtree
+- `tests/unit/services/test_paper_facts_services.py`
+- `tests/unit/domains/test_comparison_domain.py`
+- `tests/integration/test_app_layer_api.py`
+
+### Verification
+
+Run:
+
+```bash
+cd backend
+uv run pytest tests/unit/services/test_paper_facts_services.py
+uv run pytest tests/unit/domains/test_comparison_domain.py
+uv run pytest tests/integration/test_app_layer_api.py
+```
+
+Acceptance metrics should include:
+
+- key process-parameter recall
+- `claim_scope` precision
+- false-comparable rate
+- row-to-anchor traceback reviewability
+- whole-document extraction time improvement relative to the slice-1 baseline
+
+### Exit criteria
+
+- the wave can show both semantic-quality gains and runtime gains on the fixed
+  PBF-metal corpus
+- the backend can explain where a comparison result came from and why it is or
+  is not comparable
+
+## Pull Request Sequence
+
+### PR 1: Semantic-Center Freeze And Corpus Baseline
+
+Include:
+
+- doc wording alignment
+- corpus manifest and failure taxonomy
+- baseline benchmark notes
+
+Keep this PR doc-heavy and low-risk.
+
+### PR 2: Extraction Cost Reduction
+
+Include:
+
+- candidate pruning
+- JSON-text extraction cutover
+- bounded extraction concurrency
+
+Keep this PR focused on latency and extraction-unit reduction.
+
+### PR 3: PBF Semantic Extension
+
+Include:
+
+- explicit PBF process parameters
+- `claim_scope`
+- `value_origin`
+- storage and restore support
+
+Keep this PR focused on fact semantics rather than policy.
+
+### PR 4: Comparability Rules And Gold-Corpus Lock
+
+Include:
+
+- comparable-result gating
+- PBF comparability rules
+- fixed corpus assertions
+- benchmark deltas
+
+Keep this PR focused on assessment behavior and acceptance evidence.
+
+## Non-Goals During This Wave
+
+Do not use this wave to:
+
+- add a new permanent `backend/domain/materials/*` tree
+- redesign graph, report, or protocol surfaces
+- build a generic materials ontology platform
+- create a second permanent Core extraction path
+- expand the corpus beyond what is needed to validate the PBF-metal loop
+
+## Acceptance Standard
+
+This wave is done only when all of the following are true:
+
+- the repository describes one semantic center
+- extraction latency is materially lower on the known slow collection
+- PBF process parameters and result provenance are explicitly represented
+- comparable-result assembly excludes prior-work and review-summary leakage
+- collection overlays express PBF-specific comparability limits
+- the fixed gold corpus shows measurable improvement against the baseline
+
+## Related Docs
+
+- [`README.md`](README.md)
+- [`proposal.md`](proposal.md)
+- [`../core-parsing-quality-hardening-plan.md`](../core-parsing-quality-hardening-plan.md)
+- [`../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)

--- a/backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/parameter-registry-and-variant-report-scope.md
+++ b/backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/parameter-registry-and-variant-report-scope.md
@@ -1,0 +1,359 @@
+# PBF-Metal Parameter Registry And Variant Report Scope
+
+## Summary
+
+This document records how the long LPBF and EB-PBF metal parameter table
+should be used in the current PBF-metal validation wave.
+
+The table is a domain ontology seed and backend parameter registry input.
+
+It is not:
+
+- the first-version extraction field list
+- the first-version user-facing report schema
+- a flat UI table that exposes every possible metal-AM parameter at once
+
+The first version should narrow that ontology into one evidence-backed
+Material Variant Report that is precise enough for review and comparison.
+
+## Placement In The Stack
+
+The parameter table belongs in this order:
+
+```text
+domain parameter registry
+-> extraction schema
+-> paper facts
+-> material variant report
+-> comparison view
+```
+
+That placement keeps one clear separation:
+
+- the registry defines what the system can recognize and normalize
+- `paper_facts` records extracted and traceable facts
+- the Material Variant Report decides what the reader sees first
+
+The report should stay reader-centered. The registry can stay broader.
+
+## First-Version Boundary
+
+The first version should not try to support the whole ontology.
+
+The first version should support roughly three dozen Level 1 fields that are
+enough to answer the core PBF-metal review questions:
+
+- what alloy or material system is this
+- what powder condition was used
+- what process window defined the variant
+- what post-processing changed the final state
+- how good was the build quality
+- what property results were reported
+- what microstructure evidence explains those results
+- where is the source evidence
+
+Everything outside that first boundary should stay secondary or deferred even
+if it remains in the long-term parameter registry.
+
+## Level 1 Fields
+
+These fields define the first-version Material Variant Report scope.
+
+### Material Identity
+
+- `alloy_designation`
+- `nominal_composition`
+
+### Feedstock Powder
+
+- `particle_size_median`
+- `particle_size_bounds`
+- `oxygen_in_powder`
+- `carbon_in_powder`
+- `nitrogen_in_powder`
+- `apparent_powder_density`
+- `tap_powder_density`
+- `hall_flow_time`
+
+### Core PBF Process Parameters
+
+- `pbf_modality`
+- `laser_power`
+- `scan_speed`
+- `hatch_spacing`
+- `layer_thickness`
+- `volumetric_energy_density`
+- `build_orientation`
+- `chamber_oxygen_content`
+- `process_gas_composition`
+- `substrate_preheat_temperature`
+
+### Post-Processing
+
+- `hot_isostatic_pressing_cycle`
+- `solution_and_aging_treatment`
+
+### Build Quality
+
+- `relative_density`
+- `porosity_volume_fraction`
+- `lack_of_fusion_defect_fraction`
+- `surface_roughness_ra`
+
+### Mechanical Properties
+
+- `yield_strength`
+- `ultimate_tensile_strength`
+- `elongation_at_fracture`
+- `vickers_hardness`
+- `fatigue_life`
+- `fatigue_strength`
+
+### Microstructure
+
+- `grain_size`
+- `texture_strength`
+- `phase_volume_fraction`
+- `residual_stress`
+
+This is enough for a first report surface without turning the backend into a
+generic parameter warehouse.
+
+## Level 2 Fields
+
+These fields may be recognized and stored when evidence is strong, but they
+should stay out of the first report summary and out of the first hard
+acceptance scope:
+
+- `angle_of_repose`
+- `hausner_ratio`
+- `true_powder_density`
+- `gas_flow_rate`
+- `beam_spot_diameter`
+- `defocus_distance`
+- `interlayer_hatch_rotation`
+- `scan_strategy_class`
+- `contour_laser_power`
+- `contour_scan_speed`
+- `core_laser_power`
+- `number_of_contour_passes`
+- `melt_pool_depth`
+- `melt_pool_width`
+- `melt_pool_length`
+- `cooling_rate`
+- `thermal_gradient`
+
+These are valid advanced fields. They are not the first review surface.
+
+## Level 3 Fields
+
+These fields are useful for later mechanistic and crystallographic work, but
+they should not be a first-version extraction commitment:
+
+- `space_group_number`
+- `lattice_parameter_a`
+- `lattice_parameter_c`
+- `c_over_a_ratio`
+- `high_angle_grain_boundary_fraction`
+- `low_angle_grain_boundary_fraction`
+- `sigma3_twin_boundary_fraction`
+- `taylor_factor`
+- `schmid_factor`
+- `dislocation_density`
+- `gnd_density`
+- `precipitate_mean_radius`
+- `precipitate_volume_fraction`
+- `precipitate_number_density`
+- `inclusion_volume_fraction`
+
+## Level 4 Fields
+
+These fields should stay outside the first-version scope even if they remain
+valid future registry entries:
+
+- `recoater_type`
+- `recoater_speed`
+- `stripe_width`
+- `island_size`
+- `island_overlap`
+- `vector_length`
+- `laser_duty_cycle`
+- `pulse_repetition_frequency`
+- `pulse_width`
+- `pulse_energy`
+- `peak_laser_power`
+- `baseplate_thickness`
+- `build_plate_temperature_uniformity`
+- `laser_to_laser_stitch_offset`
+- `multi_laser_overlap_width`
+- `spatter_mass_rate`
+- `denudation_zone_width`
+- `powder_layer_packing_fraction`
+
+## Reader-Facing Report Shape
+
+The first front-end surface should not show the ontology as a 100-plus-column
+parameter table.
+
+The first front-end surface should be a Material Variant Report with these
+sections:
+
+1. Variant summary
+   - alloy, modality, defining process window, post-treatment, confidence
+2. Feedstock
+   - powder size, oxygen, powder density, flowability when reported
+3. Processing parameters
+   - power, speed, hatch spacing, layer thickness, VED, atmosphere, preheat
+4. Post-processing
+   - HIP and heat-treatment history
+5. Build quality
+   - density, porosity, lack-of-fusion fraction, roughness
+6. Mechanical properties
+   - yield strength, UTS, elongation, hardness, fatigue when relevant
+7. Microstructure
+   - grain size, texture, phase fraction, residual stress
+8. Comparison and baseline
+   - current variant versus explicit baseline or untreated state
+9. Evidence and warnings
+   - source quotes, unresolved bindings, missing context, value-origin warnings
+
+This shape keeps the primary reader job intact:
+
+review one variant, understand the process and result state, then compare it
+against adjacent variants.
+
+## Registry And Fact Model
+
+The ontology should enter the backend as a parameter registry, not as a fixed
+report table.
+
+One registry record should look like:
+
+```json
+{
+  "parameter_id": "laser_power",
+  "full_name": "Laser Power",
+  "aliases": ["laser power", "P"],
+  "category": "process_parameter",
+  "canonical_unit": "W",
+  "units_allowed": ["W", "kW"],
+  "domain": ["metal_am", "lpbf"],
+  "mvp_level": 1,
+  "applies_to": "variant",
+  "display_priority": "primary",
+  "is_derived": false,
+  "comparable_required_context": []
+}
+```
+
+One extracted fact should bind back to that registry:
+
+```json
+{
+  "parameter_id": "laser_power",
+  "value": 280,
+  "unit": "W",
+  "value_origin": "reported",
+  "source_anchor_ids": ["anchor_123"],
+  "applies_to_variant_id": "variant_456",
+  "confidence": 0.91
+}
+```
+
+This avoids hard-coding every future field into one ever-growing variant row
+schema.
+
+## Binding And Normalization Rules
+
+The first-version implementation should keep five rules explicit.
+
+### Variant-Defining Fields And Result Fields Stay Separate
+
+Process variables such as `laser_power`, `scan_speed`, `layer_thickness`, and
+`solution_and_aging_treatment` define the variant.
+
+Measured outcomes such as `yield_strength`, `relative_density`, `porosity`,
+and `grain_size` describe the variant state or result.
+
+They should not be flattened into one undifferentiated parameter bag.
+
+### Reported And Derived Values Stay Separate
+
+The backend should preserve `value_origin` using the same minimum vocabulary
+already planned for the PBF-metal wave:
+
+- `reported`
+- `derived`
+- `normalized`
+- `inferred`
+
+This is especially important for volumetric energy density.
+
+The system must distinguish:
+
+- a value directly reported by the paper
+- a value derived locally from power, speed, hatch spacing, and layer
+  thickness
+
+Supporting fields should preserve:
+
+- `source_value_text`
+- `source_unit_text`
+- `derivation_formula`
+
+### Required Context Drives Comparability
+
+Result facts need required context before they can become reliable comparison
+objects.
+
+Examples:
+
+- `yield_strength` should carry test method, temperature, strain rate, and
+  orientation when available
+- `fatigue_life` should carry stress amplitude, R-ratio, frequency, and runout
+  criterion when available
+- `residual_stress` should carry method and measurement direction when
+  available
+
+Missing required context should degrade comparison readiness rather than being
+silently ignored.
+
+### LLM Output Should Stay Narrow
+
+The model should identify raw parameter mentions, result claims, and evidence
+quotes.
+
+Deterministic backend code should own:
+
+- alias matching
+- unit parsing
+- canonical `parameter_id` binding
+- `value_origin` assignment
+- normalization into report sections
+
+This matches the existing direction to keep text-window extraction atomic and
+keep backend binding deterministic.
+
+### Unresolved Bindings Should Stay Visible
+
+If a parameter phrase cannot be bound to a canonical registry entry or to one
+variant state, the system should keep that missingness explicit.
+
+The report should surface unresolved or low-confidence facts as warnings
+rather than flattening them into normal comparison output.
+
+## Effect On The Current Validation Wave
+
+This scope sharpens the current PBF-metal plan family in four ways.
+
+1. Slice 3 should target the Level 1 field set first, not the whole ontology.
+2. The first user-facing acceptance surface should be the Material Variant
+   Report, not a raw parameter spreadsheet.
+3. The long parameter table should become backend registry input, not a fixed
+   UI or storage table.
+4. LLM prompts should optimize for recognizable parameter mentions and
+   evidence quotes, while deterministic backend code owns final parameter
+   binding.
+
+That keeps the current wave focused on report usefulness and evidence-backed
+comparison rather than ontology completeness.

--- a/backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/proposal.md
+++ b/backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/proposal.md
@@ -1,0 +1,531 @@
+# PBF-Metal Extraction And Comparison Validation Proposal
+
+## Summary
+
+This document records the next Core child execution wave for validating the
+Lens comparison backbone on a narrow PBF-metal corpus while reducing the
+current extraction latency and semantic drift.
+
+The target loop for this wave is:
+
+`document_profiles -> paper facts family -> comparable_results -> collection_comparable_results -> row projection`
+
+The goal is not to add another architecture layer.
+
+The goal is to make the current Core backbone fast enough, narrow enough, and
+domain-specific enough to support trustworthy PBF-metal comparison work.
+
+This child plan belongs to the Core plan family because the owned work is
+primarily:
+
+- Core fact extraction behavior
+- Core comparison-semantic assembly
+- Core comparability policy
+- Core evaluation and regression coverage
+
+It does include a small shared-doc cleanup so the repository stops presenting
+multiple competing semantic backbones, but that documentation alignment is a
+companion update rather than the main owning scope.
+
+Read this plan after:
+
+- [`README.md`](README.md)
+- [`parameter-registry-and-variant-report-scope.md`](parameter-registry-and-variant-report-scope.md)
+- [`implementation-plan.md`](implementation-plan.md)
+- [`../core-parsing-quality-hardening-plan.md`](../core-parsing-quality-hardening-plan.md)
+- [`../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)
+- [`../../../architecture/core-comparison/current-state.md`](../../../architecture/core-comparison/current-state.md)
+- [`../../backend-wide/materials-comparison-v2/implementation-plan.md`](../../backend-wide/materials-comparison-v2/implementation-plan.md)
+
+## Why This Wave Exists
+
+The current backend direction is broadly correct:
+
+- `paper_facts` has replaced claim cards as the primary research object layer
+- `comparable_results` and `collection_comparable_results` now carry the
+  comparison-semantic truth
+- `comparison_rows` is already a projection rather than the semantic source of
+  truth
+
+But the current runtime still has three concrete problems.
+
+### The repository still describes more than one semantic center
+
+Current backend and shared docs still mix old and new language:
+
+- older pages still describe the backbone as
+  `document_profiles -> evidence_cards -> comparison_rows`
+- newer pages describe the implemented backbone as
+  `document_profiles -> paper facts family -> comparable_results -> collection_comparable_results -> row projection`
+
+That mismatch makes it harder to extend the right objects and easier to
+reintroduce row-first or card-first logic by accident.
+
+### The current extraction path is too slow for real collections
+
+Recent runtime and standalone probe work showed that the main bottleneck is
+not PDF parsing and not local row projection.
+
+The main bottleneck is the current serial Core extraction path:
+
+- one 2 MB collection input spent hours in `paper_facts` extraction
+- the slow path was `221` serial structured LLM calls over text windows and
+  table rows
+- observed structured-output calls were often tens of seconds each
+- the same prompt shape without provider-native strict structured output was
+  materially faster in standalone probes
+
+This means the next wave should reduce unnecessary extraction units and stop
+depending on provider-side strict structured-output enforcement for every Core
+call.
+
+### The current schema is still too generic for the target PBF-metal job
+
+The current `paper_facts` family is more realistic than a claim-card-only
+backbone, but the active target job is not generic materials summarization.
+
+The near-term user job is PBF-metal comparison:
+
+- process parameters
+- post-processing history
+- test conditions
+- baseline relationships
+- property outcomes
+- evidence-backed comparability limits
+
+Without explicit support for those PBF-specific facts, the system falls back to
+generic text payloads and weak normalization, which makes downstream
+comparability judgments unstable.
+
+## Decision
+
+The next Core execution wave should do four things together rather than as
+isolated follow-up tasks:
+
+1. align repository language around one semantic center
+2. reduce extraction cost before broadening the schema again
+3. add a narrow PBF-metal semantic extension to the current Core fact objects
+4. validate the end-to-end comparison loop on a small gold corpus
+
+This plan rejects three common failure modes:
+
+- continuing to expand generic schema breadth without narrowing the target
+  vertical
+- keeping provider-native strict structured output on every extraction call
+  just because the backend model is structured
+- continuing to tune comparison quality only by anecdote instead of a fixed
+  benchmark corpus
+
+## Target Outcome
+
+At the end of this wave, the backend should support one reviewable and
+measurable workflow:
+
+1. upload about 30 PBF-metal papers
+2. extract `paper_facts`
+3. assemble `comparable_results`
+4. assess collection overlays
+5. project comparison rows
+6. inspect each result through anchors back to source text or tables
+
+That workflow should answer five practical questions for the researcher:
+
+- which results are comparable
+- why some results are only limited or insufficient
+- which parameters are missing
+- which studies are closest to the target process window
+- where the evidence lives in the source paper
+
+## Scope
+
+This child plan covers:
+
+- semantic-center wording alignment across backend and shared docs
+- candidate pruning for Core fact extraction units
+- table-first and result-first extraction narrowing for PBF-metal papers
+- replacing provider-native strict structured output with local schema
+  validation over JSON text responses
+- bounded extraction concurrency before deterministic Core materialization
+- a PBF-metal vertical payload extension inside existing Core fact objects
+- `claim_scope` and `value_origin` support in Core facts and comparison
+  semantics
+- PBF-specific normalization and comparability rules
+- a 30-paper PBF-metal gold corpus and repeatable benchmark checks
+
+This child plan does not cover:
+
+- a new `materials` subdomain package in the first implementation wave
+- graph, report, or protocol surface redesign
+- frontend IA or review-workflow redesign
+- image-native figure understanding
+- a repository-wide documentation refactor beyond the minimum semantic-center
+  alignment needed by this wave
+
+## Semantic Center To Preserve
+
+The semantic order for this wave should be treated as fixed:
+
+`document_profiles -> paper facts family -> comparable_results -> collection_comparable_results -> comparison_rows / evidence_cards / graph / report projections`
+
+Within that order:
+
+- `paper_facts` remains the primary research object layer
+- `comparable_results` remains the reusable result-semantic layer
+- `collection_comparable_results` remains the collection-scoped assessment
+  layer
+- `comparison_rows` remains a projection or cache
+- `evidence_cards` remains a reader-facing and traceback-facing projection
+
+No new implementation in this wave should treat `comparison_rows` or
+`evidence_cards` as the only semantic source of truth.
+
+## Workstream 1: Align Repository Language
+
+### Goal
+
+Make the repository describe one semantic backbone consistently enough that the
+next implementation wave extends the right objects.
+
+### Primary changes
+
+- update shared and backend docs that still present
+  `document_profiles -> evidence_cards -> comparison_rows` as the core
+  backbone
+- make `evidence_cards` explicitly reader-facing and traceback-facing
+- make `comparison_rows` explicitly projection or cache semantics
+- keep `comparable_results` and `collection_comparable_results` as the
+  comparison-semantic truth in backend-local docs and API docs
+
+### Expected file areas
+
+- `README.md`
+- `docs/contracts/lens-v1-definition.md`
+- `docs/contracts/lens-core-artifact-contracts.md`
+- `backend/docs/architecture/overview.md`
+- `backend/docs/architecture/core-comparison/current-state.md`
+- `backend/docs/specs/api.md`
+
+### Exit criteria
+
+- the repository no longer advertises multiple competing semantic backbones
+- new backend work can reference one authoritative semantic order
+
+## Workstream 2: Reduce Extraction Cost Before Adding More Schema
+
+### Goal
+
+Reduce Core extraction time by shrinking the number of LLM calls and removing
+provider-side structured-output overhead where it is not buying enough value.
+
+### Current implementation pressure point
+
+The current extraction loop sends one LLM request per text window and one per
+table row, then materializes each returned bundle:
+
+- text-window extraction loop in
+  `application/core/semantic_build/paper_facts_service.py`
+- table-row extraction loop in the same module
+- extraction payloads built from `_build_text_window_extraction_payload()` and
+  `_build_table_row_extraction_payload()`
+
+### Primary changes
+
+- add deterministic candidate pruning before any LLM call
+- skip obviously low-value blocks such as references, acknowledgements, and
+  most introduction-only history blocks
+- move to a table-first, result-first extraction policy for PBF-metal papers
+- keep text windows as supporting context rather than the primary parameter
+  source
+- replace provider-native strict structured-output calls with JSON-text output
+  plus local schema validation
+- run extraction calls with bounded concurrency, then keep bundle
+  materialization deterministic and ordered
+
+### Expected file areas
+
+- `application/core/semantic_build/llm/extractor.py`
+- `application/core/semantic_build/llm/prompts.py`
+- `application/core/semantic_build/llm/schemas.py`
+- `application/core/semantic_build/paper_facts_service.py`
+- `tests/support/fake_core_llm_extractor.py`
+- `tests/unit/services/test_paper_facts_services.py`
+
+### Exit criteria
+
+- one representative PBF-metal document no longer triggers exhaustive
+  low-value text-window extraction
+- extraction unit count drops materially on the known slow collection
+- one extraction call returns on a seconds-scale path rather than a
+  tens-of-seconds structured-output path
+
+## Workstream 3: Add A Narrow PBF-Metal Extension To Core Facts
+
+### Goal
+
+Support the real target comparison job without turning the generic Core
+backbone into a one-vertical-only schema.
+
+The first-version field boundary for this workstream is recorded in
+[`parameter-registry-and-variant-report-scope.md`](parameter-registry-and-variant-report-scope.md).
+
+### Primary design rule
+
+The first implementation wave should stay inside existing Core objects rather
+than introducing a new material-specific package tree.
+
+The narrow extension should use the current `domain_profile` seam plus
+additional structured payload fields in owned Core fact objects.
+
+### PBF-metal process parameters
+
+The extension should explicitly support:
+
+- `laser_power_w`
+- `scan_speed_mm_s`
+- `layer_thickness_um`
+- `hatch_spacing_um`
+- `spot_size_um`
+- `energy_density_j_mm3`
+- `scan_strategy`
+- `build_orientation`
+- `preheat_temperature_c`
+- `shielding_gas`
+- `oxygen_level_ppm`
+- `powder_size_distribution_um`
+
+### PBF-metal result properties
+
+The extension should explicitly support normalized result/property identities
+for:
+
+- `relative_density_percent`
+- `porosity_percent`
+- `residual_stress_mpa`
+- `yield_strength_mpa`
+- `ultimate_tensile_strength_mpa`
+- `elongation_percent`
+- `hardness_hv`
+- `surface_roughness_ra_um`
+
+### Expected file areas
+
+- `application/core/semantic_build/llm/schemas.py`
+- `application/core/semantic_build/llm/prompts.py`
+- `domain/core/evidence_backbone.py`
+- `application/core/semantic_build/paper_facts_service.py`
+
+### Exit criteria
+
+- PBF-metal process parameters no longer collapse into generic free-text
+  `details` payloads when strong evidence is present
+- downstream comparison assembly can distinguish process context from result
+  values using explicit fields
+
+## Workstream 4: Add Claim Scope And Value Origin
+
+### Goal
+
+Stop prior-work text and derived values from silently entering the reusable
+comparison substrate as if they were direct current-work results.
+
+### Claim scope
+
+At minimum, `measurement_results` should support:
+
+- `current_work`
+- `prior_work`
+- `literature_summary`
+- `review_summary`
+- `unclear`
+
+Only `current_work` should be eligible for `comparable_results` in the default
+path.
+
+### Value origin
+
+At minimum, measurement values should support:
+
+- `reported`
+- `derived`
+- `normalized`
+- `inferred`
+
+Supporting fields should also preserve:
+
+- `source_value_text`
+- `source_unit_text`
+- `derivation_formula`
+
+This is especially important for volumetric energy density so the backend can
+distinguish:
+
+- a value directly reported by the paper
+- a value derived locally from power, speed, hatch spacing, and layer
+  thickness
+
+### Expected file areas
+
+- `application/core/semantic_build/llm/schemas.py`
+- `application/core/semantic_build/llm/prompts.py`
+- `domain/core/evidence_backbone.py`
+- `application/core/semantic_build/paper_facts_service.py`
+- `application/core/comparison_assembly.py`
+- `domain/core/comparison.py`
+
+### Exit criteria
+
+- prior-work and review-summary result statements no longer enter the default
+  comparable-result substrate
+- derived numeric facts are distinguishable from reported ones during review
+  and assessment
+
+## Workstream 5: Add Narrow PBF Comparability Rules
+
+### Goal
+
+Make comparability assessment more faithful to PBF-metal result review without
+replacing expert judgment.
+
+### Primary changes
+
+Extend the current `evaluate_comparison_assessment()` logic so it can account
+for PBF-specific missingness and result provenance.
+
+The first rule set should include:
+
+- `claim_scope != current_work` -> `not_comparable`
+- missing `build_orientation` for orientation-sensitive properties ->
+  `limited`
+- missing baseline on an improvement-style claim -> `insufficient`
+- derived energy density with missing source parameters -> `insufficient`
+- missing test orientation for tensile or residual-stress style results ->
+  `limited`
+- direct review-summary facts stay outside the default comparable-result path
+
+### Expected file areas
+
+- `domain/core/comparison.py`
+- `application/core/comparison_assembly.py`
+- `application/core/comparison_projection.py` only if row-facing warnings need
+  new projection fields
+- `tests/unit/domains/test_comparison_domain.py`
+- `tests/unit/services/test_paper_facts_services.py`
+
+### Exit criteria
+
+- `comparable`, `limited`, `insufficient`, and `not_comparable` outcomes track
+  obvious PBF review constraints more closely
+- warning text explains missing process or test context in domain-meaningful
+  terms
+
+## Workstream 6: Build A PBF-Metal Gold Corpus
+
+### Goal
+
+Stop tuning Core extraction and comparability rules purely from individual
+manual examples.
+
+### Initial corpus shape
+
+The first gold corpus should use about 30 papers:
+
+- 10 LPBF 316L papers
+- 10 LPBF Ti-6Al-4V papers
+- 10 LPBF AlSi10Mg or Inconel 718 papers
+
+### Minimum annotation fields
+
+- material system and alloy
+- powder state or distribution when reported
+- process parameters
+- post-processing history
+- target property, value, and unit
+- baseline relationship
+- test condition
+- `claim_scope`
+- `value_origin`
+- source anchors
+- final comparability status
+
+### Expected file areas
+
+- `tests/fixtures/` or another owned backend-local test-data subtree
+- `tests/unit/services/test_paper_facts_services.py`
+- `tests/unit/domains/test_comparison_domain.py`
+- one backend-local benchmark or evaluation entry point if a stable harness is
+  needed
+
+### Exit criteria
+
+- Core changes are measured against a fixed narrow-domain corpus
+- regressions in `claim_scope`, process-parameter capture, and comparability
+  status become repeatable
+
+## Execution Order
+
+1. Align repository semantic-center language in shared and backend docs.
+2. Add candidate pruning and extraction narrowing before changing the vertical
+   schema.
+3. Replace provider-native strict structured output with JSON text plus local
+   schema validation.
+4. Add bounded extraction concurrency while keeping deterministic bundle
+   materialization.
+5. Extend Core facts with the narrow PBF-metal payloads.
+6. Add `claim_scope` and `value_origin`, then gate comparable-result assembly
+   on those fields.
+7. Add narrow PBF comparability rules.
+8. Freeze the 30-paper gold corpus and benchmark checks.
+
+## Verification
+
+This wave should be considered complete only when all of the following checks
+pass.
+
+### Semantic-center checks
+
+- shared and backend docs describe the same semantic backbone
+- no active authority page still treats `evidence_cards` as the primary
+  research object
+
+### Performance checks
+
+- extraction unit count drops on the known slow collection
+- one representative text-window or table-row extraction call completes on a
+  seconds-scale path
+- whole-document extraction time improves materially relative to the current
+  serial structured-output path
+
+### Semantic checks
+
+- process parameters are captured into explicit PBF fields when present
+- `current_work` and `prior_work` style statements are separated correctly
+- `reported` and `derived` values are distinguishable in stored facts
+- comparison assessment changes when critical PBF context is missing
+
+### Gold-corpus checks
+
+- key process-parameter recall is measured on the fixed PBF corpus
+- `claim_scope` precision is tracked
+- false-comparable rate is tracked
+- row-to-anchor traceback remains reviewable
+
+## Risks And Deferrals
+
+- the first wave can still overfit to LPBF-style papers if the corpus is too
+  narrow; the gold set should stay narrow on purpose, but the extension should
+  remain optional and domain-scoped
+- local JSON validation still needs careful prompt discipline; dropping
+  provider-native strict structured output does not justify free-form outputs
+- the first wave should not expand into a full ontology registry or a generic
+  materials knowledge graph
+- the first wave should not introduce a second permanent Core extraction path
+
+## Related Docs
+
+- [`README.md`](README.md)
+- [`implementation-plan.md`](implementation-plan.md)
+- [`../core-parsing-quality-hardening-plan.md`](../core-parsing-quality-hardening-plan.md)
+- [`../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)
+- [`../document-profile-lightweight-triage-plan.md`](../document-profile-lightweight-triage-plan.md)
+- [`../../../architecture/core-comparison/current-state.md`](../../../architecture/core-comparison/current-state.md)
+- [`../../backend-wide/materials-comparison-v2/implementation-plan.md`](../../backend-wide/materials-comparison-v2/implementation-plan.md)

--- a/backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md
+++ b/backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md
@@ -1,0 +1,431 @@
+# Variant Dossier And Result Chain Backend Plan
+
+## Purpose
+
+This document records the backend-local plan for supporting the frontend
+reading model built around:
+
+- `variant dossier`
+- `result chain`
+- `result series`
+
+It narrows one specific backend job inside the broader PBF-metal validation
+wave:
+
+- how Core should expose enough semantic thickness for document and result
+  drilldown without changing the backbone order
+
+This plan does not redefine the shared Lens v1 product hierarchy and does not
+replace the broader execution plan in [`implementation-plan.md`](implementation-plan.md).
+
+## Why This Needs A Separate Backend Plan
+
+The current Core backbone is already pointed in the right direction:
+
+`document_profiles -> paper facts family -> comparable_results -> collection_comparable_results -> row projection`
+
+The remaining problem is not that the backend still thinks in summaries.
+The remaining problem is that the extracted fact model and read projections are
+still too thin for a researcher who needs to reconstruct an experimental
+evidence chain.
+
+For the frontend to read a paper as:
+
+- one paper
+- several variant dossiers
+- several result chains under each dossier
+- several result-series rows when only a test-side axis varies
+
+the backend has to do four narrower things better:
+
+1. persist thicker process and test context
+2. preserve value provenance and missingness honestly
+3. evaluate comparability with PBF-metal review rules instead of only generic
+   row readiness
+4. expose grouped document and result drilldown payloads without inventing a
+   new semantic substrate
+
+## Keep The Backbone Fixed
+
+This plan should not introduce a new permanent top-level artifact family such
+as:
+
+- `variant_dossiers.parquet`
+- `result_chains.parquet`
+- `result_series.parquet`
+
+The first delivery wave should keep the durable Core truth in the existing
+artifact family:
+
+- `sample_variants`
+- `measurement_results`
+- `test_conditions`
+- `baseline_references`
+- `structure_features`
+- `characterization_observations`
+- `comparable_results`
+- `collection_comparable_results`
+
+The new reading units should be assembled as additive projections over those
+artifacts, not as a second semantic backbone.
+
+## Projection Model
+
+### Variant Dossier
+
+The backend should treat a variant dossier as a read projection over one
+`SampleVariant` plus its shared linked context.
+
+The dossier should be keyed by `variant_id` and summarize:
+
+- normalized variant label
+- material identity
+- shared process or sample state
+- shared structure evidence when clearly linked
+- shared missingness that affects all child chains
+
+### Result Chain
+
+A result chain should be a read projection centered on one
+`MeasurementResult`, enriched with:
+
+- parent `variant_id`
+- test condition
+- baseline
+- structure or characterization support
+- value provenance
+- collection-scoped comparability overlay when available
+- source anchors
+
+The first wave should not create a second permanent chain id. The projection
+should reuse existing identities:
+
+- `source_result_id` from `measurement_results`
+- collection-facing `result_id` that already maps to the current
+  `ComparableResult`-backed product contract
+
+### Result Series
+
+A result series should be a grouping over sibling result-chain projections.
+
+The grouping should only happen when:
+
+- `variant_id` is fixed
+- property family is fixed
+- test family is fixed
+- one explicit test-side axis varies
+
+Good first-wave series axes include:
+
+- `test_temperature_c`
+- `strain_rate_s-1`
+- `hold_time`
+
+The backend should not group rows into one series when the apparent axis is
+actually a process or sample-state change.
+
+## Fact Thickening Required For The Projection
+
+The current generic schema is not enough for the dossier and chain read model.
+Core needs thicker fields in the owning fact records before grouped drilldown
+will be trustworthy.
+
+### Process And Sample State
+
+`SampleVariant.process_context` and related method payloads should grow to
+carry the Level 1 PBF-metal fields that affect review and comparison, including
+at minimum:
+
+- `laser_power_w`
+- `scan_speed_mm_s`
+- `layer_thickness_um`
+- `hatch_spacing_um`
+- `spot_size_um`
+- `energy_density_j_mm3`
+- `energy_density_origin`
+- `scan_strategy`
+- `build_orientation`
+- `preheat_temperature_c`
+- `shielding_gas`
+- `oxygen_level_ppm`
+- `powder_size_distribution_um`
+- `post_treatment_summary`
+
+These fields should remain traceable to anchors. They should not collapse back
+into one generic text blob when explicit evidence exists.
+
+### Test Condition
+
+`TestCondition` payloads should carry the fields needed to decide whether two
+mechanical results are responsibly comparable, including at minimum:
+
+- `test_method`
+- `test_temperature_c`
+- `strain_rate_s-1`
+- `loading_direction`
+- `sample_orientation`
+- `environment`
+- `frequency_hz`
+- `specimen_geometry`
+- `surface_state`
+
+The text-window builder should consume mention types such as `rate` and
+`direction` instead of discarding them.
+
+### Structure And Observation Context
+
+The chain projection should keep linked structure and characterization support
+explicit rather than flattening it into one summary string.
+
+First-wave support should surface:
+
+- porosity or density observations
+- residual stress observations
+- grain size and texture observations
+- phase-state observations
+- fracture or failure-surface observations
+
+When an observation was made under a characterization temperature, that
+temperature belongs with the observation condition, not with process history
+and not with the main mechanical test condition.
+
+### Value Provenance
+
+`MeasurementResult.value_payload` and the stored record shape should preserve
+enough provenance for evidence-chain review:
+
+- `value_origin`
+  - `reported`
+  - `derived`
+  - `estimated`
+- `source_value_text`
+- `source_unit_text`
+- `derivation_formula`
+- `derivation_inputs`
+
+This is especially important for values such as energy density, where the user
+must be able to distinguish:
+
+- author-reported value
+- system-derived value from reported parameters
+- weakly inferred value that should not drive comparison
+
+## Comparability Policy Upgrades
+
+The current generic comparability policy should be tightened with PBF-metal
+review rules that operate on the thicker facts above.
+
+The first wave should add explicit missingness and warning rules for:
+
+- missing `build_orientation` on orientation-sensitive properties
+- missing `strain_rate_s-1` on tensile-style properties
+- missing test direction on tensile or residual-stress results
+- missing or unresolved baseline on improvement-style claims
+- mixed heat-treatment states treated as if they were one variant
+- derived energy density without enough source parameters to verify the
+  derivation
+- value-origin mismatches where a display row would otherwise hide that the
+  number is derived
+
+The policy should continue to respect the current rule that only
+`claim_scope == current_work` enters the default `ComparableResult` path.
+
+## Document And Result Drilldown Contract
+
+The first wave should support the new frontend reading model through additive
+projection fields, not through a breaking route rewrite.
+
+### Document Comparison Semantics
+
+`GET /api/v1/collections/{collection_id}/documents/{document_id}/comparison-semantics`
+should remain the document-first semantic inspection route.
+
+The additive plan for this route is:
+
+- keep the existing `items` list intact
+- add optional grouped projections when requested
+
+Suggested additive payload shape:
+
+```json
+{
+  "collection_id": "col_x",
+  "document_id": "doc_x",
+  "count": 6,
+  "items": [],
+  "variant_dossiers": [
+    {
+      "variant_id": "var_x",
+      "variant_label": "optimized VED + HIP",
+      "material": {},
+      "shared_process_state": {},
+      "shared_missingness": [],
+      "series": [
+        {
+          "series_key": "tensile:test_temperature_c",
+          "property_family": "tensile",
+          "test_family": "tensile",
+          "varying_axis": {
+            "axis_name": "test_temperature_c",
+            "axis_unit": "C"
+          },
+          "chains": [
+            {
+              "source_result_id": "mr_x",
+              "result_id": "cmp_x",
+              "measurement": {},
+              "test_condition": {},
+              "baseline": {},
+              "assessment": {},
+              "value_provenance": {},
+              "evidence": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+This grouped view should be derived from the same underlying semantic facts as
+the flat `items` list. The frontend should not receive two conflicting truths.
+The naming and field boundary for this additive payload should follow the
+shared contract freeze in
+`docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md`.
+
+### Result Detail
+
+`GET /api/v1/collections/{collection_id}/results/{result_id}` should remain the
+product-facing result contract.
+
+The additive plan for this route is to enrich the existing detail projection
+with:
+
+- parent variant dossier summary
+- chain-local test condition
+- explicit baseline detail
+- explicit value provenance
+- linked structure support summary
+- sibling result-series navigation when the same variant has other chains in
+  the same property and test family
+
+This keeps the public product model intact:
+
+`comparison row -> result -> document`
+
+while making the result page readable as one evidence chain instead of one
+isolated measurement card.
+
+## Delivery Slices
+
+### Slice 1: Fact Thickening
+
+Goal:
+
+- make `sample_variants`, `test_conditions`, and `measurement_results` thick
+  enough to express a PBF-metal evidence chain
+
+Owned file areas:
+
+- `application/core/semantic_build/llm/schemas.py`
+- `application/core/semantic_build/llm/prompts.py`
+- `domain/core/evidence_backbone.py`
+- `application/core/semantic_build/paper_facts_service.py`
+- `tests/unit/services/test_paper_facts_services.py`
+
+Verification:
+
+```bash
+cd backend
+uv run pytest tests/unit/services/test_paper_facts_services.py
+```
+
+### Slice 2: Comparability Policy
+
+Goal:
+
+- teach `ComparableResult` assessment about PBF-metal missingness and value
+  provenance
+
+Owned file areas:
+
+- `domain/core/comparison.py`
+- `application/core/comparison_assembly.py`
+- `tests/unit/domains/test_comparison_domain.py`
+- `tests/unit/services/test_paper_facts_services.py`
+
+Verification:
+
+```bash
+cd backend
+uv run pytest tests/unit/domains/test_comparison_domain.py
+uv run pytest tests/unit/services/test_paper_facts_services.py
+```
+
+### Slice 3: Grouped Drilldown Projection
+
+Goal:
+
+- expose dossier, chain, and series projections from the existing semantic
+  truth without creating a second artifact family
+
+Owned file areas:
+
+- `application/core/comparison_service.py`
+- `controllers/core/documents.py`
+- `application/core/result_service.py` if result detail projection needs
+  additive chain context
+- `backend/docs/specs/api.md`
+- `tests/integration/test_app_layer_api.py`
+
+Verification:
+
+```bash
+cd backend
+uv run pytest tests/integration/test_app_layer_api.py
+```
+
+### Slice 4: Gold-Corpus Validation
+
+Goal:
+
+- prove that the backend can reconstruct stable evidence-chain projections on
+  the narrow PBF-metal corpus before broader rollout
+
+Checks:
+
+- repeated runs keep the same dossier grouping for the same paper
+- repeated runs keep the same current-work chain identity
+- missing fields are marked as missing rather than hallucinated
+- grouped drilldown can distinguish process temperature, test temperature, and
+  characterization temperature
+- comparable versus limited judgments reflect orientation, strain-rate, and
+  baseline gaps
+
+## Exit Criteria
+
+This backend slice is done only when all of the following are true:
+
+1. the persistent Core truth remains the current paper-facts and
+   comparable-result backbone
+2. no new permanent artifact family was added for dossier, chain, or series
+3. one document can be projected into stable variant dossiers and result
+   chains
+4. one result detail response can explain the parent variant, test context,
+   structure support, baseline, and provenance in one payload
+5. missingness and value-origin warnings are explicit enough that the frontend
+   does not need to guess
+
+## Related Docs
+
+- [`README.md`](README.md)
+  Topic-family reading order for the PBF-metal validation wave
+- [`proposal.md`](proposal.md)
+  Why the narrow PBF-metal validation wave exists
+- [`parameter-registry-and-variant-report-scope.md`](parameter-registry-and-variant-report-scope.md)
+  First-wave field boundary for the variant-facing report surface
+- [`implementation-plan.md`](implementation-plan.md)
+  Broader executable implementation plan for the whole PBF-metal wave
+- [`../../../../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md`](../../../../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md)
+  Frontend-local reading model that this backend plan supports

--- a/backend/docs/plans/derived/core-derived-graph-follow-up-plan.md
+++ b/backend/docs/plans/derived/core-derived-graph-follow-up-plan.md
@@ -12,7 +12,7 @@ projection that consumes Lens research objects:
 - `comparability`
 
 The plan is a child follow-up of
-[`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md)
+[`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md)
 and should be executed after current Core stabilization waves are in a usable
 state.
 
@@ -62,7 +62,7 @@ Current child execution entrypoint:
 - [`core-derived-graph-cutover-implementation-plan.md`](core-derived-graph-cutover-implementation-plan.md)
 - [`core-derived-graph-structure-and-drilldown-plan.md`](core-derived-graph-structure-and-drilldown-plan.md)
 - [`core-derived-graph-semantic-expansion-plan.md`](core-derived-graph-semantic-expansion-plan.md)
-- [`core-first-product-surface-cutover-plan.md`](../backend-wide/core-first-product-surface-cutover-plan.md)
+- [`core-first-product-surface-cutover-plan.md`](../backend-wide/core-first-product-surface/implementation-plan.md)
 
 ## Target Semantic Model
 
@@ -187,14 +187,14 @@ Exit criteria:
 
 ## Recommended Reading Order
 
-1. [`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md)
+1. [`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md)
 2. [`core-stabilization-and-seam-extraction-plan.md`](../core/core-stabilization-and-seam-extraction-plan.md)
 3. [`graph-surface-plan.md`](graph-surface-plan.md)
 4. this follow-up plan
 
 ## Related Docs
 
-- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md)
+- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md)
 - [`core-stabilization-and-seam-extraction-plan.md`](../core/core-stabilization-and-seam-extraction-plan.md)
 - [`graph-surface-plan.md`](graph-surface-plan.md)
 - [`core-derived-graph-structure-and-drilldown-plan.md`](core-derived-graph-structure-and-drilldown-plan.md)

--- a/backend/docs/plans/derived/graph-surface-plan.md
+++ b/backend/docs/plans/derived/graph-surface-plan.md
@@ -249,7 +249,7 @@ Expected output of Phase 2:
 - [`../specs/api.md`](../../specs/api.md)
 - [`../architecture/overview.md`](../../architecture/overview.md)
 - [`../architecture/domain-architecture.md`](../../architecture/domain-architecture.md)
-- [`current-api-surface-migration-checklist.md`](../backend-wide/current-api-surface-migration-checklist.md)
+- [`current-api-surface-migration-checklist.md`](../backend-wide/api-surface-migration/current-state.md)
 - [`v1-api-migration-notes.md`](../historical/v1-api-migration-notes.md)
 - [`evidence-first-parsing-plan.md`](../historical/evidence-first-parsing-plan.md)
 - [`core-derived-graph-follow-up-plan.md`](core-derived-graph-follow-up-plan.md)

--- a/backend/docs/plans/derived/query-retirement-and-graphrag-query-decoupling-plan.md
+++ b/backend/docs/plans/derived/query-retirement-and-graphrag-query-decoupling-plan.md
@@ -175,8 +175,8 @@ Primary changes:
 - remove `/query` OpenAPI expectations from
   [`tests/integration/routers/test_protocol_api.py`](../../../tests/integration/routers/test_protocol_api.py)
 - update [`../specs/api.md`](../../specs/api.md)
-- update [`current-api-surface-migration-checklist.md`](../backend-wide/current-api-surface-migration-checklist.md)
-- update [`core-first-product-surface-cutover-plan.md`](../backend-wide/core-first-product-surface-cutover-plan.md)
+- update [`current-api-surface-migration-checklist.md`](../backend-wide/api-surface-migration/current-state.md)
+- update [`core-first-product-surface-cutover-plan.md`](../backend-wide/core-first-product-surface/implementation-plan.md)
 - update [`../architecture/domain-architecture.md`](../../architecture/domain-architecture.md)
 - update
   [`../../../docs/overview/system-overview.md`](../../../../docs/overview/system-overview.md)
@@ -231,8 +231,8 @@ than folded into this query retirement wave.
 
 ## Related Docs
 
-- [`core-first-product-surface-cutover-plan.md`](../backend-wide/core-first-product-surface-cutover-plan.md)
-- [`current-api-surface-migration-checklist.md`](../backend-wide/current-api-surface-migration-checklist.md)
+- [`core-first-product-surface-cutover-plan.md`](../backend-wide/core-first-product-surface/implementation-plan.md)
+- [`current-api-surface-migration-checklist.md`](../backend-wide/api-surface-migration/current-state.md)
 - [`../specs/api.md`](../../specs/api.md)
 - [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
 - [`../architecture/domain-architecture.md`](../../architecture/domain-architecture.md)

--- a/backend/docs/plans/historical/comparable-result/core-comparable-result-domain-model-plan.md
+++ b/backend/docs/plans/historical/comparable-result/core-comparable-result-domain-model-plan.md
@@ -424,9 +424,9 @@ Guardrails:
 
 ### Companion Docs
 
-- [`../../core/core-llm-structured-extraction-hard-cutover-plan.md`](../../core/core-llm-structured-extraction-hard-cutover-plan.md)
+- [`../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)
   remains the extraction-contract and semantic-build companion plan.
-- [`../../core/core-llm-structured-extraction-id-boundary-plan.md`](../../core/core-llm-structured-extraction-id-boundary-plan.md)
+- [`../../../../application/core/semantic_build/llm/docs/structured-extraction/id-boundary.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/id-boundary.md)
   remains the boundary-cleanup companion plan that keeps backend ids out of the
   LLM contract.
 
@@ -437,7 +437,7 @@ Guardrails:
 - [`core-comparable-result-phase1-persistence-split-plan.md`](core-comparable-result-phase1-persistence-split-plan.md)
 - [`core-comparable-result-phase1-read-path-cutover-plan.md`](core-comparable-result-phase1-read-path-cutover-plan.md)
 - [`core-comparable-result-phase1-service-boundary-plan.md`](core-comparable-result-phase1-service-boundary-plan.md)
-- [`../../core/core-llm-structured-extraction-hard-cutover-plan.md`](../../core/core-llm-structured-extraction-hard-cutover-plan.md)
-- [`../../core/core-llm-structured-extraction-id-boundary-plan.md`](../../core/core-llm-structured-extraction-id-boundary-plan.md)
+- [`../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)
+- [`../../../../application/core/semantic_build/llm/docs/structured-extraction/id-boundary.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/id-boundary.md)
 - [`../../../architecture/domain-architecture.md`](../../../architecture/domain-architecture.md)
 - [`../../../architecture/goal-core-source-layering.md`](../../../architecture/goal-core-source-layering.md)

--- a/backend/docs/plans/historical/comparable-result/core-comparable-result-evolution-roadmap-plan.md
+++ b/backend/docs/plans/historical/comparable-result/core-comparable-result-evolution-roadmap-plan.md
@@ -32,8 +32,8 @@ Read this plan with:
 - [`core-comparable-result-phase2-policy-lifecycle-plan.md`](core-comparable-result-phase2-policy-lifecycle-plan.md)
 - [`core-comparable-result-phase3-corpus-retrieval-plan.md`](core-comparable-result-phase3-corpus-retrieval-plan.md)
 - [`../../core/minimal-core-domain-backfill-plan.md`](../../core/minimal-core-domain-backfill-plan.md)
-- [`../../core/core-llm-structured-extraction-hard-cutover-plan.md`](../../core/core-llm-structured-extraction-hard-cutover-plan.md)
-- [`../../core/core-llm-structured-extraction-id-boundary-plan.md`](../../core/core-llm-structured-extraction-id-boundary-plan.md)
+- [`../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)
+- [`../../../../application/core/semantic_build/llm/docs/structured-extraction/id-boundary.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/id-boundary.md)
 
 ## Purpose
 
@@ -350,6 +350,6 @@ should stay narrow:
 
 ### Companion Docs
 
-- [`../../core/core-llm-structured-extraction-hard-cutover-plan.md`](../../core/core-llm-structured-extraction-hard-cutover-plan.md)
-- [`../../core/core-llm-structured-extraction-id-boundary-plan.md`](../../core/core-llm-structured-extraction-id-boundary-plan.md)
+- [`../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/hard-cutover.md)
+- [`../../../../application/core/semantic_build/llm/docs/structured-extraction/id-boundary.md`](../../../../application/core/semantic_build/llm/docs/structured-extraction/id-boundary.md)
 - [`../../core/minimal-core-domain-backfill-plan.md`](../../core/minimal-core-domain-backfill-plan.md)

--- a/backend/docs/plans/historical/evidence-first-parsing-plan.md
+++ b/backend/docs/plans/historical/evidence-first-parsing-plan.md
@@ -29,11 +29,11 @@ This is a target implementation plan, not a description of already-implemented
 backend current-state behavior.
 
 For the current backend migration state, read
-[`current-api-surface-migration-checklist.md`](../backend-wide/current-api-surface-migration-checklist.md).
+[`current-api-surface-migration-checklist.md`](../backend-wide/api-surface-migration/current-state.md).
 For the active near-term execution plan, read
 [`core-stabilization-and-seam-extraction-plan.md`](../core/core-stabilization-and-seam-extraction-plan.md).
 For the broader parent roadmap, read
-[`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md).
+[`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md).
 
 ## Scope
 
@@ -326,11 +326,11 @@ This backend plan is successful when:
 
 ## Related Docs
 
-- [`current-api-surface-migration-checklist.md`](../backend-wide/current-api-surface-migration-checklist.md)
+- [`current-api-surface-migration-checklist.md`](../backend-wide/api-surface-migration/current-state.md)
   Current backend migration state and reading order
 - [`core-stabilization-and-seam-extraction-plan.md`](../core/core-stabilization-and-seam-extraction-plan.md)
   Active near-term child execution plan for the Core slice
-- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md)
+- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md)
   Broader parent roadmap for later Core, Goal, and Source waves
 - [`../../../docs/overview/lens-mission-positioning.md`](../../../../docs/overview/lens-mission-positioning.md)
   Shared long-lived Lens mission and positioning

--- a/backend/docs/plans/historical/v1-api-migration-notes.md
+++ b/backend/docs/plans/historical/v1-api-migration-notes.md
@@ -6,7 +6,7 @@ The authoritative frontend/backend API contract now lives in
 [`../specs/api.md`](../../specs/api.md).
 
 The current backend migration state now lives in
-[`current-api-surface-migration-checklist.md`](../backend-wide/current-api-surface-migration-checklist.md).
+[`current-api-surface-migration-checklist.md`](../backend-wide/api-surface-migration/current-state.md).
 
 This document remains only as a historical backend-local bridge note for
 earlier implementation sequencing and migration decisions behind that contract.
@@ -36,7 +36,7 @@ The recommended backend order remains:
 ## Related Docs
 
 - [`../specs/api.md`](../../specs/api.md)
-- [`current-api-surface-migration-checklist.md`](../backend-wide/current-api-surface-migration-checklist.md)
+- [`current-api-surface-migration-checklist.md`](../backend-wide/api-surface-migration/current-state.md)
 - [`../architecture/domain-architecture.md`](../../architecture/domain-architecture.md)
 - [`evidence-first-parsing-plan.md`](evidence-first-parsing-plan.md)
 - [`../../../docs/contracts/lens-v1-definition.md`](../../../../docs/contracts/lens-v1-definition.md)

--- a/backend/docs/plans/source/README.md
+++ b/backend/docs/plans/source/README.md
@@ -6,6 +6,9 @@ GraphRAG-era Source seams.
 
 ## Reading Order
 
+- [`source-build-task-background-execution-plan.md`](source-build-task-background-execution-plan.md)
+  Minimal background execution model for collection builds and task-status
+  polling without blocking the main request loop
 - [`source-collection-builder-normalization-plan.md`](source-collection-builder-normalization-plan.md)
   Normalize the collection-builder and import handoff seam
 - [`source-residual-graphrag-retirement-plan.md`](source-residual-graphrag-retirement-plan.md)

--- a/backend/docs/plans/source/born-digital-source-parser-first-plan.md
+++ b/backend/docs/plans/source/born-digital-source-parser-first-plan.md
@@ -31,7 +31,7 @@ target that was later replaced by the active
 For the parent Source retirement lineage, read
 [`source-residual-graphrag-retirement-plan.md`](source-residual-graphrag-retirement-plan.md).
 For the downstream consumer target, read
-[`materials-comparison-v2-plan.md`](../backend-wide/materials-comparison-v2-plan.md).
+[`materials-comparison-v2-plan.md`](../backend-wide/materials-comparison-v2/implementation-plan.md).
 
 ## Why This Follow-up Exists
 
@@ -142,7 +142,7 @@ That means:
 ### Target Source Evidence Contract
 
 This plan adopts the Source evidence contract required by
-[`materials-comparison-v2-plan.md`](../backend-wide/materials-comparison-v2-plan.md) as its
+[`materials-comparison-v2-plan.md`](../backend-wide/materials-comparison-v2/implementation-plan.md) as its
 target output.
 
 The target collection-local Source artifacts are:

--- a/backend/docs/plans/source/docling-first-source-parser-cutover-plan.md
+++ b/backend/docs/plans/source/docling-first-source-parser-cutover-plan.md
@@ -21,7 +21,7 @@ Read this plan with:
 
 - [`source-parser-evaluation-plan.md`](source-parser-evaluation-plan.md)
 - [`born-digital-source-parser-first-plan.md`](born-digital-source-parser-first-plan.md)
-- [`../backend-wide/materials-comparison-v2-plan.md`](../backend-wide/materials-comparison-v2-plan.md)
+- [`../backend-wide/materials-comparison-v2/implementation-plan.md`](../backend-wide/materials-comparison-v2/implementation-plan.md)
 
 ## Decision
 

--- a/backend/docs/plans/source/retrieval-package-retirement-plan.md
+++ b/backend/docs/plans/source/retrieval-package-retirement-plan.md
@@ -19,7 +19,7 @@ decoupling:
 Read this plan with:
 
 - [`source-residual-graphrag-retirement-plan.md`](source-residual-graphrag-retirement-plan.md)
-- [`goal-source-core-business-layer-alignment-plan.md`](../backend-wide/goal-source-core-business-layer-alignment-plan.md)
+- [`goal-source-core-business-layer-alignment-plan.md`](../backend-wide/goal-source-core-layering/proposal.md)
 
 ## Status
 

--- a/backend/docs/plans/source/source-build-task-background-execution-plan.md
+++ b/backend/docs/plans/source/source-build-task-background-execution-plan.md
@@ -1,0 +1,244 @@
+# Source Build Task Background Execution Plan
+
+## Summary
+
+This document records the minimal Source-layer execution plan for collection
+builds:
+
+keep file upload synchronous and narrow, create a build task that returns
+immediately, run the real build flow outside the main request loop, and let
+clients poll task status by `task_id`.
+
+This is a Source-owned execution plan because it is primarily about collection
+construction, task progression, and Source-to-Core handoff behavior. It does
+not change the public API contract defined in
+[`../../specs/api.md`](../../specs/api.md).
+
+## Context
+
+The current frontend-facing contract already points clients to this flow:
+
+1. `POST /api/v1/collections`
+2. `POST /api/v1/collections/{collection_id}/files`
+3. `POST /api/v1/collections/{collection_id}/tasks/build`
+4. poll `GET /api/v1/tasks/{task_id}`
+
+That contract shape is correct for Lens v1. The operational failure comes from
+how the build work executes after task creation.
+
+Current backend facts:
+
+- `controllers/source/tasks.py` creates a build task and schedules the real
+  work through `CollectionBuildTaskRunner`
+- `application/source/collection_build_task_runner.py` runs a long chain that
+  includes Source artifact generation, document profiles, paper facts,
+  comparison rows, and conditional protocol work
+- several steps in that chain are synchronous heavy work even when they are
+  called from an `async` route or wrapper
+- synchronous LLM calls or CPU-heavy dataframe work inside the main request
+  event loop can still block unrelated API traffic on a single-worker process
+
+The key rule is simple:
+
+- `async` route shape alone does not guarantee non-blocking behavior
+- long-running build execution must be isolated from the main request loop
+
+## Scope
+
+This plan covers:
+
+- the minimal execution model for collection builds
+- the required split between upload, task creation, background build
+  execution, and task-status reads
+- the minimum task lifecycle fields needed for frontend polling
+- the smallest acceptable isolation rule for single-node backend deployment
+
+This plan does not cover:
+
+- introducing Celery, Redis, RabbitMQ, or another distributed task system
+- task cancellation, retries, or priority queues
+- multi-instance task coordination
+- changing the public request or response shapes for the existing build-task
+  routes
+- changing the Core semantic build order
+
+## Proposed Change
+
+### Design Rule
+
+Collection build is a background task model, not a request-response model.
+
+That means:
+
+- upload requests store files and return
+- build-task requests create task records and return
+- background execution owns the long-running build chain
+- task detail routes expose progress and terminal status
+
+### Minimal Runtime Shape
+
+#### 1. File upload stays narrow
+
+`POST /api/v1/collections/{collection_id}/files` should only do collection
+file registration and storage.
+
+It should not start the full semantic build as part of the upload request.
+
+#### 2. Build task creation returns immediately
+
+`POST /api/v1/collections/{collection_id}/tasks/build` should do only these
+steps:
+
+- validate that the collection exists
+- validate that at least one file is present
+- create a task record
+- schedule background execution
+- return the created `task_id`
+
+The request should not wait for:
+
+- Source artifact generation
+- document profile extraction
+- paper facts extraction
+- comparison row assembly
+- protocol artifact generation
+
+#### 3. Background execution must leave the request loop
+
+The real build chain must run outside the main request event loop.
+
+The minimum acceptable implementation for the current single-node backend is:
+
+- schedule a synchronous background entrypoint
+- run the full build chain in a worker thread or equivalent isolated executor
+- keep task-state updates in `TaskService` as the observable progress contract
+
+This plan intentionally chooses the smallest isolated runtime that fits the
+current repository:
+
+- no new queue infrastructure
+- no new deployment dependency
+- no compatibility layer between the route and the real runner
+
+#### 4. Task status polling stays the primary progress surface
+
+`GET /api/v1/tasks/{task_id}` remains the primary polling route.
+
+At minimum, clients need:
+
+- `task_id`
+- `task_type`
+- `status`
+- `current_stage`
+- `progress_percent`
+- `warnings`
+- `errors`
+
+`GET /api/v1/collections/{collection_id}/tasks` remains the history surface
+for collection-scoped task lists.
+
+#### 5. Frontend flow remains poll-driven
+
+The frontend should continue to:
+
+1. upload files
+2. create a build task
+3. poll `GET /api/v1/tasks/{task_id}`
+4. open workspace and downstream resources only after terminal task state or
+   sufficient readiness
+
+This keeps the browser contract simple and aligned with the current public API
+surface.
+
+## Why This Is The Minimal Fix
+
+The backend does not need a larger task platform to solve the immediate
+blocking problem.
+
+The immediate problem is not the absence of a status route. The status route
+already exists. The immediate problem is that long-running build work can
+still execute on the same main request loop as unrelated API traffic.
+
+The smallest correct fix is therefore:
+
+- keep the current build-task API contract
+- keep the current task registry model
+- move the long-running execution off the main request loop
+
+Anything larger should be deferred until the repository actually needs:
+
+- cross-process queue durability
+- retries after worker restart
+- distributed scheduling
+- explicit cancellation controls
+
+## Implementation Slice
+
+### Phase 1: Preserve The Existing HTTP Contract
+
+Keep these routes as the stable frontend contract:
+
+- `POST /api/v1/collections/{collection_id}/tasks/build`
+- `GET /api/v1/collections/{collection_id}/tasks`
+- `GET /api/v1/tasks/{task_id}`
+- `GET /api/v1/tasks/{task_id}/artifacts`
+
+No new compatibility route should be added in this wave.
+
+### Phase 2: Offload The Real Build Chain
+
+Keep `CollectionBuildTaskRunner` as the owning application-layer runner, but
+ensure the route schedules an entrypoint that executes outside the main
+request loop.
+
+The execution rule is:
+
+- task creation and scheduling happen in the request path
+- task progression and artifact generation happen in the isolated background
+  path
+
+### Phase 3: Keep Task Progress Observable
+
+Every stage transition should continue to write task state that can be read by
+polling clients.
+
+The minimum externally meaningful sequence is:
+
+- `queued`
+- `files_registered`
+- `source_artifacts_started`
+- `source_artifacts_completed`
+- `document_profiles_started`
+- `paper_facts_started`
+- `comparison_rows_started`
+- `protocol_artifacts_started`
+- `artifacts_ready`
+- `failed`
+
+Terminal `status` remains:
+
+- `completed`
+- `partial_success`
+- `failed`
+
+## Verification
+
+This plan is working when these checks hold:
+
+1. `POST /api/v1/collections/{collection_id}/tasks/build` returns a `task_id`
+   without waiting for artifact generation to finish.
+2. While a build is running, unrelated routes such as
+   `GET /api/v1/tasks/{task_id}`, `GET /api/v1/collections`, or read-only
+   collection routes remain responsive on the same backend instance.
+3. Task polling shows stage progression through the existing task payload.
+4. Completion and failure are visible through task status without requiring the
+   build request to stay open.
+
+## Follow-Up Boundary
+
+If the repository later needs durable multi-process execution, retries, or
+cross-instance scheduling, record that as a new Source or backend-wide plan.
+
+That future wave should replace the same execution seam directly. It should
+not introduce a temporary compatibility layer that keeps both in-process and
+distributed task models alive by default.

--- a/backend/docs/plans/source/source-collection-builder-normalization-plan.md
+++ b/backend/docs/plans/source/source-collection-builder-normalization-plan.md
@@ -14,9 +14,9 @@ spans one backend seam across `application/collections/` and
 `infra/ingestion/`.
 
 For the broader five-layer roadmap, read
-[`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md).
+[`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md).
 For the parent contract freeze, read
-[`goal-core-source-contract-follow-up-plan.md`](../backend-wide/goal-core-source-contract-follow-up-plan.md).
+[`goal-core-source-contract-follow-up-plan.md`](../backend-wide/goal-source-core-layering/contract-follow-up.md).
 
 ## Context
 

--- a/backend/docs/plans/source/source-parser-evaluation-plan.md
+++ b/backend/docs/plans/source/source-parser-evaluation-plan.md
@@ -25,7 +25,7 @@ evidence for the fixed Source contract".
 Read this plan with:
 
 - [`born-digital-source-parser-first-plan.md`](born-digital-source-parser-first-plan.md)
-- [`materials-comparison-v2-plan.md`](../backend-wide/materials-comparison-v2-plan.md)
+- [`materials-comparison-v2-plan.md`](../backend-wide/materials-comparison-v2/implementation-plan.md)
 - [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)
 
 ## Status

--- a/backend/docs/plans/source/source-residual-graphrag-retirement-plan.md
+++ b/backend/docs/plans/source/source-residual-graphrag-retirement-plan.md
@@ -363,8 +363,8 @@ Exit criteria:
 ## Related Docs
 
 - [`query-retirement-and-graphrag-query-decoupling-plan.md`](../derived/query-retirement-and-graphrag-query-decoupling-plan.md)
-- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-core-source-implementation-plan.md)
+- [`goal-core-source-implementation-plan.md`](../backend-wide/goal-source-core-layering/implementation-plan.md)
 - [`source-collection-builder-normalization-plan.md`](source-collection-builder-normalization-plan.md)
-- [`core-first-product-surface-cutover-plan.md`](../backend-wide/core-first-product-surface-cutover-plan.md)
-- [`current-api-surface-migration-checklist.md`](../backend-wide/current-api-surface-migration-checklist.md)
+- [`core-first-product-surface-cutover-plan.md`](../backend-wide/core-first-product-surface/implementation-plan.md)
+- [`current-api-surface-migration-checklist.md`](../backend-wide/api-surface-migration/current-state.md)
 - [`../architecture/goal-core-source-layering.md`](../../architecture/goal-core-source-layering.md)

--- a/backend/docs/plans/source/source-structure-first-substrate-plan.md
+++ b/backend/docs/plans/source/source-structure-first-substrate-plan.md
@@ -27,7 +27,7 @@ Read this plan with:
 
 - [`docling-first-source-parser-cutover-plan.md`](docling-first-source-parser-cutover-plan.md)
 - [`born-digital-source-parser-first-plan.md`](born-digital-source-parser-first-plan.md)
-- [`../backend-wide/materials-comparison-v2-plan.md`](../backend-wide/materials-comparison-v2-plan.md)
+- [`../backend-wide/materials-comparison-v2/implementation-plan.md`](../backend-wide/materials-comparison-v2/implementation-plan.md)
 - [`../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md`](../../../../docs/decisions/rfc-paper-facts-primary-domain-model.md)
 
 ## Context

--- a/backend/docs/runbooks/backend-ops.md
+++ b/backend/docs/runbooks/backend-ops.md
@@ -17,7 +17,14 @@ Set backend LLM runtime variables before local runs:
 export LLM_BASE_URL=http://localhost:11434/v1
 export LLM_MODEL=qwen1.5-8b-chat
 export LLM_API_KEY=sk-local
+export CORE_LLM_EXTRACTION_MODE=json_text
+export CORE_EXTRACTION_MAX_CONCURRENCY=4
 ```
+
+`CORE_EXTRACTION_MAX_CONCURRENCY` is optional. When unset, Core extraction uses
+`4`.
+`CORE_LLM_EXTRACTION_MODE` is optional. Supported values are `json_text` and
+`provider_parse`. When unset, Core extraction uses `json_text`.
 
 ## Start the Backend
 

--- a/backend/docs/specs/api.md
+++ b/backend/docs/specs/api.md
@@ -365,12 +365,30 @@
 - `evidence`
 - `actions`
 
+下一波 additive contract 冻结字段：
+
+- `variant_dossier`
+- `test_condition_detail`
+- `baseline_detail`
+- `structure_support`
+- `value_provenance`
+- `series_navigation`
+
 语义要求：
 
 - `result_id` 是产品向标识；当前可以内部映射到 deterministic
   `comparable_result_id`
 - 结果页必须由 `ComparableResult` 与当前 collection 的
   `CollectionComparableResult` 共同投影
+- 结果页的下一波 additive contract 已在
+  `docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md`
+  冻结；该 contract 应把结果页提升为 chain-first drilldown，而不是继续停留在
+  generic measurement card
+- `variant_dossier` 是当前 result 对应的 parent dossier summary，不是第二个主页面模型
+- `test_condition_detail`、`baseline_detail`、`structure_support`、
+  `value_provenance` 应作为 additive fields 暴露，不应挤压现有根级结果合同
+- `series_navigation`
+  只在同一 dossier 下存在 sibling result series 时出现，可选返回
 - 结果页应同时提供回到 comparison 视图和 source document 的链接
 - 结果页不应把 `binding`、`normalized_context`、`collection_overlays`
   这些 raw semantic 字段直接作为主页面合同
@@ -398,6 +416,10 @@
 - `total`
 - `count`
 - `items`
+
+下一波 additive contract 冻结字段：
+
+- `variant_dossiers`
 
 每个 item 至少应包含：
 
@@ -434,6 +456,14 @@
 语义要求：
 
 - 这是 `ComparableResult` 的 document-scoped inspection surface，不是 row list
+- 该路由的下一波 additive grouped drilldown contract 已在
+  `docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md`
+  冻结
+- flat `items` list 必须继续保留；grouped projections 是 additive read model，
+  不是第二套相互冲突的 semantic truth
+- `variant_dossiers`
+  应作为 document-side grouped drilldown 的顶层字段，由 backend 从同一 semantic
+  truth 投影而来
 - `collection_overlays`
   必须来自 `collection_comparable_results.parquet`，按 `comparable_result_id`
   关联
@@ -449,6 +479,9 @@
 - `include_row_projections=true|false`
   - `false` 时不要求返回 row projection
   - `true` 时允许为 document-facing drilldown 附带按需生成的 row payload
+- `include_grouped_projections=true|false`
+  - `false` 时允许省略 grouped dossier/series projection
+  - `true` 时应返回 `variant_dossiers`
 
 ### Corpus Comparable Results
 
@@ -812,9 +845,9 @@ readiness 类错误至少应包含：
 - [`../../../docs/decisions/rfc-comparison-result-document-product-flow.md`](../../../docs/decisions/rfc-comparison-result-document-product-flow.md)
 - [`../architecture/domain-architecture.md`](../architecture/domain-architecture.md)
 - [`../architecture/goal-core-source-layering.md`](../architecture/goal-core-source-layering.md)
-- [`../plans/core-first-product-surface-cutover-plan.md`](../plans/backend-wide/core-first-product-surface-cutover-plan.md)
+- [`../plans/core-first-product-surface-cutover-plan.md`](../plans/backend-wide/core-first-product-surface/implementation-plan.md)
 - [`../plans/evidence-first-parsing-plan.md`](../plans/historical/evidence-first-parsing-plan.md)
-- [`../plans/goal-core-source-contract-follow-up-plan.md`](../plans/backend-wide/goal-core-source-contract-follow-up-plan.md)
+- [`../plans/goal-core-source-contract-follow-up-plan.md`](../plans/backend-wide/goal-source-core-layering/contract-follow-up.md)
 - [`../plans/claim-traceback-navigation-implementation-plan.md`](../plans/core/claim-traceback-navigation-implementation-plan.md)
 - [`../../../docs/contracts/lens-v1-definition.md`](../../../docs/contracts/lens-v1-definition.md)
 - [`../../../docs/contracts/lens-core-artifact-contracts.md`](../../../docs/contracts/lens-core-artifact-contracts.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,13 +63,19 @@ Supporting research binaries live under `docs/research/assets/`.
   then
   [`decisions/rfc-comparison-result-document-product-flow.md`](decisions/rfc-comparison-result-document-product-flow.md),
   then
+  [`decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md`](decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md),
+  then
+  [`decisions/rfc-document-result-evidence-chain-contract-freeze.md`](decisions/rfc-document-result-evidence-chain-contract-freeze.md),
+  then
   [`decisions/rfc-comparable-result-substrate-and-materials-database-direction.md`](decisions/rfc-comparable-result-substrate-and-materials-database-direction.md)
 - Shared system understanding:
   start with [`overview/system-overview.md`](overview/system-overview.md), then
   move to the relevant module entry page
 - Shared contracts:
-  start with [`contracts/lens-v1-definition.md`](contracts/lens-v1-definition.md)
-  and
+  start with [`contracts/lens-v1-definition.md`](contracts/lens-v1-definition.md),
+  then
+  [`architecture/lens-v1-architecture-boundary.md`](architecture/lens-v1-architecture-boundary.md),
+  then
   [`contracts/lens-core-artifact-contracts.md`](contracts/lens-core-artifact-contracts.md)
 - Historical or proposed shared decisions:
   use docs under [`decisions/`](decisions/)
@@ -127,6 +133,8 @@ Decisions:
 - [`decisions/rfc-paper-facts-primary-domain-model.md`](decisions/rfc-paper-facts-primary-domain-model.md)
 - [`decisions/rfc-comparable-result-substrate-and-materials-database-direction.md`](decisions/rfc-comparable-result-substrate-and-materials-database-direction.md)
 - [`decisions/rfc-comparison-result-document-product-flow.md`](decisions/rfc-comparison-result-document-product-flow.md)
+- [`decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md`](decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md)
+- [`decisions/rfc-document-result-evidence-chain-contract-freeze.md`](decisions/rfc-document-result-evidence-chain-contract-freeze.md)
 
 Research:
 

--- a/docs/architecture/paper-facts-and-comparison-current-state.md
+++ b/docs/architecture/paper-facts-and-comparison-current-state.md
@@ -310,4 +310,4 @@ Until the design is reconciled, changes should preserve these guardrails:
 - [Lens V1 Architecture Boundary](lens-v1-architecture-boundary.md)
 - [RFC Paper-Facts Primary Domain Model and Derived Comparison Views](../decisions/rfc-paper-facts-primary-domain-model.md)
 - [Lens Mission and Positioning](../overview/lens-mission-positioning.md)
-- [Materials Comparison V2 Plan](../../backend/docs/plans/backend-wide/materials-comparison-v2-plan.md)
+- [Materials Comparison V2 Plan](../../backend/docs/plans/backend-wide/materials-comparison-v2/implementation-plan.md)

--- a/docs/contracts/lens-v1-definition.md
+++ b/docs/contracts/lens-v1-definition.md
@@ -62,7 +62,9 @@ That surface should let a user inspect:
 - weak-evidence and conflict flags
 - direct traceback from a surfaced result to source evidence and conditions
 
-Other surfaces may exist in v1, but they are not the acceptance center.
+Single-paper fact inspection and evidence review may exist as supporting
+surfaces, but they support the comparison workspace rather than replacing it
+as the acceptance center.
 
 ## Core V1 Outputs
 
@@ -70,9 +72,10 @@ The outputs that define v1 value are:
 
 - document profiling that distinguishes `experimental`, `review`, `mixed`, and
   `uncertain` papers
-- comparison-ready rows as the primary collection-facing view for material,
-  process, structure, property, and baseline inspection
-- evidence-backed units such as claim, evidence, and condition/context
+- paper-facts-backed comparison-ready rows as the primary collection-facing
+  view for material, process, structure, property, and baseline inspection
+- paper-facts-backed evidence views and reviewable evidence units for claim,
+  result, and condition/context inspection
 - source traceback into original spans or equivalent evidence anchors
 - explicit warnings when a collection or paper is not suitable for protocol
   extraction or direct comparison
@@ -86,7 +89,7 @@ Lens v1 is in scope for:
 
 - evidence-grounded comparison across a collection
 - document typing and protocol suitability signals
-- traceable evidence outputs
+- traceable paper-facts-backed evidence outputs
 - comparability warnings and weak-evidence warnings
 - materials science as the first proving vertical
 - conditional protocol browsing for methods-heavy papers when the corpus
@@ -137,14 +140,17 @@ It should not redefine the whole product as a materials-only protocol system.
 
 This document is the v1 product boundary.
 
-- shared object relationships and artifact roles belong in architecture docs
-- minimum artifact contracts belong in shared specs
+- the shared object model and system boundary belong in
+  [Lens V1 Architecture Boundary](../architecture/lens-v1-architecture-boundary.md)
+- minimum artifact contracts and artifact roles belong in
+  [Lens Core Artifact Contracts](lens-core-artifact-contracts.md)
 - implementation sequencing belongs in backend-local plans
 - long-term product identity belongs in the mission and positioning guide
 
 ## Related Docs
 
 - [Lens Mission and Positioning](../overview/lens-mission-positioning.md)
+- [Lens V1 Architecture Boundary](../architecture/lens-v1-architecture-boundary.md)
 - [Lens Core Artifact Contracts](lens-core-artifact-contracts.md)
 - [Lens Evidence-First Direction and Conditional Protocol Generation](../decisions/rfc-evidence-first-literature-parsing.md)
 - [Lens Agent-Era Positioning and Evidence Layer Direction](../decisions/rfc-lens-agent-era-positioning.md)

--- a/docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md
+++ b/docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md
@@ -1,0 +1,537 @@
+# RFC Document-Result Evidence-Chain Contract Freeze
+
+## Summary
+
+This RFC freezes the next additive contract wave for the two drilldown routes
+that have to support evidence-chain reading:
+
+- `GET /api/v1/collections/{collection_id}/documents/{document_id}/comparison-semantics`
+- `GET /api/v1/collections/{collection_id}/results/{result_id}`
+
+The goal is narrow:
+
+- keep the current Lens v1 product flow
+- keep the current Core semantic backbone
+- freeze the shared payload shape that backend and frontend should implement
+  next for evidence-chain reading
+
+This RFC is a shared contract-freeze page. It does not replace the backend API
+authority, but it does freeze the intended additive payload for the next wave
+so backend and frontend can execute against the same target.
+
+## Relationship To Current Docs
+
+Read this RFC with:
+
+- [RFC Evidence-Chain Product Surface Delivery Roadmap](rfc-evidence-chain-product-surface-delivery-roadmap.md)
+- [RFC Comparison-Result-Document Product Flow](rfc-comparison-result-document-product-flow.md)
+- [Lens V1 Definition](../contracts/lens-v1-definition.md)
+- [Paper Facts And Comparison Current State](../architecture/paper-facts-and-comparison-current-state.md)
+- [`../../backend/docs/specs/api.md`](../../backend/docs/specs/api.md)
+- [`../../backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md`](../../backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md)
+- [`../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md`](../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md)
+
+This RFC should be treated as the shared freeze point for the next additive
+read contract. The backend API spec remains the long-lived authority after the
+routes land.
+
+## Problem
+
+The repository already agrees on the high-level product flow:
+
+`workspace -> comparisons -> result detail -> document detail`
+
+The repository also already agrees on the semantic backbone:
+
+`document_profiles -> paper facts family -> comparable_results -> collection_comparable_results -> row projection`
+
+What is still underspecified is the exact payload contract for the next
+evidence-chain drilldown wave.
+
+Today:
+
+- the backend-local plan already proposes grouped document drilldown
+- the frontend-local proposal already expects variant dossiers, result chains,
+  and result series
+- the shared roadmap already says single-chain trustworthiness comes before
+  collection aggregation
+
+But there is still no single shared page that freezes the exact additive
+contract for the two routes that have to carry that model.
+
+Without this freeze, two failures remain likely:
+
+1. the backend may ship grouped payloads that the frontend has to reinterpret
+2. the frontend may invent dossier or chain groupings that the backend never
+   actually resolved
+
+## Decision
+
+The next-wave contract is frozen by these rules.
+
+### 1. Keep The Existing Route Hierarchy
+
+The next wave does not add a new top-level browser route family.
+
+The user-facing flow remains:
+
+`comparison row -> result -> document`
+
+The route roles remain:
+
+- `comparisons` is the collection-facing analysis layer
+- `results` is the product-facing chain drilldown layer
+- `documents` is the source-verification layer
+
+### 2. Keep Existing Flat Semantic Payloads Intact
+
+The document semantic route keeps the current flat `items` list as part of the
+response.
+
+Grouped dossier and series payloads are additive projections over the same
+underlying semantic truth. They must not become a conflicting second truth.
+
+### 3. Freeze Grouped Document Drilldown As An Additive Projection
+
+The document semantic route is the canonical backend source for document-side
+variant dossier and result-series grouping.
+
+The frontend should not invent unsupported semantic grouping from raw text when
+the backend has not resolved it.
+
+### 4. Freeze Result Detail As A Chain-First Product Projection
+
+The result detail route remains the product-facing object contract, but its
+next additive fields must make one result readable as one evidence chain rather
+than only as one measurement card.
+
+## Frozen Route 1: Document Comparison Semantics
+
+### Route
+
+`GET /api/v1/collections/{collection_id}/documents/{document_id}/comparison-semantics`
+
+### Existing Behavior To Preserve
+
+The route keeps these current top-level fields:
+
+- `collection_id`
+- `document_id`
+- `total`
+- `count`
+- `items`
+
+The route also keeps the existing optional `include_row_projections` behavior.
+
+### New Query Parameter
+
+Freeze one additive query parameter:
+
+- `include_grouped_projections: bool = false`
+
+Rules:
+
+- when omitted or `false`, the route may omit grouped fields
+- when `true`, the route must include `variant_dossiers`
+- grouped fields remain derived from the same semantic facts as `items`
+
+### New Top-Level Additive Field
+
+When `include_grouped_projections=true`, the response must add:
+
+- `variant_dossiers`
+
+### Frozen `variant_dossiers` Shape
+
+Each dossier must contain:
+
+- `variant_id`
+- `variant_label`
+- `material`
+- `shared_process_state`
+- `shared_missingness`
+- `series`
+
+Frozen object shape:
+
+```json
+{
+  "variant_id": "var_x",
+  "variant_label": "optimized VED + HIP",
+  "material": {
+    "label": "Ti-6Al-4V",
+    "composition": "Ti-6Al-4V",
+    "host_material_system": {
+      "family": "titanium alloy",
+      "composition": "Ti-6Al-4V"
+    }
+  },
+  "shared_process_state": {
+    "laser_power_w": 280,
+    "scan_speed_mm_s": 1200,
+    "layer_thickness_um": 30,
+    "hatch_spacing_um": 100,
+    "build_orientation": "vertical",
+    "post_treatment_summary": "HIP"
+  },
+  "shared_missingness": [
+    "powder_oxygen_not_reported"
+  ],
+  "series": []
+}
+```
+
+Rules:
+
+- `shared_process_state` carries dossier-level process or sample-state facts
+- test-side fields do not belong in `shared_process_state`
+- `shared_missingness` is for gaps that affect all child chains of the dossier
+
+### Frozen `series` Shape
+
+Each dossier `series` item must contain:
+
+- `series_key`
+- `property_family`
+- `test_family`
+- `varying_axis`
+- `chains`
+
+Frozen object shape:
+
+```json
+{
+  "series_key": "tensile:test_temperature_c",
+  "property_family": "tensile",
+  "test_family": "tensile",
+  "varying_axis": {
+    "axis_name": "test_temperature_c",
+    "axis_unit": "C"
+  },
+  "chains": []
+}
+```
+
+Rules:
+
+- one series groups sibling chains only when the same dossier is fixed
+- one series groups sibling chains only when one explicit test-side axis varies
+- process or sample-state changes must split into different dossiers, not into
+  one series
+
+### Frozen `chains` Shape Inside A Series
+
+Each chain item must contain:
+
+- `result_id`
+- `source_result_id`
+- `measurement`
+- `test_condition`
+- `baseline`
+- `assessment`
+- `value_provenance`
+- `evidence`
+
+Frozen object shape:
+
+```json
+{
+  "result_id": "cmp_x",
+  "source_result_id": "mr_x",
+  "measurement": {
+    "property": "yield_strength",
+    "value": 940.0,
+    "unit": "MPa",
+    "result_type": "scalar",
+    "summary": "YS 940 MPa",
+    "statistic_type": null,
+    "uncertainty": null
+  },
+  "test_condition": {
+    "test_method": "tensile",
+    "test_temperature_c": 25.0,
+    "strain_rate_s-1": 0.001,
+    "loading_direction": "vertical",
+    "sample_orientation": "vertical"
+  },
+  "baseline": {
+    "label": "S2",
+    "reference": "optimized VED without HIP",
+    "baseline_type": "same_paper_control",
+    "resolved": true
+  },
+  "assessment": {
+    "comparability_status": "comparable",
+    "warnings": [],
+    "basis": [
+      "variant_linked",
+      "baseline_resolved",
+      "test_condition_resolved"
+    ],
+    "missing_context": [],
+    "requires_expert_review": false,
+    "assessment_epistemic_status": "normalized_from_evidence"
+  },
+  "value_provenance": {
+    "value_origin": "reported",
+    "source_value_text": "940",
+    "source_unit_text": "MPa",
+    "derivation_formula": null,
+    "derivation_inputs": null
+  },
+  "evidence": {
+    "evidence_ids": [
+      "evi_x"
+    ],
+    "direct_anchor_ids": [
+      "anc_x"
+    ],
+    "contextual_anchor_ids": [],
+    "structure_feature_ids": [
+      "sf_x"
+    ],
+    "characterization_observation_ids": [
+      "obs_x"
+    ],
+    "traceability_status": "direct"
+  }
+}
+```
+
+Rules:
+
+- `measurement` is the display-facing measurement summary for the chain row
+- `test_condition` is chain-local and may differ across siblings in one series
+- `baseline.resolved=false` is allowed when the link remains unresolved
+- `assessment` stays collection-scoped when collection overlays exist
+- `value_provenance` must distinguish reported and derived values explicitly
+- `evidence` keeps ids needed for traceback and drilldown; frontend should use
+  these ids rather than infer anchors from text
+
+## Frozen Route 2: Result Detail
+
+### Route
+
+`GET /api/v1/collections/{collection_id}/results/{result_id}`
+
+### Existing Behavior To Preserve
+
+The route keeps these current top-level fields:
+
+- `result_id`
+- `document`
+- `material`
+- `measurement`
+- `context`
+- `assessment`
+- `evidence`
+- `actions`
+
+The route remains the product-facing projection over:
+
+- one `ComparableResult`
+- one current-collection `CollectionComparableResult`
+
+It must not expose raw semantic substrate fields such as:
+
+- `binding`
+- `normalized_context`
+- `collection_overlays`
+
+as the primary page contract.
+
+### New Top-Level Additive Fields
+
+Freeze these additive fields:
+
+- `variant_dossier`
+- `test_condition_detail`
+- `baseline_detail`
+- `structure_support`
+- `value_provenance`
+- `series_navigation`
+
+### Frozen `variant_dossier` Shape
+
+```json
+{
+  "variant_id": "var_x",
+  "variant_label": "optimized VED + HIP",
+  "material": {
+    "label": "Ti-6Al-4V",
+    "composition": "Ti-6Al-4V"
+  },
+  "shared_process_state": {
+    "laser_power_w": 280,
+    "scan_speed_mm_s": 1200,
+    "build_orientation": "vertical",
+    "post_treatment_summary": "HIP"
+  },
+  "shared_missingness": []
+}
+```
+
+Rules:
+
+- this object is the parent dossier summary for the current chain
+- it is not a second page model; it is supporting context for the result page
+
+### Frozen `test_condition_detail` Shape
+
+```json
+{
+  "test_method": "tensile",
+  "test_temperature_c": 25.0,
+  "strain_rate_s-1": 0.001,
+  "loading_direction": "vertical",
+  "sample_orientation": "vertical",
+  "environment": null,
+  "frequency_hz": null,
+  "specimen_geometry": null,
+  "surface_state": null
+}
+```
+
+### Frozen `baseline_detail` Shape
+
+```json
+{
+  "label": "S2",
+  "reference": "optimized VED without HIP",
+  "baseline_type": "same_paper_control",
+  "baseline_scope": "current_paper",
+  "resolved": true
+}
+```
+
+### Frozen `structure_support` Shape
+
+`structure_support` must be a list of support summaries. Each item must
+contain:
+
+- `support_id`
+- `support_type`
+- `summary`
+- `condition`
+
+Example:
+
+```json
+[
+  {
+    "support_id": "obs_x",
+    "support_type": "characterization_observation",
+    "summary": "Porosity 0.1% with fracture SEM support",
+    "condition": {
+      "characterization_temperature_c": null
+    }
+  }
+]
+```
+
+Rule:
+
+- characterization temperature belongs inside support condition, not under
+  `test_condition_detail` and not under dossier process state
+
+### Frozen `value_provenance` Shape
+
+```json
+{
+  "value_origin": "reported",
+  "source_value_text": "940",
+  "source_unit_text": "MPa",
+  "derivation_formula": null,
+  "derivation_inputs": null
+}
+```
+
+### Frozen `series_navigation` Shape
+
+```json
+{
+  "series_key": "tensile:test_temperature_c",
+  "varying_axis": {
+    "axis_name": "test_temperature_c",
+    "axis_unit": "C"
+  },
+  "siblings": [
+    {
+      "result_id": "cmp_x",
+      "axis_value": 25.0,
+      "axis_unit": "C",
+      "measurement": {
+        "property": "yield_strength",
+        "value": 940.0,
+        "unit": "MPa"
+      }
+    }
+  ]
+}
+```
+
+Rules:
+
+- `series_navigation` is optional when no sibling series exists
+- siblings must stay inside the same dossier and property or test family
+- process-side variation must not be collapsed into one series
+
+## Compatibility Rules
+
+These freezes are additive.
+
+The next implementation wave must preserve:
+
+- current route paths
+- current top-level route purposes
+- current flat `items` response on the document semantic route
+- current result detail root contract
+
+The next implementation wave must not:
+
+- add a new top-level `variant-dossiers` browser resource
+- replace result detail with raw comparable-result retrieval payloads
+- make the frontend compute authoritative dossier or chain identity from raw
+  source text
+
+## Non-Goals
+
+This contract freeze does not define:
+
+- experiment-planning payloads
+- collection-level synthesis payloads
+- new comparison row contracts
+- corpus-wide material dossier contracts
+- extraction prompt wording
+
+## Adoption Rule
+
+The intended adoption order is:
+
+1. implement backend fact thickening and provenance support
+2. implement backend grouped projections for the document semantic route
+3. implement backend additive chain-first fields for result detail
+4. implement frontend dossier, series, and chain reading surfaces against
+   these frozen payloads
+5. absorb the landed route shapes back into the long-lived backend API spec
+
+## Open Question Left Intentionally Narrow
+
+This RFC intentionally does not freeze a separate top-level paper overview
+payload for the document route.
+
+For the first wave:
+
+- the frontend may derive paper-level counts from `items` and
+  `variant_dossiers`
+- if later implementation proves that a backend-authored paper summary is
+  necessary, that should be a follow-up additive RFC instead of a silent
+  expansion here
+
+## Related Docs
+
+- [RFC Evidence-Chain Product Surface Delivery Roadmap](rfc-evidence-chain-product-surface-delivery-roadmap.md)
+- [RFC Comparison-Result-Document Product Flow](rfc-comparison-result-document-product-flow.md)
+- [`../../backend/docs/specs/api.md`](../../backend/docs/specs/api.md)
+- [`../../backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md`](../../backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md)
+- [`../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md`](../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md)

--- a/docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md
+++ b/docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md
@@ -1,0 +1,437 @@
+# RFC Evidence-Chain Product Surface Delivery Roadmap
+
+## Summary
+
+This RFC records the shared delivery order for the next Lens wave that turns
+the existing paper-facts and comparable-result backbone into a researcher-
+readable evidence-chain product surface.
+
+This page should be treated as the overall cross-module planning entry point
+for this wave.
+
+The core judgment is:
+
+- the current semantic backbone is good enough to keep
+- the next step is not a new top-level substrate
+- the next step is to make one narrow vertical readable as:
+  - one paper
+  - several variant dossiers
+  - several result chains under each dossier
+  - several result-series rows when only a test-side axis varies
+
+The first acceptance target for this roadmap is a narrow PBF-metal slice.
+
+This RFC is a shared cross-module delivery guide. It does not replace the
+backend API authority, backend Core plan family, or frontend route-family
+implementation docs.
+
+## Relationship To Current Docs
+
+Read this RFC with:
+
+- [Lens V1 Definition](../contracts/lens-v1-definition.md)
+- [Lens V1 Architecture Boundary](../architecture/lens-v1-architecture-boundary.md)
+- [Paper Facts And Comparison Current State](../architecture/paper-facts-and-comparison-current-state.md)
+- [RFC Paper-Facts Primary Domain Model and Derived Comparison Views](rfc-paper-facts-primary-domain-model.md)
+- [RFC Comparison-Result-Document Product Flow](rfc-comparison-result-document-product-flow.md)
+- [RFC Document-Result Evidence-Chain Contract Freeze](rfc-document-result-evidence-chain-contract-freeze.md)
+
+The main module-owned implementation companions are:
+
+- [`../../backend/docs/plans/backend-wide/evidence-chain-product-surface/backend-implementation-plan.md`](../../backend/docs/plans/backend-wide/evidence-chain-product-surface/backend-implementation-plan.md)
+- [`../../backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md`](../../backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md)
+- [`../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md`](../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md)
+
+This RFC should be used to coordinate the order of delivery across modules.
+It should not be used as the backend schema authority or as the frontend page
+spec by itself.
+
+## Planning Role
+
+Use this roadmap when the question is:
+
+- what the shared target end state is
+- which layer has to be made trustworthy first
+- what order backend and frontend work should ship in
+- what the narrow-wave acceptance bar is
+
+Use the module-owned companion docs when the question is:
+
+- which backend files and payloads change
+- which frontend route surfaces and groupings change
+- which local verification commands should run
+
+This roadmap exists to prevent backend and frontend from carrying separate
+"master plans" for the same wave.
+
+## Problem
+
+Lens has already moved away from a summary-first reading model.
+
+The current runtime and contracts are already centered on:
+
+`document_profiles -> paper facts family -> comparable_results -> collection_comparable_results -> row projection`
+
+The remaining issue is that this backbone is still not thick enough and not
+surfaced clearly enough to satisfy a researcher who needs a full experimental
+evidence chain.
+
+Today the main gap is not:
+
+- whether the system has `variant` and `result` objects
+
+The main gap is:
+
+- whether one paper can be projected into stable evidence chains with enough
+  process, test, structure, baseline, provenance, and comparability detail to
+  support real review and next-step decisions
+
+If the backend and frontend continue to evolve independently, three problems
+follow:
+
+1. the backend may add fields without producing a readable drilldown unit
+2. the frontend may invent grouping logic that the semantic truth does not
+   support
+3. the system may look more detailed while still failing the actual research
+   job
+
+## Execution Hierarchy
+
+The wave should be understood through four nested units of work.
+
+### 1. Result Chain Is The Foundational Acceptance Unit
+
+The first unit that must become trustworthy is one result chain:
+
+- one variant or sample state
+- one test-condition set
+- one result or tightly coupled result bundle
+- one baseline interpretation
+- one support path back to anchors
+
+If this unit is unstable or semantically mixed, every higher grouping will
+amplify the error.
+
+### 2. Variant Dossier Groups Stable Chains Inside One Paper
+
+A variant dossier is a paper-local grouping over shared sample or process
+state. It is only trustworthy after the child result chains are trustworthy.
+
+### 3. Collection Comparison Aligns Chains Across Papers
+
+Collection comparison is a semantic alignment and assessment layer over many
+result chains inside one collection.
+
+It should answer:
+
+- which chains can be compared
+- which chains remain limited or blocked
+- which missing fields or provenance issues explain the limit
+
+It should not be treated as a replacement for the underlying chain truth.
+
+### 4. Collection Synthesis And Experiment Planning Stay Downstream
+
+Broader material-level synthesis or experiment-planning output may eventually
+be added as a higher projection, but it is not the first acceptance target for
+this wave.
+
+The first wave succeeds when evidence-chain reconstruction and collection-level
+comparison become trustworthy enough that downstream synthesis no longer has to
+guess.
+
+## Target End State
+
+The first accepted end state for this roadmap is:
+
+- one narrow materials vertical can be read and reviewed as an evidence-chain
+  system rather than as a summary system
+
+In practical terms, that means:
+
+### On The Backend
+
+- `sample_variants`, `test_conditions`, and `measurement_results` are thick
+  enough to represent a PBF-metal evidence chain
+- value provenance is explicit enough to distinguish reported, derived, and
+  estimated values
+- comparability assessment reflects real review constraints such as
+  orientation, strain rate, baseline type, and missing source parameters
+- document and result drilldown can expose grouped dossier and chain
+  projections without adding a new permanent top-level artifact family
+
+### On The Frontend
+
+- one document can be read as several variant dossiers
+- each dossier can show grouped result chains or result-series rows
+- one result page can explain one full evidence chain instead of one isolated
+  measurement
+- source anchors remain one click away from any chain row
+
+### At The Product Level
+
+- the intended user flow remains:
+
+`workspace -> comparisons -> result detail -> document detail`
+
+- but the result and document pages become evidence-chain reading surfaces
+  rather than thin detail shells
+
+## Acceptance Ladder
+
+This wave should be accepted in this order:
+
+1. one result chain is reconstructed honestly and repeatedly
+2. one paper can be read as several variant dossiers over those chains
+3. one collection can compare those chains without hiding missingness or
+   provenance
+4. only after the first three are reliable should broader synthesis or
+   experiment-planning claims be treated as credible
+
+This ladder is important because collection aggregation is only a useful
+projection when the single-chain layer is already stable.
+
+## Delivery Order
+
+The shared delivery order should be:
+
+1. backend fact thickening
+2. backend comparability and provenance policy
+3. backend grouped drilldown projection
+4. frontend document-page dossier and series surface
+5. frontend result-page chain surface
+6. collection-workspace handoff and end-to-end acceptance
+
+The rest of this RFC explains why this order matters.
+
+### Phase 1: Backend Fact Thickening
+
+Goal:
+
+- make the Core truth thick enough before any UI tries to present evidence
+  chains
+
+This phase should add the minimum PBF-metal fact detail needed for:
+
+- shared process or sample state
+- test conditions
+- structure and characterization support
+- value provenance
+
+It should explicitly avoid creating a second semantic backbone.
+
+This phase is done when the backend can distinguish at least:
+
+- process temperature
+- test temperature
+- characterization temperature
+- reported value
+- derived value
+
+without forcing the frontend to guess.
+
+### Phase 2: Backend Comparability And Provenance Policy
+
+Goal:
+
+- make collection-scoped judgments reflect real evidence-chain missingness
+
+This phase should tighten `ComparableResult` assessment for the narrow
+materials slice, including checks such as:
+
+- missing orientation
+- missing strain rate
+- unresolved baseline type
+- derived energy density without adequate source parameters
+
+This phase is done when a result can be marked `comparable`, `limited`,
+`insufficient`, or `not_comparable` for reasons that a domain reviewer would
+recognize as meaningful.
+
+### Phase 3: Backend Grouped Drilldown Projection
+
+Goal:
+
+- expose dossier, chain, and series read projections over the existing
+  semantic truth
+
+This phase should add grouped drilldown to the existing read paths rather than
+replace them with a breaking contract wave.
+
+The main required outputs are:
+
+- document-scoped grouped drilldown
+- result-scoped chain context
+- explicit provenance and missingness fields for UI use
+
+This phase is done when one paper can be projected into stable dossier and
+chain groupings from the current Core truth.
+
+### Phase 4: Frontend Document-Page Dossier And Series Surface
+
+Goal:
+
+- make the document page a real source-reading page with an evidence review
+  panel
+
+This phase should introduce:
+
+- paper overview
+- variant dossier list
+- grouped result series under each dossier
+- chain detail drawer
+- source-anchor jump actions
+
+This phase is done when a user can inspect one paper and answer:
+
+- which variants exist
+- what process or sample state is shared
+- which results change only because a test-side axis changes
+
+without leaving the document page.
+
+### Phase 5: Frontend Result-Page Chain Surface
+
+Goal:
+
+- make the result page readable as one evidence chain
+
+This phase should reframe result detail around:
+
+- parent variant dossier
+- process or sample state
+- test condition
+- structure support
+- result values
+- baseline
+- comparability
+- provenance
+- source anchors
+
+This phase is done when the result page can explain why a value matters before
+the user needs to return to the comparison table or source document.
+
+### Phase 6: Collection Handoff And End-To-End Acceptance
+
+Goal:
+
+- make the collection flow coherent from comparison row into evidence-chain
+  drilldown
+
+This phase should verify the full path:
+
+`comparison row -> result chain -> source document anchors`
+
+It should also verify that the system can support a first real narrow-vertical
+research review rather than only a more detailed looking UI.
+
+## Acceptance Gates
+
+This roadmap should be treated as successful only when all of the following
+are true on the narrow target corpus.
+
+### 1. Stable Single-Chain Reconstruction
+
+Given one paper, the system can repeatedly reconstruct:
+
+- the same current-work result chains
+- the same parent variant binding
+- the same baseline and test-condition binding
+- the same source-linked support trail
+
+within normal model variance bounds.
+
+### 2. Honest Missingness
+
+The system reports missing conditions instead of inventing them.
+
+Important examples include:
+
+- missing strain rate
+- missing build orientation
+- missing baseline type
+- missing source parameters for a derived value
+
+### 3. Temperature Semantics Stay Separated
+
+The system does not collapse these into one generic field:
+
+- process temperature
+- test temperature
+- characterization temperature
+
+### 4. Document Pages Support Variant Review
+
+One document page can support a researcher reviewing:
+
+- the paper's variants
+- the result series under each variant
+- the supporting source anchors
+
+without falling back to a raw list of unrelated results.
+
+### 5. Collection Comparison Preserves Chain Honesty
+
+Collection comparison groups and filters stable chains without hiding that a
+row is limited by:
+
+- missing test context
+- missing baseline meaning
+- unresolved provenance
+- non-comparable sample-state differences
+
+### 6. Result Pages Carry Real Chain Context
+
+One result page can explain:
+
+- what was measured
+- under what test condition
+- for which variant
+- relative to which baseline
+- with what structure or characterization support
+- with what provenance and comparability warnings
+
+## Boundary Rules
+
+This roadmap should not be misread as permission to:
+
+- add a new permanent `variant_dossiers` artifact family
+- treat collection aggregation as a replacement for stable single-chain facts
+- turn the frontend into a second semantic owner
+- broaden the first delivery wave beyond the narrow proving vertical
+- skip comparability and provenance work in favor of presentation polish
+- treat experimental planning output as done before evidence-chain
+  reconstruction is reliable
+
+## Risks
+
+- the backend may still be too generic in areas outside the first vertical
+- grouped drilldown can become unstable if fact thickening is incomplete
+- the frontend may overfit to the first materials slice if grouped projections
+  are not kept additive and explicit
+- cross-module sequencing can drift if module-local plans are updated without
+  a shared acceptance conversation
+
+## Adoption Notes
+
+The preferred adoption pattern is:
+
+1. finish the backend-local dossier and chain support slices
+2. expose additive grouped drilldown payloads
+3. build the frontend document and result reading surfaces against those
+   payloads
+4. validate the full comparison-to-document path on the narrow corpus
+5. only then discuss broader experiment-planning automation
+
+The main point of this order is simple:
+
+- evidence-chain reconstruction must become reliable before downstream
+  research-planning claims are treated as trustworthy
+
+## Related Docs
+
+- [RFC Comparison-Result-Document Product Flow](rfc-comparison-result-document-product-flow.md)
+- [RFC Paper-Facts Primary Domain Model and Derived Comparison Views](rfc-paper-facts-primary-domain-model.md)
+- [`../../backend/docs/plans/backend-wide/evidence-chain-product-surface/backend-implementation-plan.md`](../../backend/docs/plans/backend-wide/evidence-chain-product-surface/backend-implementation-plan.md)
+- [`../../backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md`](../../backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/variant-dossier-and-result-chain-backend-plan.md)
+- [`../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md`](../../frontend/src/routes/collections/document-result-evidence-chain-proposal.md)

--- a/docs/decisions/rfc-paper-facts-primary-domain-model.md
+++ b/docs/decisions/rfc-paper-facts-primary-domain-model.md
@@ -30,15 +30,15 @@ The current shared product boundary remains defined by:
 - [Lens V1 Definition](../contracts/lens-v1-definition.md)
 - [Lens Mission and Positioning](../overview/lens-mission-positioning.md)
 
-The current shared artifact contracts and architecture boundary still reflect a
-stronger claim-centered backbone:
+The current shared architecture and shared artifact contracts that promoted
+this correction now live in:
 
-- [Lens Core Artifact Contracts](../contracts/lens-core-artifact-contracts.md)
 - [Lens V1 Architecture Boundary](../architecture/lens-v1-architecture-boundary.md)
+- [Lens Core Artifact Contracts](../contracts/lens-core-artifact-contracts.md)
 
-This RFC proposes the next reconciliation step. It should not be treated as
-the current source of truth until the repository accepts the change and updates
-the shared contracts and architecture docs.
+This RFC should now be read as the historical rationale for the paper-facts
+correction and the tradeoffs behind it. It is not the current source of truth
+for the shared object model or artifact contracts.
 
 ## Context
 
@@ -56,9 +56,9 @@ In practical product terms, Lens needs both:
 2. a comparison surface that tells the user which extracted results can be
    inspected side by side without misleading them
 
-The current repository has drifted into a hybrid state:
+When this RFC was written, the repository had drifted into a hybrid state:
 
-- shared contracts still define `evidence_cards` as the core research object
+- shared contracts still defined `evidence_cards` as the core research object
 - the materials comparison direction already relies more heavily on
   `sample_variants`, `measurement_results`, `test_conditions`, and
   `baseline_references`
@@ -405,4 +405,4 @@ That risk is still lower than preserving the current ambiguity indefinitely.
 - [Lens Core Artifact Contracts](../contracts/lens-core-artifact-contracts.md)
 - [Lens V1 Architecture Boundary](../architecture/lens-v1-architecture-boundary.md)
 - [Lens Evidence-First Direction and Conditional Protocol Generation](rfc-evidence-first-literature-parsing.md)
-- [Materials Comparison V2 Plan](../../backend/docs/plans/backend-wide/materials-comparison-v2-plan.md)
+- [Materials Comparison V2 Plan](../../backend/docs/plans/backend-wide/materials-comparison-v2/implementation-plan.md)

--- a/docs/overview/lens-mission-positioning.md
+++ b/docs/overview/lens-mission-positioning.md
@@ -104,6 +104,34 @@ enough that it can later support:
 That direction should extend the evidence-and-comparison philosophy rather than
 replace it with generic chat or opaque database convenience.
 
+## Post-V1 Workflow Direction
+
+Beyond the current Lens v1 comparison foundation, Lens should move toward
+supporting how professional materials researchers actually work with papers and
+follow-up experiments.
+
+That workflow is not "read a paper and summarize it". It is:
+
+- identify the research problem and the decision the paper is trying to support
+- reconstruct sample variants, controlled variables, process parameters, test
+  conditions, and baselines
+- connect process, structure, defects, properties, and evidence into one
+  inspectable chain
+- judge which results are genuinely comparable and which remain weak,
+  incomplete, or baseline-misaligned
+- turn the literature into candidate hypotheses, control groups, parameter
+  matrices, characterization plans, and decision criteria for the next
+  experiment
+
+If Lens grows in this direction, it should help users treat one paper as an
+experimental design and evidence object rather than only as prose. It should
+help them review literature as variable tables, condition-bound results,
+baseline-aware comparisons, and mechanism-backed evidence chains.
+
+The output of that later workflow should remain human-reviewable. Lens should
+help researchers propose and evaluate experiment plans, not pretend to replace
+scientific judgment with a generic autonomous agent.
+
 ## Related Docs
 
 - [Lens V1 Definition](../contracts/lens-v1-definition.md)

--- a/frontend/src/routes/collections/README.md
+++ b/frontend/src/routes/collections/README.md
@@ -16,6 +16,11 @@ This node owns the collection workspace route family in the frontend.
 
 ## Local Docs
 
+- [`../../../../docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md`](../../../../docs/decisions/rfc-evidence-chain-product-surface-delivery-roadmap.md)
+  Shared cross-module roadmap and overall delivery order for the evidence-chain
+  wave
+- [`../../../../docs/decisions/rfc-comparison-result-document-product-flow.md`](../../../../docs/decisions/rfc-comparison-result-document-product-flow.md)
+  Shared product-flow decision for comparison, result, and document drilldown
 - [`lens-v1-interface-spec.md`](lens-v1-interface-spec.md)
   Collection-facing interface spec for the Lens v1 workspace flow
 - [`core-derived-graph-structure-and-drilldown-frontend-alignment-plan.md`](core-derived-graph-structure-and-drilldown-frontend-alignment-plan.md)
@@ -38,6 +43,9 @@ This node owns the collection workspace route family in the frontend.
 - [`collection-ui-restructure-proposal.md`](collection-ui-restructure-proposal.md)
   Follow-on collection UI restructuring proposal for state hierarchy and page
   information architecture
+- [`document-result-evidence-chain-proposal.md`](document-result-evidence-chain-proposal.md)
+  Frontend-local proposal for reading documents and results as variant dossiers,
+  result chains, and result series
 - [`claim-traceback-navigation-contract.md`](claim-traceback-navigation-contract.md)
   Claim-to-source navigation contract for comparison/evidence to document
   traceback behavior

--- a/frontend/src/routes/collections/collection-main-flow-frontend-test-plan.md
+++ b/frontend/src/routes/collections/collection-main-flow-frontend-test-plan.md
@@ -195,12 +195,18 @@ Files:
 
 Changes:
 
-- add tests that render result detail with measurement, context, assessment,
-  and evidence sections
+- add tests that render result detail with chain-first sections:
+  - parent variant dossier summary
+  - chain-local test condition or baseline detail
+  - collection assessment
+  - evidence support
+  - value provenance
 - assert the page exposes the source-document action
 - assert the source-document action points to
   `/collections/{id}/documents/{document_id}`
 - assert the page keeps the comparison return path visible
+- add one assertion for optional sibling series navigation when the fixture
+  includes related chains
 
 ### 5. Document detail coverage
 
@@ -211,10 +217,15 @@ Files:
 
 Changes:
 
-- add tests that render document detail with related results
-- assert related results link back into result detail
-- keep source-verification and related-result behavior covered in the same page
-  test instead of splitting the product story across two disconnected specs
+- add tests that render document detail with:
+  - variant dossier summary or dossier list
+  - grouped result series
+  - related result drilldown
+- assert one series row opens or exposes full chain detail
+- assert document detail still links back into result detail where applicable
+- keep source-verification, dossier review, and related-result behavior covered
+  in the same page test instead of splitting the product story across two
+  disconnected specs
 
 ### 6. Optional Playwright main-flow guard
 

--- a/frontend/src/routes/collections/document-result-evidence-chain-proposal.md
+++ b/frontend/src/routes/collections/document-result-evidence-chain-proposal.md
@@ -1,0 +1,421 @@
+# Document And Result Evidence-Chain Proposal
+
+## Purpose
+
+This document records a frontend-local proposal for making `documents` and
+`results` readable as evidence-chain surfaces instead of generic detail pages.
+
+It narrows the collection route family to one specific UI question:
+
+- what should the frontend use as the primary reading unit once semantic
+  comparison artifacts are available
+
+It does not redefine the shared Lens v1 product boundary or the backend API
+contract.
+
+## Why This Needs A Separate Proposal
+
+The existing route-family docs already define the broad Lens v1 hierarchy:
+
+- `comparisons` is the primary analysis surface
+- `results` is the core drilldown object
+- `documents` is the source verification surface
+- `evidence` remains a support layer
+
+What those docs do not yet define tightly enough is how a researcher should
+read a paper or one extracted result when the work depends on an experimental
+evidence chain rather than on one isolated value.
+
+This gap matters most in materials and other experimental domains where one
+reported number is not meaningful without:
+
+- sample or variant state
+- processing history
+- test conditions
+- structure or defect evidence
+- baseline meaning
+- comparability limits
+
+This proposal records the frontend reading model for that narrower problem.
+
+## Scope
+
+In scope:
+
+- document detail information architecture
+- result detail information architecture
+- frontend grouping model for `variant dossier`, `result chain`, and
+  `result series`
+- source-viewer and anchor interactions for those groupings
+- UI rules for separating process conditions, test conditions, and structure
+  observations
+
+Out of scope:
+
+- backend schema redesign
+- shared product hierarchy between workspace, comparisons, results, and
+  documents
+- extraction prompt design
+- collection-level comparison table redesign beyond entry points into the new
+  drilldown model
+
+## Reader Questions
+
+The proposed document and result surfaces should let a user answer these
+questions quickly:
+
+1. Which sample or variant states appear in this paper?
+2. What process or sample-state context is shared by each variant?
+3. Which result chains belong to each variant?
+4. Which parts of the result change because the test condition changed?
+5. What structure or defect evidence supports the reported behavior?
+6. Which missing fields or warnings limit cross-paper comparison?
+
+## Core Reading Model
+
+The frontend should use four nested reading units.
+
+### Paper
+
+The paper remains the entry point for document reading.
+
+At this level the UI should summarize:
+
+- material system
+- process route
+- primary property families covered
+- variant count
+- missingness or traceability warnings that affect the whole paper
+
+### Variant Dossier
+
+A `variant dossier` is the shared experimental state for one normalized sample
+or material condition inside a paper.
+
+Examples:
+
+- `optimized VED`
+- `optimized VED + HIP`
+- `900 C annealed`
+
+The dossier should carry the context that does not change across its child
+chains:
+
+- material label or composition
+- normalized variant label
+- process or sample-state fields
+- shared structure evidence when that evidence applies to the whole variant
+- known missing fields that affect all child chains
+
+### Result Chain
+
+A `result chain` is the smallest drilldown unit that should appear as a
+complete, reviewable piece of evidence in the frontend.
+
+One result chain should bind together:
+
+- one variant
+- one fixed result context
+- one test condition set
+- one result or tightly coupled result bundle
+- one baseline interpretation
+- one support trail back to source anchors
+
+In practice, a result chain should answer:
+
+- what was measured
+- under which conditions
+- relative to what baseline
+- with what supporting structure or defect evidence
+- with what comparability limits
+
+### Result Series
+
+A `result series` is a UI grouping for multiple sibling result chains that keep
+the same variant dossier and only vary along one test-side axis.
+
+Typical example:
+
+- same `optimized VED + HIP` variant
+- same tensile method
+- same orientation and strain rate
+- test temperature changes from `25 C` to `400 C` to `650 C`
+
+The frontend should render these as one series instead of as unrelated cards.
+
+## Chain Identity Rules
+
+The frontend should group data with these rules.
+
+### Keep One Variant Dossier When Process Or Sample State Is Shared
+
+Fields that belong to the dossier include:
+
+- composition
+- powder or feedstock state when available
+- process parameters
+- post-treatment history
+- build orientation when it is part of sample preparation
+- exposure or aging history before testing
+
+If one of those changes in a way that creates a new sample state, the frontend
+should treat it as a different variant dossier instead of as one series row.
+
+### Create Separate Result Chains When Test Context Changes
+
+A result chain changes when test-side conditions change, such as:
+
+- test temperature
+- strain rate
+- loading direction
+- environment
+- frequency
+- specimen state at test time
+
+These are different chains even when the parent variant dossier stays the
+same.
+
+### Use A Result Series Only For Test-Side Variation
+
+The frontend should build a series when:
+
+- the same variant dossier is fixed
+- the same property family is fixed
+- the same test family is fixed
+- one explicit test-side axis varies in a user-readable way
+
+Good series axes include:
+
+- test temperature
+- strain rate
+- hold time
+- cycle count bucket
+
+The frontend should not collapse rows into one series when the apparent axis is
+actually a process or sample-state change.
+
+## Temperature Placement Rules
+
+Temperature is the most common place where semantics get mixed, so the UI needs
+explicit placement rules.
+
+### Process Temperature
+
+Examples:
+
+- preheat temperature
+- HIP temperature
+- solution-treatment temperature
+- aging temperature
+
+These belong in the variant dossier under shared process or sample state.
+
+If the temperature change creates a different treatment condition, it usually
+creates a different variant dossier.
+
+### Test Temperature
+
+Examples:
+
+- room-temperature tensile
+- `400 C` tensile
+- `650 C` creep
+
+These belong in the result chain under test condition.
+
+If the same variant is tested at multiple temperatures, the frontend should
+keep one variant dossier and show multiple result chains inside one result
+series.
+
+### Characterization Temperature
+
+Examples:
+
+- in-situ heated XRD
+- DSC scan temperature
+- hot-stage microscopy
+
+These belong under structure or observation conditions, not under process
+state and not under the main test axis unless the measured property is itself a
+characterization result.
+
+## Document Page Proposal
+
+The document page should become a source-reading page with an evidence review
+panel, not only a content viewer plus related result links.
+
+### Layout
+
+- left: source viewer or content viewer with anchor highlighting
+- right: evidence review panel
+- bottom or secondary panel: cross-paper entry points when needed
+
+### Evidence Review Panel
+
+The right panel should have these top-level tabs:
+
+- `Overview`
+- `Variants`
+- `Chains`
+- `Missingness`
+
+### Overview Tab
+
+This tab should summarize:
+
+- paper scope
+- material system
+- process route
+- primary properties covered
+- number of variants
+- number of result chains
+- paper-level missingness or traceability warnings
+
+### Variants Tab
+
+This should list one card per variant dossier.
+
+Each card should show:
+
+- normalized variant label
+- material system
+- shared process or sample state
+- properties covered
+- shared evidence summary
+- shared missingness badges
+
+Selecting a dossier should expand its child result series.
+
+### Result Series In Document View
+
+Inside one dossier, result chains should be grouped into series when possible.
+
+Example:
+
+```text
+Variant S3 = optimized VED + HIP
+
+Shared state
+P=280 W, v=1200 mm/s, h=100 um, t=30 um
+HIP=yes
+
+Tensile vs test temperature
+25 C  -> YS 940, UTS 1040, EL 15%
+400 C -> YS 780, UTS 860, EL 18%
+650 C -> YS 520, UTS 610, EL 22%
+```
+
+Each row should expose:
+
+- the varying axis value
+- primary result values
+- baseline label
+- comparability status
+- missingness or warning badges
+- an action to open full chain detail
+
+### Chain Detail Drawer
+
+Clicking a row should open a detail drawer or side panel that shows the full
+result chain:
+
+- variant summary
+- process or sample state
+- test condition
+- structure or defect evidence
+- result values
+- baseline
+- mechanism claim
+- support evidence
+- comparability warnings
+- source anchors
+
+Each anchor should support direct jump back into the source viewer.
+
+## Result Detail Page Proposal
+
+The result detail page should present one result chain as the primary object,
+not only a generic measurement card.
+
+### Required Sections
+
+- chain summary
+- parent variant dossier summary
+- process or sample state
+- test condition
+- structure or defect support
+- result values
+- baseline and baseline type
+- collection-scoped comparability assessment
+- source anchors and document jump actions
+
+### Related Context
+
+When sibling chains exist in the same result series, the page should also show
+a compact series navigator so users can move across:
+
+- the same variant at different test temperatures
+- the same variant at different strain rates
+- other closely related test-side axes
+
+This keeps the user inside one experimental story instead of forcing repeated
+returns to the result list.
+
+## Comparison Workspace Entry Rules
+
+The comparison workspace should remain the main cross-paper analysis surface,
+but it should be able to open into the new chain model cleanly.
+
+The preferred flow is:
+
+1. open comparison row
+2. open result detail
+3. inspect supporting chain context
+4. jump to document anchors for source verification
+
+The comparison table should not try to absorb the full chain detail into one
+row.
+
+## Backend Consumption Rules
+
+This proposal does not redefine backend ownership, but the frontend should use
+semantic drilldown data as its primary source when available.
+
+Preferred source:
+
+- collection-scoped document comparison semantics
+
+The route-family UI should prefer backend-provided semantics for:
+
+- variant identity
+- process context
+- test conditions
+- structure support
+- baseline resolution
+- comparability status
+- anchor linkage
+
+The frontend should not invent unsupported semantic groupings from raw text
+when the backend has not resolved them.
+
+## First Delivery Slice
+
+The first implementation wave should stay narrow.
+
+1. Add a `Variant dossier` panel to the document page.
+2. Render result chains as grouped series inside each dossier.
+3. Add a chain detail drawer with anchor jump actions.
+4. Reframe the result detail page around one chain plus its parent dossier.
+
+This is enough to test whether the frontend is presenting a real evidence
+chain rather than only a result card and a source link.
+
+## Related Docs
+
+- [`lens-v1-interface-spec.md`](lens-v1-interface-spec.md)
+  Collection route-family product hierarchy and broad page responsibilities
+- [`claim-traceback-navigation-contract.md`](claim-traceback-navigation-contract.md)
+  Source-navigation rules for anchor-based document verification
+- [`../../../../docs/decisions/rfc-comparison-result-document-product-flow.md`](../../../../docs/decisions/rfc-comparison-result-document-product-flow.md)
+  Shared Lens v1 product decision for comparison, result, document, and
+  evidence roles

--- a/frontend/src/routes/collections/lens-v1-interface-spec.md
+++ b/frontend/src/routes/collections/lens-v1-interface-spec.md
@@ -229,13 +229,16 @@ Result list sections:
 
 Result detail sections:
 
-- result summary
-- material and variant context
-- measurement value and property
-- baseline and test-condition context
+- chain summary
+- parent variant dossier summary
+- process or sample state
+- chain-local test condition
+- result values and value provenance
+- baseline detail
+- structure or defect support
 - collection-scoped assessment
-- supporting evidence
-- source document links
+- series navigation when sibling chains exist
+- source document links and anchor actions
 
 Expected interactions:
 
@@ -243,11 +246,13 @@ Expected interactions:
 - open result detail from list or from comparison rows
 - open filtered comparisons from a result
 - open source document verification from a result
-- inspect supporting evidence without losing result context
+- inspect supporting evidence without losing result-chain context
 
 `Results` is the product-facing projection over internal semantic comparison
 artifacts. Route code should not expose raw `ComparableResult` internals as the
-page's primary conceptual model.
+page's primary conceptual model. As the additive evidence-chain contract lands,
+the result page should read as one chain-first drilldown rather than as a
+generic measurement card.
 
 ### Documents
 
@@ -273,8 +278,11 @@ Document detail sections:
 
 - source metadata
 - original content or content viewer
+- paper overview and missingness summary
+- variant dossier list
+- grouped result series under each dossier
+- chain detail drawer or equivalent drilldown
 - evidence highlights or traceback targets
-- extracted results from the same paper
 
 Expected interactions:
 
@@ -283,6 +291,8 @@ Expected interactions:
 - inspect `protocol_extractability_signals`
 - inspect parsing warnings per paper
 - open result detail for results extracted from the same paper
+- expand one variant dossier and inspect grouped result series
+- open one full chain detail from a series row
 - land on anchored source context from result or evidence flows
 
 ### Evidence

--- a/frontend/src/routes/collections/materials-comparison-v2-frontend-alignment-plan.md
+++ b/frontend/src/routes/collections/materials-comparison-v2-frontend-alignment-plan.md
@@ -32,7 +32,7 @@ Out of scope:
 
 ## Companion Docs
 
-- [`../../../../backend/docs/plans/materials-comparison-v2-plan.md`](../../../../backend/docs/plans/backend-wide/materials-comparison-v2-plan.md)
+- [`../../../../backend/docs/plans/materials-comparison-v2-plan.md`](../../../../backend/docs/plans/backend-wide/materials-comparison-v2/implementation-plan.md)
   Backend-owned source plan for the sample/result-backed comparison backbone
 - [`lens-v1-interface-spec.md`](lens-v1-interface-spec.md)
   Collection route-family interface authority for Lens v1


### PR DESCRIPTION
## Summary
- reorganize backend plan docs into node-local topic folders
- move structured-extraction docs under the Core LLM owner path
- add evidence-chain RFCs and align backend/frontend collection contract docs

## Verification
- python3 scripts/check_docs_governance.py
- git diff --check

## Split Notes
- Stacked on: #110 / split/backend-extraction-runtime-hardening
- This PR intentionally contains docs and contract surfaces only; runtime behavior is in the base PR.