### PR TITLE
feat(core): add evidence-chain drilldown APIs

### DIFF
--- a/backend/application/core/comparison_assembly.py
+++ b/backend/application/core/comparison_assembly.py
@@ -96,6 +96,12 @@ class ComparableResultAssembler:
         for sort_order, (_, result_row) in enumerate(
             frames.measurement_results.iterrows()
         ):
+            assessment_context = self.build_assessment_context(
+                result_row=result_row,
+                sample_lookup=sample_lookup,
+                test_condition_lookup=test_condition_lookup,
+                baseline_lookup=baseline_lookup,
+            )
             comparable_result = self.assemble_comparable_result(
                 result_row=result_row,
                 sample_lookup=sample_lookup,
@@ -108,6 +114,7 @@ class ComparableResultAssembler:
                 collection_id=collection_id,
                 comparable_result=comparable_result,
                 sort_order=sort_order,
+                assessment_context=assessment_context,
             )
             existing_comparable_result = comparable_results_by_id.get(
                 comparable_result.comparable_result_id
@@ -308,8 +315,12 @@ class ComparableResultAssembler:
         collection_id: str,
         comparable_result: ComparableResult,
         sort_order: int | None,
+        assessment_context: dict[str, Any] | None = None,
     ) -> CollectionComparableResult:
-        assessment = evaluate_comparison_assessment(comparable_result)
+        assessment = evaluate_comparison_assessment(
+            comparable_result,
+            assessment_context=assessment_context,
+        )
         return CollectionComparableResult(
             collection_id=collection_id,
             comparable_result_id=comparable_result.comparable_result_id,
@@ -325,6 +336,24 @@ class ComparableResultAssembler:
             ),
             reassessment_triggers=DEFAULT_COLLECTION_REASSESSMENT_TRIGGERS,
         )
+
+    def build_assessment_context(
+        self,
+        *,
+        result_row: pd.Series,
+        sample_lookup: dict[str, dict[str, Any]],
+        test_condition_lookup: dict[str, dict[str, Any]],
+        baseline_lookup: dict[str, dict[str, Any]],
+    ) -> dict[str, Any]:
+        variant_id = self.safe_text(result_row.get("variant_id"))
+        test_condition_id = self.safe_text(result_row.get("test_condition_id"))
+        baseline_id = self.safe_text(result_row.get("baseline_id"))
+        return {
+            "variant": sample_lookup.get(variant_id or "", {}),
+            "test_condition": test_condition_lookup.get(test_condition_id or "", {}),
+            "baseline": baseline_lookup.get(baseline_id or "", {}),
+            "measurement_result": dict(result_row),
+        }
 
     def normalize_comparable_results_table(self, results: pd.DataFrame) -> pd.DataFrame:
         if results is None or results.empty:
@@ -526,16 +555,55 @@ class ComparableResultAssembler:
             return "unspecified test condition"
 
         parts: list[str] = []
-        method = self.safe_text(payload.get("method"))
+        method = self.safe_text(payload.get("test_method")) or self.safe_text(
+            payload.get("method")
+        )
         methods = self.normalize_string_list(payload.get("methods"))
         if method:
             parts.append(method)
         elif methods:
             parts.append(", ".join(methods))
 
-        temperatures = payload.get("temperatures_c")
-        if isinstance(temperatures, list) and temperatures:
-            parts.append(" / ".join(f"{float(value):g} C" for value in temperatures))
+        test_temperature = self.safe_float(payload.get("test_temperature_c"))
+        if test_temperature is not None:
+            parts.append(f"{test_temperature:g} C")
+        else:
+            temperatures = payload.get("temperatures_c")
+            if isinstance(temperatures, list) and temperatures:
+                parts.append(" / ".join(f"{float(value):g} C" for value in temperatures))
+
+        strain_rate = (
+            payload.get("strain_rate_s-1")
+            or payload.get("strain_rate_s_1")
+            or payload.get("strain_rate")
+        )
+        strain_rate_value = self.normalize_scalar_or_text(strain_rate)
+        if strain_rate_value not in (None, "", [], {}):
+            parts.append(f"strain_rate={strain_rate_value} s^-1")
+
+        loading_direction = self.safe_text(payload.get("loading_direction"))
+        if loading_direction:
+            parts.append(f"loading={loading_direction}")
+
+        sample_orientation = self.safe_text(payload.get("sample_orientation"))
+        if sample_orientation:
+            parts.append(f"sample={sample_orientation}")
+
+        frequency = self.safe_float(payload.get("frequency_hz"))
+        if frequency is not None:
+            parts.append(f"f={frequency:g} Hz")
+
+        environment = self.safe_text(payload.get("environment"))
+        if environment:
+            parts.append(f"env={environment}")
+
+        surface_state = self.safe_text(payload.get("surface_state"))
+        if surface_state:
+            parts.append(f"surface={surface_state}")
+
+        specimen_geometry = self.safe_text(payload.get("specimen_geometry"))
+        if specimen_geometry:
+            parts.append(f"specimen={specimen_geometry}")
 
         durations = self.normalize_string_list(payload.get("durations"))
         if durations:
@@ -576,20 +644,61 @@ class ComparableResultAssembler:
             return "unspecified process"
 
         parts: list[str] = []
+        consumed_keys: set[str] = set()
+        pbf_key_specs = (
+            ("laser_power_w", "P", "W"),
+            ("scan_speed_mm_s", "v", "mm/s"),
+            ("hatch_spacing_um", "h", "um"),
+            ("layer_thickness_um", "t", "um"),
+            ("spot_size_um", "spot", "um"),
+            ("energy_density_j_mm3", "VED", "J/mm3"),
+            ("preheat_temperature_c", "preheat", "C"),
+            ("oxygen_level_ppm", "O2", "ppm"),
+        )
+        for key, label, unit in pbf_key_specs:
+            numeric = self.safe_float(payload.get(key))
+            if numeric is not None:
+                parts.append(f"{label}={numeric:g} {unit}")
+                consumed_keys.add(key)
+
+        energy_density_origin = self.safe_text(payload.get("energy_density_origin"))
+        if energy_density_origin:
+            parts.append(f"VED_origin={energy_density_origin}")
+            consumed_keys.add("energy_density_origin")
+
+        for key, label in (
+            ("scan_strategy", "scan"),
+            ("build_orientation", "build"),
+            ("shielding_gas", "gas"),
+            ("powder_size_distribution_um", "powder"),
+        ):
+            value = self.normalize_scalar_or_text(payload.get(key))
+            if value not in (None, "", [], {}):
+                parts.append(f"{label}={value}")
+                consumed_keys.add(key)
+
+        post_treatment = self.safe_text(payload.get("post_treatment_summary"))
+        if post_treatment:
+            parts.append(post_treatment)
+            consumed_keys.add("post_treatment_summary")
+
         temperatures = payload.get("temperatures_c")
         if isinstance(temperatures, list) and temperatures:
             parts.append(" / ".join(f"{float(value):g} C" for value in temperatures))
+            consumed_keys.add("temperatures_c")
 
         durations = self.normalize_string_list(payload.get("durations"))
         if durations:
             parts.append(" / ".join(durations))
+            consumed_keys.add("durations")
 
         atmosphere = self.safe_text(payload.get("atmosphere"))
         if atmosphere:
             parts.append(f"under {atmosphere}")
+            consumed_keys.add("atmosphere")
 
         for key, value in payload.items():
-            if key in {"temperatures_c", "durations", "atmosphere"}:
+            if key in consumed_keys:
                 continue
             normalized = self.normalize_scalar_or_text(value)
             if normalized not in (None, "", [], {}):

--- a/backend/application/core/comparison_service.py
+++ b/backend/application/core/comparison_service.py
@@ -51,6 +51,8 @@ _SAMPLE_VARIANTS_FILE = "sample_variants.parquet"
 _MEASUREMENT_RESULTS_FILE = "measurement_results.parquet"
 _TEST_CONDITIONS_FILE = "test_conditions.parquet"
 _BASELINE_REFERENCES_FILE = "baseline_references.parquet"
+_CHARACTERIZATION_OBSERVATIONS_FILE = "characterization_observations.parquet"
+_STRUCTURE_FEATURES_FILE = "structure_features.parquet"
 _SAMPLE_VARIANT_JSON_COLUMNS = (
     "host_material_system",
     "variable_value",
@@ -71,6 +73,11 @@ _TEST_CONDITION_JSON_COLUMNS = (
     "evidence_anchor_ids",
 )
 _BASELINE_REFERENCE_JSON_COLUMNS = ("evidence_anchor_ids",)
+_CHARACTERIZATION_OBSERVATION_JSON_COLUMNS = (
+    "condition_context",
+    "evidence_anchor_ids",
+)
+_STRUCTURE_FEATURE_JSON_COLUMNS = ("source_observation_ids",)
 _COMPARABLE_RESULT_JSON_COLUMNS = (
     "binding",
     "normalized_context",
@@ -100,6 +107,35 @@ _CORPUS_COMPARABLE_RESULTS_CACHE_JSON_COLUMNS = (
     "evidence",
     "observed_collection_ids",
     "collection_overlays",
+)
+_PROCESS_STATE_KEYS = (
+    "laser_power_w",
+    "scan_speed_mm_s",
+    "layer_thickness_um",
+    "hatch_spacing_um",
+    "spot_size_um",
+    "energy_density_j_mm3",
+    "energy_density_origin",
+    "scan_strategy",
+    "build_orientation",
+    "preheat_temperature_c",
+    "shielding_gas",
+    "oxygen_level_ppm",
+    "powder_size_distribution_um",
+    "post_treatment_summary",
+)
+_SERIES_AXIS_UNITS = {
+    "test_temperature_c": "C",
+    "strain_rate_s-1": "s^-1",
+    "hold_time": "s",
+    "frequency_hz": "Hz",
+    "test_condition": None,
+}
+_TEST_SERIES_AXIS_CANDIDATES = (
+    "test_temperature_c",
+    "strain_rate_s-1",
+    "hold_time",
+    "frequency_hz",
 )
 
 
@@ -292,18 +328,24 @@ class ComparisonService:
         result_id: str,
     ) -> dict[str, Any]:
         result_key = self._safe_text(result_id) or ""
-        records = self._collect_collection_result_records(
-            collection_id,
-            result_id=result_key,
-        )
-        if not records:
+        all_records = self._collect_collection_result_records(collection_id)
+        matching_records = [
+            item
+            for item in all_records
+            if self._safe_text(item[1].comparable_result_id) == result_key
+        ]
+        if not matching_records:
             raise ResultNotFoundError(collection_id, result_key)
-        scoped_record, comparable_record, document_payload = records[0]
+        scoped_record, comparable_record, document_payload = matching_records[0]
+        output_dir = self._resolve_output_dir(collection_id)
+        projection_context = self._load_optional_projection_context(output_dir)
         return self._serialize_collection_result_detail(
             collection_id,
             comparable_record,
             scoped_record,
             document_payload=document_payload,
+            projection_context=projection_context,
+            sibling_records=all_records,
         )
 
     def read_comparison_rows(self, collection_id: str) -> pd.DataFrame:
@@ -358,6 +400,7 @@ class ComparisonService:
         source_document_id: str,
         *,
         include_row_projections: bool = False,
+        include_grouped_projections: bool = False,
     ) -> dict[str, Any]:
         output_dir = self._resolve_output_dir(collection_id)
         semantic_tables = self._read_semantic_comparison_artifacts(
@@ -372,13 +415,16 @@ class ComparisonService:
             )
         ].copy()
         if document_results.empty:
-            return {
+            payload = {
                 "collection_id": collection_id,
                 "source_document_id": document_id,
                 "total": 0,
                 "count": 0,
                 "items": [],
             }
+            if include_grouped_projections:
+                payload["variant_dossiers"] = []
+            return payload
 
         comparable_records = [
             ComparableResult.from_mapping(dict(row))
@@ -459,13 +505,22 @@ class ComparisonService:
                     [],
                 )
             items.append(item)
-        return {
+        payload = {
             "collection_id": collection_id,
             "source_document_id": document_id,
             "total": len(items),
             "count": len(items),
             "items": items,
         }
+        if include_grouped_projections:
+            projection_context = self._load_optional_projection_context(output_dir)
+            payload["variant_dossiers"] = self._build_variant_dossiers(
+                collection_id=collection_id,
+                comparable_records=comparable_records,
+                scoped_records_by_result_id=scoped_records_by_result_id,
+                projection_context=projection_context,
+            )
+        return payload
 
     def _collect_collection_result_items(
         self,
@@ -703,6 +758,7 @@ class ComparisonService:
         comparable_results: pd.DataFrame,
         scoped_records_by_result_id: dict[str, CollectionComparableResult],
     ) -> ComparisonSemanticTables:
+        projection_context = self._load_optional_projection_context(output_dir)
         refreshed_scoped_records: list[CollectionComparableResult] = []
         next_generated_sort_order = (
             max(
@@ -734,6 +790,10 @@ class ComparisonService:
                 collection_id=collection_id,
                 comparable_result=comparable_record,
                 sort_order=effective_sort_order,
+                assessment_context=self._build_assessment_context_for_comparable_record(
+                    comparable_record,
+                    projection_context,
+                ),
             )
             if existing_scoped_record is not None:
                 refreshed_scoped_record = CollectionComparableResult(
@@ -781,6 +841,34 @@ class ComparisonService:
             comparable_results=comparable_results,
             collection_comparable_results=refreshed_scoped_results,
         )
+
+    def _build_assessment_context_for_comparable_record(
+        self,
+        comparable_record: ComparableResult,
+        projection_context: dict[str, Any],
+    ) -> dict[str, Any]:
+        variant_id = self._safe_text(comparable_record.binding.variant_id)
+        test_condition_id = self._safe_text(comparable_record.binding.test_condition_id)
+        baseline_id = self._safe_text(comparable_record.binding.baseline_id)
+        source_result_id = self._safe_text(comparable_record.source_result_id)
+        return {
+            "variant": projection_context.get("sample_variants_by_id", {}).get(
+                variant_id or "",
+                {},
+            ),
+            "test_condition": projection_context.get("test_conditions_by_id", {}).get(
+                test_condition_id or "",
+                {},
+            ),
+            "baseline": projection_context.get("baseline_references_by_id", {}).get(
+                baseline_id or "",
+                {},
+            ),
+            "measurement_result": projection_context.get(
+                "measurement_results_by_id",
+                {},
+            ).get(source_result_id or "", {}),
+        }
 
     def build_comparison_rows(
         self,
@@ -1331,6 +1419,709 @@ class ComparisonService:
     ) -> dict[str, Any]:
         return record.to_record()
 
+    def _load_optional_projection_context(self, output_dir: Path) -> dict[str, Any]:
+        sample_variants = self._read_optional_semantic_frame(
+            output_dir / _SAMPLE_VARIANTS_FILE,
+            _SAMPLE_VARIANT_JSON_COLUMNS,
+        )
+        measurement_results = self._read_optional_semantic_frame(
+            output_dir / _MEASUREMENT_RESULTS_FILE,
+            _MEASUREMENT_RESULT_JSON_COLUMNS,
+        )
+        test_conditions = self._read_optional_semantic_frame(
+            output_dir / _TEST_CONDITIONS_FILE,
+            _TEST_CONDITION_JSON_COLUMNS,
+        )
+        baseline_references = self._read_optional_semantic_frame(
+            output_dir / _BASELINE_REFERENCES_FILE,
+            _BASELINE_REFERENCE_JSON_COLUMNS,
+        )
+        characterization_observations = self._read_optional_semantic_frame(
+            output_dir / _CHARACTERIZATION_OBSERVATIONS_FILE,
+            _CHARACTERIZATION_OBSERVATION_JSON_COLUMNS,
+        )
+        structure_features = self._read_optional_semantic_frame(
+            output_dir / _STRUCTURE_FEATURES_FILE,
+            _STRUCTURE_FEATURE_JSON_COLUMNS,
+        )
+        return {
+            "sample_variants_by_id": self._index_frame_by_text(
+                sample_variants,
+                "variant_id",
+            ),
+            "measurement_results_by_id": self._index_frame_by_text(
+                measurement_results,
+                "result_id",
+            ),
+            "test_conditions_by_id": self._index_frame_by_text(
+                test_conditions,
+                "test_condition_id",
+            ),
+            "baseline_references_by_id": self._index_frame_by_text(
+                baseline_references,
+                "baseline_id",
+            ),
+            "characterization_observations_by_id": self._index_frame_by_text(
+                characterization_observations,
+                "observation_id",
+            ),
+            "structure_features_by_id": self._index_frame_by_text(
+                structure_features,
+                "feature_id",
+            ),
+        }
+
+    def _read_optional_semantic_frame(
+        self,
+        path: Path,
+        json_columns: tuple[str, ...],
+    ) -> pd.DataFrame:
+        if not path.is_file():
+            return pd.DataFrame()
+        return restore_frame_from_storage(pd.read_parquet(path), json_columns)
+
+    def _index_frame_by_text(
+        self,
+        frame: pd.DataFrame,
+        key: str,
+    ) -> dict[str, dict[str, Any]]:
+        if frame.empty or key not in frame.columns:
+            return {}
+        lookup: dict[str, dict[str, Any]] = {}
+        for _, row in frame.iterrows():
+            row_payload = dict(row)
+            record_key = self._safe_text(row_payload.get(key))
+            if record_key:
+                lookup[record_key] = row_payload
+        return lookup
+
+    def _build_variant_dossiers(
+        self,
+        *,
+        collection_id: str,
+        comparable_records: list[ComparableResult],
+        scoped_records_by_result_id: dict[str, list[CollectionComparableResult]],
+        projection_context: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        records_by_variant: dict[str, list[ComparableResult]] = {}
+        for record in comparable_records:
+            variant_key = (
+                self._safe_text(record.binding.variant_id)
+                or f"unresolved:{record.source_document_id}"
+            )
+            records_by_variant.setdefault(variant_key, []).append(record)
+
+        dossiers: list[dict[str, Any]] = []
+        for variant_key in sorted(records_by_variant):
+            variant_records = records_by_variant[variant_key]
+            representative = variant_records[0]
+            dossier = self._build_variant_dossier_summary(
+                representative,
+                projection_context=projection_context,
+            )
+            dossier["series"] = self._build_result_series(
+                collection_id=collection_id,
+                comparable_records=variant_records,
+                scoped_records_by_result_id=scoped_records_by_result_id,
+                projection_context=projection_context,
+            )
+            dossiers.append(dossier)
+        return dossiers
+
+    def _build_result_series(
+        self,
+        *,
+        collection_id: str,
+        comparable_records: list[ComparableResult],
+        scoped_records_by_result_id: dict[str, list[CollectionComparableResult]],
+        projection_context: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        grouped: dict[tuple[str, str], list[ComparableResult]] = {}
+        for record in comparable_records:
+            test_condition = self._build_test_condition_detail(
+                record,
+                projection_context=projection_context,
+            )
+            key = (
+                self._property_family(record),
+                self._test_family(record, test_condition),
+            )
+            grouped.setdefault(key, []).append(record)
+
+        series_items: list[dict[str, Any]] = []
+        for property_family, test_family in sorted(grouped):
+            sibling_records = sorted(
+                grouped[(property_family, test_family)],
+                key=lambda item: item.comparable_result_id,
+            )
+            chain_payloads = [
+                self._build_result_chain(
+                    comparable_record=record,
+                    scoped_records=scoped_records_by_result_id.get(
+                        record.comparable_result_id,
+                        [],
+                    ),
+                    projection_context=projection_context,
+                )
+                for record in sibling_records
+            ]
+            axis_name = self._select_series_axis(chain_payloads)
+            chain_payloads.sort(
+                key=lambda chain: (
+                    self._axis_sort_key((chain.get("test_condition") or {}).get(axis_name)),
+                    chain["result_id"],
+                )
+            )
+            series_items.append(
+                {
+                    "series_key": f"{property_family}:{axis_name}",
+                    "property_family": property_family,
+                    "test_family": test_family,
+                    "varying_axis": {
+                        "axis_name": axis_name,
+                        "axis_unit": _SERIES_AXIS_UNITS.get(axis_name),
+                    },
+                    "chains": chain_payloads,
+                }
+            )
+        return series_items
+
+    def _build_result_chain(
+        self,
+        *,
+        comparable_record: ComparableResult,
+        scoped_records: list[CollectionComparableResult],
+        projection_context: dict[str, Any],
+    ) -> dict[str, Any]:
+        scoped_record = self._select_scoped_record(scoped_records)
+        return {
+            "result_id": comparable_record.comparable_result_id,
+            "source_result_id": comparable_record.source_result_id,
+            "measurement": self._build_measurement_payload(comparable_record),
+            "test_condition": self._build_test_condition_detail(
+                comparable_record,
+                projection_context=projection_context,
+            ),
+            "baseline": self._build_baseline_detail(
+                comparable_record,
+                projection_context=projection_context,
+                include_scope=False,
+            ),
+            "assessment": self._build_chain_assessment(scoped_record),
+            "value_provenance": self._build_value_provenance(
+                comparable_record,
+                projection_context=projection_context,
+            ),
+            "evidence": self._build_chain_evidence(comparable_record),
+        }
+
+    def _select_scoped_record(
+        self,
+        scoped_records: list[CollectionComparableResult],
+    ) -> CollectionComparableResult | None:
+        if not scoped_records:
+            return None
+        return sorted(
+            scoped_records,
+            key=lambda record: (
+                1_000_000_000 if record.sort_order is None else record.sort_order,
+                record.comparable_result_id,
+            ),
+        )[0]
+
+    def _build_variant_dossier_summary(
+        self,
+        comparable_record: ComparableResult,
+        *,
+        projection_context: dict[str, Any],
+    ) -> dict[str, Any]:
+        variant = self._lookup_variant(comparable_record, projection_context)
+        variant_id = self._safe_text(comparable_record.binding.variant_id)
+        host_material_system = self._safe_mapping(
+            variant.get("host_material_system") if variant else None
+        )
+        composition = self._safe_text((variant or {}).get("composition")) or self._safe_text(
+            host_material_system.get("composition")
+        )
+        material_label = (
+            self._safe_text(comparable_record.normalized_context.material_system_normalized)
+            or self._safe_text(host_material_system.get("family"))
+            or composition
+            or "unspecified material system"
+        )
+        return {
+            "variant_id": variant_id,
+            "variant_label": comparable_record.variant_label
+            or self._safe_text((variant or {}).get("variant_label")),
+            "material": {
+                "label": material_label,
+                "composition": composition,
+                "host_material_system": host_material_system or None,
+            },
+            "shared_process_state": self._build_shared_process_state(variant),
+            "shared_missingness": self._build_shared_missingness(variant),
+        }
+
+    def _build_shared_process_state(
+        self,
+        variant: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        process_context = self._safe_mapping((variant or {}).get("process_context"))
+        process_state: dict[str, Any] = {}
+        for key in _PROCESS_STATE_KEYS:
+            value = process_context.get(key)
+            if value not in (None, "", [], {}):
+                process_state[key] = value
+        return process_state
+
+    def _build_shared_missingness(
+        self,
+        variant: dict[str, Any] | None,
+    ) -> list[str]:
+        process_context = self._safe_mapping((variant or {}).get("process_context"))
+        missing: list[str] = []
+        if variant is None:
+            missing.append("variant_fact_not_available")
+        if not process_context:
+            missing.append("process_context_not_reported")
+        return missing
+
+    def _build_measurement_payload(
+        self,
+        comparable_record: ComparableResult,
+    ) -> dict[str, Any]:
+        return {
+            "property": comparable_record.value.property_normalized,
+            "value": comparable_record.value.numeric_value,
+            "unit": comparable_record.value.unit,
+            "result_type": comparable_record.value.result_type,
+            "summary": comparable_record.value.summary,
+            "statistic_type": comparable_record.value.statistic_type,
+            "uncertainty": comparable_record.value.uncertainty,
+        }
+
+    def _build_test_condition_detail(
+        self,
+        comparable_record: ComparableResult,
+        *,
+        projection_context: dict[str, Any],
+    ) -> dict[str, Any]:
+        condition = self._lookup_test_condition(comparable_record, projection_context)
+        payload = self._safe_mapping((condition or {}).get("condition_payload"))
+        method = self._safe_text(payload.get("test_method")) or self._safe_text(
+            payload.get("method")
+        )
+        methods = self._safe_list(payload.get("methods"))
+        if method is None and methods:
+            method = self._safe_text(methods[0])
+        temperature = self._optional_float(payload.get("test_temperature_c"))
+        if temperature is None:
+            temperatures = self._safe_list(payload.get("temperatures_c"))
+            if temperatures:
+                temperature = self._optional_float(temperatures[0])
+        return {
+            "test_method": method
+            or self._safe_text(comparable_record.normalized_context.test_condition_normalized),
+            "test_temperature_c": temperature,
+            "strain_rate_s-1": self._optional_float(
+                payload.get("strain_rate_s-1")
+                or payload.get("strain_rate_s_1")
+                or payload.get("strain_rate")
+                or payload.get("rate")
+            )
+            or self._safe_text(payload.get("strain_rate_text")),
+            "loading_direction": self._safe_text(
+                payload.get("loading_direction") or payload.get("direction")
+            ),
+            "sample_orientation": self._safe_text(payload.get("sample_orientation")),
+            "environment": self._safe_text(payload.get("environment"))
+            or self._safe_text(payload.get("atmosphere")),
+            "frequency_hz": self._optional_float(
+                payload.get("frequency_hz") or payload.get("frequency")
+            ),
+            "specimen_geometry": self._safe_text(payload.get("specimen_geometry")),
+            "surface_state": self._safe_text(payload.get("surface_state")),
+        }
+
+    def _build_baseline_detail(
+        self,
+        comparable_record: ComparableResult,
+        *,
+        projection_context: dict[str, Any],
+        include_scope: bool,
+    ) -> dict[str, Any]:
+        baseline = self._lookup_baseline(comparable_record, projection_context)
+        label = self._safe_text((baseline or {}).get("baseline_label"))
+        reference = comparable_record.baseline_reference or label
+        payload = {
+            "label": label or reference,
+            "reference": reference,
+            "baseline_type": self._safe_text((baseline or {}).get("baseline_type")),
+            "resolved": bool(reference or baseline),
+        }
+        if include_scope:
+            payload["baseline_scope"] = self._safe_text((baseline or {}).get("baseline_scope"))
+        return payload
+
+    def _build_chain_assessment(
+        self,
+        scoped_record: CollectionComparableResult | None,
+    ) -> dict[str, Any]:
+        if scoped_record is None:
+            return {
+                "comparability_status": "insufficient",
+                "warnings": ["Collection assessment is missing for this result."],
+                "basis": [],
+                "missing_context": ["collection_assessment"],
+                "requires_expert_review": True,
+                "assessment_epistemic_status": "unresolved",
+            }
+        assessment = scoped_record.assessment
+        return {
+            "comparability_status": assessment.comparability_status,
+            "warnings": list(assessment.comparability_warnings),
+            "basis": list(assessment.comparability_basis),
+            "missing_context": list(assessment.missing_critical_context),
+            "requires_expert_review": assessment.requires_expert_review,
+            "assessment_epistemic_status": assessment.assessment_epistemic_status,
+        }
+
+    def _build_value_provenance(
+        self,
+        comparable_record: ComparableResult,
+        *,
+        projection_context: dict[str, Any],
+    ) -> dict[str, Any]:
+        measurement_result = self._lookup_measurement_result(
+            comparable_record,
+            projection_context,
+        )
+        value_payload = self._safe_mapping((measurement_result or {}).get("value_payload"))
+        value_origin = self._safe_text(value_payload.get("value_origin"))
+        if value_origin is None:
+            value_origin = "derived" if value_payload.get("derivation_formula") else "reported"
+        source_value_text = self._safe_text(value_payload.get("source_value_text"))
+        if source_value_text is None:
+            source_value_text = self._first_value_text(
+                value_payload,
+                ("value", "min", "max", "retention_percent", "statement"),
+            )
+        return {
+            "value_origin": value_origin,
+            "source_value_text": source_value_text,
+            "source_unit_text": self._safe_text(value_payload.get("source_unit_text"))
+            or comparable_record.value.unit,
+            "derivation_formula": self._safe_text(value_payload.get("derivation_formula")),
+            "derivation_inputs": self._safe_mapping_or_none(
+                value_payload.get("derivation_inputs")
+            ),
+        }
+
+    def _build_chain_evidence(self, comparable_record: ComparableResult) -> dict[str, Any]:
+        return {
+            "evidence_ids": list(comparable_record.evidence.evidence_ids),
+            "direct_anchor_ids": list(comparable_record.evidence.direct_anchor_ids),
+            "contextual_anchor_ids": list(comparable_record.evidence.contextual_anchor_ids),
+            "structure_feature_ids": list(comparable_record.evidence.structure_feature_ids),
+            "characterization_observation_ids": list(
+                comparable_record.evidence.characterization_observation_ids
+            ),
+            "traceability_status": comparable_record.evidence.traceability_status,
+        }
+
+    def _build_structure_support(
+        self,
+        comparable_record: ComparableResult,
+        *,
+        projection_context: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        supports: list[dict[str, Any]] = []
+        structure_lookup = projection_context.get("structure_features_by_id", {})
+        observation_lookup = projection_context.get("characterization_observations_by_id", {})
+        for feature_id in comparable_record.evidence.structure_feature_ids:
+            feature = structure_lookup.get(feature_id, {})
+            supports.append(
+                {
+                    "support_id": feature_id,
+                    "support_type": "structure_feature",
+                    "summary": self._structure_feature_summary(feature, feature_id),
+                    "condition": {
+                        "characterization_temperature_c": self._support_temperature(
+                            feature,
+                            observation_lookup,
+                        )
+                    },
+                }
+            )
+        for observation_id in comparable_record.evidence.characterization_observation_ids:
+            observation = observation_lookup.get(observation_id, {})
+            supports.append(
+                {
+                    "support_id": observation_id,
+                    "support_type": "characterization_observation",
+                    "summary": self._characterization_observation_summary(
+                        observation,
+                        observation_id,
+                    ),
+                    "condition": {
+                        "characterization_temperature_c": self._observation_temperature(
+                            observation,
+                        )
+                    },
+                }
+            )
+        return supports
+
+    def _build_series_navigation(
+        self,
+        *,
+        current_record: ComparableResult,
+        sibling_records: list[
+            tuple[CollectionComparableResult, ComparableResult, dict[str, Any] | None]
+        ],
+        projection_context: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        current_variant = self._safe_text(current_record.binding.variant_id)
+        current_property = self._property_family(current_record)
+        current_test_condition = self._build_test_condition_detail(
+            current_record,
+            projection_context=projection_context,
+        )
+        current_test_family = self._test_family(current_record, current_test_condition)
+        siblings: list[ComparableResult] = []
+        for _scoped, record, _document in sibling_records:
+            if self._safe_text(record.binding.variant_id) != current_variant:
+                continue
+            if self._property_family(record) != current_property:
+                continue
+            condition = self._build_test_condition_detail(
+                record,
+                projection_context=projection_context,
+            )
+            if self._test_family(record, condition) != current_test_family:
+                continue
+            siblings.append(record)
+        if len(siblings) < 2:
+            return None
+
+        chain_payloads = [
+            {
+                "result_id": record.comparable_result_id,
+                "test_condition": self._build_test_condition_detail(
+                    record,
+                    projection_context=projection_context,
+                ),
+                "measurement": self._build_measurement_payload(record),
+            }
+            for record in sorted(siblings, key=lambda item: item.comparable_result_id)
+        ]
+        axis_name = self._select_series_axis(chain_payloads)
+        if axis_name == "test_condition":
+            return None
+        chain_payloads.sort(
+            key=lambda chain: (
+                self._axis_sort_key((chain["test_condition"] or {}).get(axis_name)),
+                chain["result_id"],
+            )
+        )
+        return {
+            "series_key": f"{current_property}:{axis_name}",
+            "varying_axis": {
+                "axis_name": axis_name,
+                "axis_unit": _SERIES_AXIS_UNITS.get(axis_name),
+            },
+            "siblings": [
+                {
+                    "result_id": chain["result_id"],
+                    "axis_value": (chain["test_condition"] or {}).get(axis_name),
+                    "axis_unit": _SERIES_AXIS_UNITS.get(axis_name),
+                    "measurement": {
+                        "property": chain["measurement"]["property"],
+                        "value": chain["measurement"]["value"],
+                        "unit": chain["measurement"]["unit"],
+                    },
+                }
+                for chain in chain_payloads
+            ],
+        }
+
+    def _select_series_axis(self, chains: list[dict[str, Any]]) -> str:
+        for axis_name in _TEST_SERIES_AXIS_CANDIDATES:
+            values = {
+                self._axis_value_key((chain.get("test_condition") or {}).get(axis_name))
+                for chain in chains
+                if (chain.get("test_condition") or {}).get(axis_name) is not None
+            }
+            if len(values) > 1:
+                return axis_name
+        for axis_name in _TEST_SERIES_AXIS_CANDIDATES:
+            if any((chain.get("test_condition") or {}).get(axis_name) is not None for chain in chains):
+                return axis_name
+        return "test_condition"
+
+    def _property_family(self, comparable_record: ComparableResult) -> str:
+        return comparable_record.value.property_normalized or "qualitative"
+
+    def _test_family(
+        self,
+        comparable_record: ComparableResult,
+        test_condition: dict[str, Any],
+    ) -> str:
+        return (
+            self._safe_text(test_condition.get("test_method"))
+            or self._safe_text(comparable_record.normalized_context.test_condition_normalized)
+            or "unspecified test"
+        )
+
+    def _lookup_variant(
+        self,
+        comparable_record: ComparableResult,
+        projection_context: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        variant_id = self._safe_text(comparable_record.binding.variant_id)
+        return (projection_context.get("sample_variants_by_id", {}) or {}).get(variant_id)
+
+    def _lookup_measurement_result(
+        self,
+        comparable_record: ComparableResult,
+        projection_context: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        source_result_id = self._safe_text(comparable_record.source_result_id)
+        return (projection_context.get("measurement_results_by_id", {}) or {}).get(
+            source_result_id
+        )
+
+    def _lookup_test_condition(
+        self,
+        comparable_record: ComparableResult,
+        projection_context: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        test_condition_id = self._safe_text(comparable_record.binding.test_condition_id)
+        return (projection_context.get("test_conditions_by_id", {}) or {}).get(
+            test_condition_id
+        )
+
+    def _lookup_baseline(
+        self,
+        comparable_record: ComparableResult,
+        projection_context: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        baseline_id = self._safe_text(comparable_record.binding.baseline_id)
+        return (projection_context.get("baseline_references_by_id", {}) or {}).get(
+            baseline_id
+        )
+
+    def _structure_feature_summary(
+        self,
+        feature: dict[str, Any],
+        fallback_id: str,
+    ) -> str:
+        descriptor = self._safe_text(feature.get("qualitative_descriptor"))
+        feature_type = self._safe_text(feature.get("feature_type"))
+        feature_value = feature.get("feature_value")
+        feature_unit = self._safe_text(feature.get("feature_unit"))
+        if descriptor:
+            return descriptor
+        if feature_type and feature_value not in (None, "", [], {}):
+            value_text = str(feature_value)
+            if feature_unit:
+                value_text = f"{value_text} {feature_unit}"
+            return f"{feature_type}: {value_text}"
+        return f"Linked structure feature {fallback_id}"
+
+    def _characterization_observation_summary(
+        self,
+        observation: dict[str, Any],
+        fallback_id: str,
+    ) -> str:
+        text = self._safe_text(observation.get("observation_text"))
+        if text:
+            return text
+        observation_type = self._safe_text(observation.get("characterization_type"))
+        observed_value = observation.get("observed_value")
+        observed_unit = self._safe_text(observation.get("observed_unit"))
+        if observation_type and observed_value not in (None, "", [], {}):
+            value_text = str(observed_value)
+            if observed_unit:
+                value_text = f"{value_text} {observed_unit}"
+            return f"{observation_type}: {value_text}"
+        return f"Linked characterization observation {fallback_id}"
+
+    def _support_temperature(
+        self,
+        feature: dict[str, Any],
+        observation_lookup: dict[str, dict[str, Any]],
+    ) -> float | None:
+        for observation_id in self._safe_list(feature.get("source_observation_ids")):
+            temperature = self._observation_temperature(
+                observation_lookup.get(str(observation_id), {})
+            )
+            if temperature is not None:
+                return temperature
+        return None
+
+    def _observation_temperature(self, observation: dict[str, Any]) -> float | None:
+        condition = self._safe_mapping(observation.get("condition_context"))
+        direct = self._optional_float(condition.get("characterization_temperature_c"))
+        if direct is not None:
+            return direct
+        process = self._safe_mapping(condition.get("process"))
+        temperatures = self._safe_list(process.get("temperatures_c"))
+        if temperatures:
+            return self._optional_float(temperatures[0])
+        return None
+
+    def _safe_mapping(self, value: Any) -> dict[str, Any]:
+        if isinstance(value, dict):
+            return value
+        return {}
+
+    def _safe_mapping_or_none(self, value: Any) -> dict[str, Any] | None:
+        payload = self._safe_mapping(value)
+        return payload or None
+
+    def _safe_list(self, value: Any) -> list[Any]:
+        if isinstance(value, list):
+            return value
+        if isinstance(value, tuple):
+            return list(value)
+        if isinstance(value, set):
+            return list(value)
+        return []
+
+    def _optional_float(self, value: Any) -> float | None:
+        try:
+            if value is None:
+                return None
+            if isinstance(value, float) and pd.isna(value):
+                return None
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _first_value_text(
+        self,
+        payload: dict[str, Any],
+        keys: tuple[str, ...],
+    ) -> str | None:
+        for key in keys:
+            value = payload.get(key)
+            if value not in (None, "", [], {}):
+                return str(value)
+        return None
+
+    def _axis_value_key(self, value: Any) -> str:
+        if isinstance(value, float):
+            return f"{value:g}"
+        return str(value)
+
+    def _axis_sort_key(self, value: Any) -> tuple[int, float | str]:
+        numeric = self._optional_float(value)
+        if numeric is not None:
+            return (0, numeric)
+        text = self._safe_text(value)
+        return (1, text or "")
+
     def _serialize_corpus_comparable_result(
         self,
         record: ComparableResult,
@@ -1381,6 +2172,11 @@ class ComparisonService:
         scoped_record: CollectionComparableResult,
         *,
         document_payload: dict[str, Any] | None,
+        projection_context: dict[str, Any] | None = None,
+        sibling_records: list[
+            tuple[CollectionComparableResult, ComparableResult, dict[str, Any] | None]
+        ]
+        | None = None,
     ) -> dict[str, Any]:
         baseline = self._safe_text(comparable_record.baseline_reference) or self._safe_text(
             comparable_record.normalized_context.baseline_normalized
@@ -1389,7 +2185,8 @@ class ComparisonService:
             *comparable_record.evidence.direct_anchor_ids,
             *comparable_record.evidence.contextual_anchor_ids,
         ]
-        return {
+        context = projection_context or {}
+        detail = {
             "result_id": comparable_record.comparable_result_id,
             "document": {
                 "document_id": comparable_record.source_document_id,
@@ -1438,6 +2235,37 @@ class ComparisonService:
             ],
             "actions": self._build_collection_result_actions(collection_id, comparable_record),
         }
+        detail.update(
+            {
+                "variant_dossier": self._build_variant_dossier_summary(
+                    comparable_record,
+                    projection_context=context,
+                ),
+                "test_condition_detail": self._build_test_condition_detail(
+                    comparable_record,
+                    projection_context=context,
+                ),
+                "baseline_detail": self._build_baseline_detail(
+                    comparable_record,
+                    projection_context=context,
+                    include_scope=True,
+                ),
+                "structure_support": self._build_structure_support(
+                    comparable_record,
+                    projection_context=context,
+                ),
+                "value_provenance": self._build_value_provenance(
+                    comparable_record,
+                    projection_context=context,
+                ),
+                "series_navigation": self._build_series_navigation(
+                    current_record=comparable_record,
+                    sibling_records=sibling_records or [],
+                    projection_context=context,
+                ),
+            }
+        )
+        return detail
 
     def _load_document_profile_lookup(self, collection_id: str) -> dict[str, dict[str, Any]]:
         try:

--- a/backend/application/core/semantic_build/document_profile_service.py
+++ b/backend/application/core/semantic_build/document_profile_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import json
 import logging
+import math
 from pathlib import Path
 from typing import Any
 
@@ -649,6 +650,11 @@ class DocumentProfileService:
                     "text_unit_ids": self._normalize_string_list(block.get("text_unit_ids")),
                     "start_offset": start_offset,
                     "end_offset": end_offset,
+                    "page": self._normalize_page(block.get("page")),
+                    "bbox": self._normalize_bbox_payload(block.get("bbox")),
+                    "char_range": self._normalize_char_range_payload(
+                        block.get("char_range")
+                    ),
                 }
             )
 
@@ -667,6 +673,9 @@ class DocumentProfileService:
                     "text_unit_ids": [],
                     "start_offset": 0,
                     "end_offset": len(full_text),
+                    "page": None,
+                    "bbox": None,
+                    "char_range": None,
                 }
             ]
         return []
@@ -702,6 +711,85 @@ class DocumentProfileService:
             return int(value)
         except (TypeError, ValueError):
             return default
+
+    def _normalize_page(self, value: Any) -> int | None:
+        number = self._finite_float(value)
+        if number is None:
+            return None
+        page = int(number)
+        return page if page > 0 and page == number else None
+
+    def _normalize_char_range_payload(self, value: Any) -> dict[str, int] | None:
+        payload = self._normalize_object_payload(value)
+        if payload is None:
+            return None
+
+        start = self._whole_number(payload.get("start"))
+        end = self._whole_number(payload.get("end"))
+        if start is None or end is None or start < 0 or end < start:
+            return None
+        return {"start": start, "end": end}
+
+    def _normalize_bbox_payload(self, value: Any) -> dict[str, float | str | None] | None:
+        payload = self._normalize_object_payload(value)
+        if payload is None:
+            return None
+
+        x0 = self._finite_float(payload.get("x0", payload.get("l")))
+        y0 = self._finite_float(payload.get("y0", payload.get("t")))
+        x1 = self._finite_float(payload.get("x1", payload.get("r")))
+        y1 = self._finite_float(payload.get("y1", payload.get("b")))
+        if x0 is None or y0 is None or x1 is None or y1 is None:
+            return None
+
+        return {
+            "x0": x0,
+            "y0": y0,
+            "x1": x1,
+            "y1": y1,
+            "coord_origin": self._normalize_optional_text(payload.get("coord_origin")),
+        }
+
+    def _normalize_object_payload(self, value: Any) -> dict[str, Any] | None:
+        if isinstance(value, dict):
+            return value
+        if value is None:
+            return None
+        if isinstance(value, float) and pd.isna(value):
+            return None
+        if not isinstance(value, str):
+            return None
+
+        text = value.strip()
+        if not text:
+            return None
+
+        for loader in (json.loads, ast.literal_eval):
+            try:
+                parsed = loader(text)
+            except (TypeError, ValueError, SyntaxError, json.JSONDecodeError):
+                continue
+            if isinstance(parsed, dict):
+                return parsed
+        return None
+
+    def _whole_number(self, value: Any) -> int | None:
+        number = self._finite_float(value)
+        if number is None:
+            return None
+        whole = int(number)
+        return whole if number == whole else None
+
+    def _finite_float(self, value: Any) -> float | None:
+        if value is None:
+            return None
+        if isinstance(value, float) and pd.isna(value):
+            return None
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return None
+        return number if math.isfinite(number) else None
 
     def _build_collection_file_lookup(self, collection_id: str) -> dict[str, Any]:
         try:

--- a/backend/application/core/semantic_build/llm/prompts.py
+++ b/backend/application/core/semantic_build/llm/prompts.py
@@ -139,6 +139,11 @@ JSON compliance rules for this extraction:
 - Put nullable scalars inside those required objects instead of nulling the whole object.
 - `unit` belongs at `measurement_results[*].unit`, never inside `value_payload`.
 - `host_material_system` may be `null`, but `process_context` may not be `null`.
+- For PBF metal rows, put laser/process/sample-state facts in `process_context`; do not put test temperature or strain rate there.
+- Put mechanical test facts in `condition_payload`: `test_method`, `test_temperature_c`, `strain_rate_s-1`, `loading_direction`, and `sample_orientation`.
+- Put value provenance in `value_payload`: `value_origin`, `source_value_text`, `source_unit_text`, `derivation_formula`, and `derivation_inputs`.
+- Use `value_origin: "reported"` only for directly reported values, `derived` only when the row gives enough inputs and a formula, and `estimated` only when the row itself marks the value as approximate.
+- Omit weakly grounded PBF fields. Do not infer missing laser power, scan speed, orientations, strain rate, or energy density from general domain knowledge.
 - Extract row-grounded facts only. Use `supporting_text_windows` only to disambiguate row labels, abbreviations, or column meaning.
 - Do not mine `supporting_text_windows` for extra standalone facts that are not needed to interpret this row.
 - If a fact cannot be grounded to the row or a short disambiguating support quote, omit it.
@@ -160,14 +165,37 @@ Valid nested object example:
   "process_context": {
     "temperatures_c": [],
     "durations": [],
-    "atmosphere": null
+    "atmosphere": null,
+    "laser_power_w": null,
+    "scan_speed_mm_s": null,
+    "layer_thickness_um": null,
+    "hatch_spacing_um": null,
+    "spot_size_um": null,
+    "energy_density_j_mm3": null,
+    "energy_density_origin": null,
+    "scan_strategy": null,
+    "build_orientation": null,
+    "preheat_temperature_c": null,
+    "shielding_gas": null,
+    "oxygen_level_ppm": null,
+    "powder_size_distribution_um": null,
+    "post_treatment_summary": null
   },
   "condition_payload": {
     "method": null,
     "methods": [],
     "temperatures_c": [],
     "durations": [],
-    "atmosphere": null
+    "atmosphere": null,
+    "test_method": null,
+    "test_temperature_c": null,
+    "strain_rate_s-1": null,
+    "loading_direction": null,
+    "sample_orientation": null,
+    "environment": null,
+    "frequency_hz": null,
+    "specimen_geometry": null,
+    "surface_state": null
   },
   "value_payload": {
     "value": null,
@@ -175,8 +203,100 @@ Valid nested object example:
     "max": null,
     "retention_percent": null,
     "direction": null,
-    "statement": null
+    "statement": null,
+    "value_origin": null,
+    "source_value_text": null,
+    "source_unit_text": null,
+    "derivation_formula": null,
+    "derivation_inputs": null
   }
+}
+```
+
+Valid PBF metal row example:
+```json
+{
+  "method_facts": [],
+  "sample_variants": [
+    {
+      "variant_label": "S3",
+      "host_material_system": {
+        "family": "titanium alloy",
+        "composition": "Ti-6Al-4V"
+      },
+      "composition": "Ti-6Al-4V",
+      "variable_axis_type": "post_treatment",
+      "variable_value": "optimized VED + HIP",
+      "process_context": {
+        "temperatures_c": [],
+        "durations": [],
+        "atmosphere": null,
+        "laser_power_w": 280,
+        "scan_speed_mm_s": 1200,
+        "layer_thickness_um": 30,
+        "hatch_spacing_um": 100,
+        "energy_density_j_mm3": 78,
+        "energy_density_origin": "reported",
+        "build_orientation": "vertical",
+        "post_treatment_summary": "HIP"
+      },
+      "confidence": 0.86,
+      "epistemic_status": "normalized_from_evidence",
+      "source_kind": "table_row"
+    }
+  ],
+  "test_conditions": [
+    {
+      "property_type": "yield_strength",
+      "condition_payload": {
+        "method": "tensile",
+        "methods": ["tensile"],
+        "temperatures_c": [],
+        "durations": [],
+        "atmosphere": null,
+        "test_method": "tensile",
+        "test_temperature_c": 25,
+        "strain_rate_s-1": 0.001,
+        "loading_direction": "vertical",
+        "sample_orientation": "vertical"
+      },
+      "confidence": 0.86,
+      "epistemic_status": "normalized_from_evidence"
+    }
+  ],
+  "baseline_references": [
+    {
+      "baseline_label": "S2",
+      "confidence": 0.86,
+      "epistemic_status": "normalized_from_evidence"
+    }
+  ],
+  "measurement_results": [
+    {
+      "claim_text": "S3 showed a yield strength of 940 MPa at 25 C.",
+      "property_normalized": "yield_strength",
+      "result_type": "scalar",
+      "value_payload": {
+        "value": 940,
+        "statement": "S3 showed a yield strength of 940 MPa at 25 C.",
+        "value_origin": "reported",
+        "source_value_text": "940",
+        "source_unit_text": "MPa"
+      },
+      "unit": "MPa",
+      "variant_label": "S3",
+      "baseline_label": "S2",
+      "anchors": [
+        {
+          "quote": "S3 showed a yield strength of 940 MPa at 25 C",
+          "source_type": "table",
+          "page": 5
+        }
+      ],
+      "claim_scope": "current_work",
+      "confidence": 0.86
+    }
+  ]
 }
 ```
 
@@ -192,7 +312,12 @@ Valid measurement result example:
     "max": null,
     "retention_percent": null,
     "direction": null,
-    "statement": null
+    "statement": null,
+    "value_origin": "reported",
+    "source_value_text": "560",
+    "source_unit_text": "MPa",
+    "derivation_formula": null,
+    "derivation_inputs": null
   },
   "unit": "MPa",
   "variant_label": null,

--- a/backend/application/core/semantic_build/llm/schemas.py
+++ b/backend/application/core/semantic_build/llm/schemas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -41,6 +41,7 @@ _CLAIM_SCOPES = {
     "unclear",
 }
 _EVIDENCE_SOURCE_TYPES = {"text", "method", "table", "figure"}
+_VALUE_ORIGINS = {"reported", "derived", "estimated"}
 
 
 def _normalize_literal_choice(value: object, *, allowed: set[str], default: str) -> str:
@@ -58,6 +59,15 @@ def _normalize_underscored_choice(value: object, *, allowed: set[str], default: 
     return lowered if lowered in allowed else default
 
 
+def _normalize_optional_underscored_choice(
+    value: object,
+    *,
+    allowed: set[str],
+) -> str | None:
+    lowered = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    return lowered if lowered in allowed else None
+
+
 def _normalize_list_container(value: object) -> object:
     return [] if value is None else value
 
@@ -67,7 +77,7 @@ def _normalize_object_container(value: object) -> object:
 
 
 class _StrictModel(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
 
 class MaterialSystemPayload(_StrictModel):
@@ -79,11 +89,33 @@ class ProcessContextPayload(_StrictModel):
     temperatures_c: list[float] = Field(default_factory=list)
     durations: list[str] = Field(default_factory=list)
     atmosphere: str | None = None
+    laser_power_w: float | None = None
+    scan_speed_mm_s: float | None = None
+    layer_thickness_um: float | None = None
+    hatch_spacing_um: float | None = None
+    spot_size_um: float | None = None
+    energy_density_j_mm3: float | None = None
+    energy_density_origin: Literal["reported", "derived", "estimated"] | None = None
+    scan_strategy: str | None = None
+    build_orientation: str | None = None
+    preheat_temperature_c: float | None = None
+    shielding_gas: str | None = None
+    oxygen_level_ppm: float | None = None
+    powder_size_distribution_um: str | list[float] | None = None
+    post_treatment_summary: str | None = None
 
     @field_validator("temperatures_c", "durations", mode="before")
     @classmethod
     def _normalize_lists(cls, value: object) -> object:
         return _normalize_list_container(value)
+
+    @field_validator("energy_density_origin", mode="before")
+    @classmethod
+    def _normalize_energy_density_origin(cls, value: object) -> str | None:
+        return _normalize_optional_underscored_choice(
+            value,
+            allowed=_VALUE_ORIGINS,
+        )
 
 
 class BaselineContextPayload(_StrictModel):
@@ -135,11 +167,33 @@ class MethodPayloadModel(_StrictModel):
     atmosphere: str | None = None
     methods: list[str] = Field(default_factory=list)
     details: str | None = None
+    laser_power_w: float | None = None
+    scan_speed_mm_s: float | None = None
+    layer_thickness_um: float | None = None
+    hatch_spacing_um: float | None = None
+    spot_size_um: float | None = None
+    energy_density_j_mm3: float | None = None
+    energy_density_origin: Literal["reported", "derived", "estimated"] | None = None
+    scan_strategy: str | None = None
+    build_orientation: str | None = None
+    preheat_temperature_c: float | None = None
+    shielding_gas: str | None = None
+    oxygen_level_ppm: float | None = None
+    powder_size_distribution_um: str | list[float] | None = None
+    post_treatment_summary: str | None = None
 
     @field_validator("temperatures_c", "durations", "methods", mode="before")
     @classmethod
     def _normalize_lists(cls, value: object) -> object:
         return _normalize_list_container(value)
+
+    @field_validator("energy_density_origin", mode="before")
+    @classmethod
+    def _normalize_energy_density_origin(cls, value: object) -> str | None:
+        return _normalize_optional_underscored_choice(
+            value,
+            allowed=_VALUE_ORIGINS,
+        )
 
 
 class MethodFactPayload(_StrictModel):
@@ -193,6 +247,15 @@ class TestConditionPayloadModel(_StrictModel):
     temperatures_c: list[float] = Field(default_factory=list)
     durations: list[str] = Field(default_factory=list)
     atmosphere: str | None = None
+    test_method: str | None = None
+    test_temperature_c: float | None = None
+    strain_rate_s_1: float | str | None = Field(default=None, alias="strain_rate_s-1")
+    loading_direction: str | None = None
+    sample_orientation: str | None = None
+    environment: str | None = None
+    frequency_hz: float | None = None
+    specimen_geometry: str | None = None
+    surface_state: str | None = None
 
     @field_validator("methods", "temperatures_c", "durations", mode="before")
     @classmethod
@@ -225,6 +288,19 @@ class MeasurementValuePayload(_StrictModel):
     retention_percent: float | None = None
     direction: str | None = None
     statement: str | None = None
+    value_origin: Literal["reported", "derived", "estimated"] | None = None
+    source_value_text: str | None = None
+    source_unit_text: str | None = None
+    derivation_formula: str | None = None
+    derivation_inputs: dict[str, Any] | None = None
+
+    @field_validator("value_origin", mode="before")
+    @classmethod
+    def _normalize_value_origin(cls, value: object) -> str | None:
+        return _normalize_optional_underscored_choice(
+            value,
+            allowed=_VALUE_ORIGINS,
+        )
 
 
 class MeasurementResultPayload(_StrictModel):

--- a/backend/application/core/semantic_build/paper_facts_service.py
+++ b/backend/application/core/semantic_build/paper_facts_service.py
@@ -278,6 +278,22 @@ _PROPERTY_HINTS = (
     ("density", "density"),
     ("strength", "strength"),
 )
+_PBF_PROCESS_PAYLOAD_KEYS = (
+    "laser_power_w",
+    "scan_speed_mm_s",
+    "layer_thickness_um",
+    "hatch_spacing_um",
+    "spot_size_um",
+    "energy_density_j_mm3",
+    "energy_density_origin",
+    "scan_strategy",
+    "build_orientation",
+    "preheat_temperature_c",
+    "shielding_gas",
+    "oxygen_level_ppm",
+    "powder_size_distribution_um",
+    "post_treatment_summary",
+)
 _OBSERVED_VALUE_PATTERN = re.compile(
     r"([-+]?\d+(?:\.\d+)?)\s*(nm|um|μm|mm|cm|m2/g|m\^2/g|m²/g|mpa|gpa|pa|%)\b",
     re.IGNORECASE,
@@ -1644,6 +1660,9 @@ class PaperFactsService:
                     min=float(range_match.group(1)),
                     max=float(range_match.group(2)),
                     statement=statement,
+                    value_origin="reported",
+                    source_value_text=range_match.group(0),
+                    source_unit_text=unit,
                 ),
                 unit,
             )
@@ -1657,6 +1676,9 @@ class PaperFactsService:
                 MeasurementValuePayload(
                     min=float(min_match.group(1)),
                     statement=statement,
+                    value_origin="reported",
+                    source_value_text=min_match.group(0),
+                    source_unit_text=unit,
                 ),
                 unit,
             )
@@ -1670,6 +1692,9 @@ class PaperFactsService:
                 MeasurementValuePayload(
                     max=float(max_match.group(1)),
                     statement=statement,
+                    value_origin="reported",
+                    source_value_text=max_match.group(0),
+                    source_unit_text=unit,
                 ),
                 unit,
             )
@@ -1685,6 +1710,9 @@ class PaperFactsService:
                     MeasurementValuePayload(
                         retention_percent=numeric,
                         statement=statement,
+                        value_origin="reported",
+                        source_value_text=approx_match.group(0),
+                        source_unit_text=unit or "%",
                     ),
                     unit or "%",
                 )
@@ -1692,6 +1720,9 @@ class PaperFactsService:
                 MeasurementValuePayload(
                     value=numeric,
                     statement=statement,
+                    value_origin="reported",
+                    source_value_text=approx_match.group(0),
+                    source_unit_text=unit,
                 ),
                 unit,
             )
@@ -1699,11 +1730,15 @@ class PaperFactsService:
         numeric = self._coerce_numeric_text_window_value(value_text, claim_text)
         if numeric is None:
             return MeasurementValuePayload(statement=statement), unit
+        source_value_text = value_text or f"{numeric:g}"
         if str(claim.result_type or "").strip().lower() == "retention":
             return (
                 MeasurementValuePayload(
                     retention_percent=float(numeric),
                     statement=statement,
+                    value_origin="reported",
+                    source_value_text=source_value_text,
+                    source_unit_text=unit or "%",
                 ),
                 unit or "%",
             )
@@ -1711,6 +1746,9 @@ class PaperFactsService:
             MeasurementValuePayload(
                 value=float(numeric),
                 statement=statement,
+                value_origin="reported",
+                source_value_text=source_value_text,
+                source_unit_text=unit,
             ),
             unit,
         )
@@ -2148,7 +2186,7 @@ class PaperFactsService:
         document_state: dict[str, Any],
     ) -> tuple[str, dict[str, Any] | None]:
         normalized_payload = self._normalize_condition_payload(
-            payload.condition_payload.model_dump(exclude_none=True)
+            payload.condition_payload.model_dump(exclude_none=True, by_alias=True)
         )
         property_type = self._normalize_property_name(payload.property_type)
         condition_key = (
@@ -4105,6 +4143,11 @@ class PaperFactsService:
                 "durations": payload.get("durations"),
                 "atmosphere": payload.get("atmosphere"),
                 "methods": payload.get("methods"),
+                **{
+                    key: payload.get(key)
+                    for key in _PBF_PROCESS_PAYLOAD_KEYS
+                    if key in payload
+                },
             }
         )
         details = self._normalize_scalar_text(payload.get("details"))

--- a/backend/application/source/collection_service.py
+++ b/backend/application/source/collection_service.py
@@ -24,6 +24,24 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+class DocumentSourceUnavailableError(RuntimeError):
+    """Raised when a document exists but its original source file cannot be served."""
+
+    def __init__(
+        self,
+        collection_id: str,
+        document_id: str,
+        *,
+        code: str = "document_source_unavailable",
+        message: str = "The original source file is not available for this document.",
+    ) -> None:
+        self.collection_id = collection_id
+        self.document_id = document_id
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
 class CollectionService:
     """File-backed collection registry for the application layer."""
 
@@ -141,6 +159,54 @@ class CollectionService:
         if manifest is None:
             return empty_import_manifest(collection_id)
         return manifest
+
+    def resolve_document_source_file(
+        self,
+        collection_id: str,
+        document_id: str,
+        *,
+        source_filename: str | None = None,
+    ) -> dict[str, Any]:
+        self.get_collection(collection_id)
+        paths = self.repository.get_paths(collection_id)
+        document_key = str(document_id or "").strip()
+        if not document_key:
+            raise DocumentSourceUnavailableError(collection_id, document_key)
+
+        match_keys = self._source_match_keys(document_key, source_filename)
+        manifest = self.repository.read_import_manifest(collection_id) or {}
+        manifest_documents = self._iter_manifest_documents(manifest)
+        for document in manifest_documents:
+            if self._source_document_record_matches(document, match_keys):
+                return self._build_source_file_payload(
+                    collection_id=collection_id,
+                    document_id=document_key,
+                    record=document,
+                    paths=paths,
+                )
+
+        file_matches = [
+            record
+            for record in self.repository.read_files(collection_id) or []
+            if self._source_file_record_matches(record, match_keys)
+        ]
+        if len(file_matches) == 1:
+            return self._build_source_file_payload(
+                collection_id=collection_id,
+                document_id=document_key,
+                record=file_matches[0],
+                paths=paths,
+            )
+        if len(file_matches) > 1:
+            raise DocumentSourceUnavailableError(
+                collection_id,
+                document_key,
+                code="document_source_ambiguous",
+                message="More than one stored source file matches this document.",
+            )
+        if manifest_documents:
+            raise FileNotFoundError(f"document not found: {collection_id}/{document_key}")
+        raise DocumentSourceUnavailableError(collection_id, document_key)
 
     def register_goal_brief_handoff(
         self,
@@ -389,3 +455,155 @@ class CollectionService:
             "ingested_at": batch.source_metadata.ingested_at,
             "documents": documents,
         }
+
+    def _iter_manifest_documents(self, manifest: dict[str, Any]) -> list[dict[str, Any]]:
+        documents: list[dict[str, Any]] = []
+        imports = manifest.get("imports")
+        if not isinstance(imports, list):
+            return documents
+        for import_record in imports:
+            if not isinstance(import_record, dict):
+                continue
+            import_documents = import_record.get("documents")
+            if not isinstance(import_documents, list):
+                continue
+            documents.extend(
+                document
+                for document in import_documents
+                if isinstance(document, dict)
+            )
+        return documents
+
+    def _source_file_record_matches(
+        self,
+        record: dict[str, Any],
+        match_keys: set[str],
+    ) -> bool:
+        candidates = (
+            record.get("source_document_id"),
+            record.get("document_id"),
+            record.get("original_filename"),
+            record.get("stored_filename"),
+            Path(str(record.get("stored_path") or "")).name,
+        )
+        return any(self._source_match_value(candidate) in match_keys for candidate in candidates)
+
+    def _source_document_record_matches(
+        self,
+        record: dict[str, Any],
+        match_keys: set[str],
+    ) -> bool:
+        candidates = (
+            record.get("source_document_id"),
+            record.get("original_filename"),
+            record.get("stored_filename"),
+            record.get("storage_relpath"),
+            Path(str(record.get("storage_relpath") or "")).name,
+            Path(str(record.get("stored_path") or "")).name,
+        )
+        return any(self._source_match_value(candidate) in match_keys for candidate in candidates)
+
+    def _source_match_keys(
+        self,
+        document_id: str,
+        source_filename: str | None,
+    ) -> set[str]:
+        keys = {
+            self._source_match_value(document_id),
+            self._source_match_value(source_filename),
+            self._source_match_value(Path(str(source_filename or "")).name),
+        }
+        return {key for key in keys if key}
+
+    def _source_match_value(self, value: Any) -> str:
+        return str(value or "").strip()
+
+    def _build_source_file_payload(
+        self,
+        *,
+        collection_id: str,
+        document_id: str,
+        record: dict[str, Any],
+        paths: CollectionPaths,
+    ) -> dict[str, Any]:
+        path = self._resolve_source_record_path(
+            collection_id=collection_id,
+            document_id=document_id,
+            record=record,
+            paths=paths,
+        )
+        filename = (
+            self._optional_text(record.get("original_filename"))
+            or self._optional_text(record.get("stored_filename"))
+            or path.name
+        )
+        return {
+            "path": path,
+            "filename": filename,
+            "media_type": self._optional_text(record.get("media_type")),
+            "source_document_id": self._optional_text(record.get("source_document_id"))
+            or document_id,
+        }
+
+    def _resolve_source_record_path(
+        self,
+        *,
+        collection_id: str,
+        document_id: str,
+        record: dict[str, Any],
+        paths: CollectionPaths,
+    ) -> Path:
+        candidates: list[Path] = []
+        storage_relpath = self._optional_text(record.get("storage_relpath"))
+        if storage_relpath:
+            relpath = Path(storage_relpath)
+            candidates.append(
+                relpath if relpath.is_absolute() else paths.collection_dir / relpath
+            )
+
+        stored_path = self._optional_text(record.get("stored_path"))
+        if stored_path:
+            candidates.append(Path(stored_path))
+
+        stored_filename = self._optional_text(record.get("stored_filename"))
+        if stored_filename:
+            candidates.append(paths.input_dir / Path(stored_filename).name)
+
+        for candidate in candidates:
+            resolved = self._validate_collection_input_path(
+                collection_id=collection_id,
+                document_id=document_id,
+                candidate=candidate,
+                paths=paths,
+            )
+            if resolved.is_file():
+                return resolved
+
+        raise DocumentSourceUnavailableError(collection_id, document_id)
+
+    def _validate_collection_input_path(
+        self,
+        *,
+        collection_id: str,
+        document_id: str,
+        candidate: Path,
+        paths: CollectionPaths,
+    ) -> Path:
+        resolved = candidate.expanduser().resolve()
+        try:
+            resolved.relative_to(paths.collection_dir.resolve())
+            resolved.relative_to(paths.input_dir.resolve())
+        except ValueError as exc:
+            raise DocumentSourceUnavailableError(
+                collection_id,
+                document_id,
+                code="document_source_path_invalid",
+                message="The stored source file path is not safe to serve.",
+            ) from exc
+        return resolved
+
+    def _optional_text(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None

--- a/backend/controllers/core/documents.py
+++ b/backend/controllers/core/documents.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import mimetypes
 from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import FileResponse
 
 from application.core.comparison_service import (
     ComparisonRowsNotReadyError,
@@ -14,6 +16,7 @@ from application.core.semantic_build.document_profile_service import (
     DocumentProfileService,
     DocumentProfilesNotReadyError,
 )
+from application.source.collection_service import DocumentSourceUnavailableError
 from controllers.schemas.core.documents import (
     DocumentComparisonSemanticListResponse,
     DocumentContentResponse,
@@ -47,6 +50,38 @@ def _document_comparison_semantics_not_ready_detail(collection_id: str) -> dict[
         "code": "document_comparison_semantics_not_ready",
         "message": "The collection does not have document comparison semantics yet. Finish indexing first.",
         "collection_id": collection_id,
+    }
+
+
+def _document_source_unavailable_detail(
+    exc: DocumentSourceUnavailableError,
+) -> dict[str, str]:
+    return {
+        "code": exc.code,
+        "message": exc.message,
+        "collection_id": exc.collection_id,
+        "document_id": exc.document_id,
+    }
+
+
+def _source_not_found_detail(
+    collection_id: str,
+    document_id: str,
+    exc: FileNotFoundError,
+) -> dict[str, str]:
+    message = str(exc)
+    if message.startswith("collection not found"):
+        return {
+            "code": "collection_not_found",
+            "message": "Collection not found.",
+            "collection_id": collection_id,
+            "document_id": document_id,
+        }
+    return {
+        "code": "document_not_found",
+        "message": "Document not found in this collection.",
+        "collection_id": collection_id,
+        "document_id": document_id,
     }
 
 
@@ -139,6 +174,52 @@ async def get_collection_document_content(
 
 
 @router.get(
+    "/{collection_id}/documents/{document_id}/source",
+    summary="Stream the original source file for one document",
+)
+async def get_collection_document_source(
+    collection_id: str,
+    document_id: str,
+) -> FileResponse:
+    source_filename: str | None = None
+    try:
+        profile = document_profile_service.get_document_profile(collection_id, document_id)
+        source_filename = profile.get("source_filename")
+    except (DocumentNotFoundError, DocumentProfilesNotReadyError):
+        source_filename = None
+
+    try:
+        payload = document_profile_service.collection_service.resolve_document_source_file(
+            collection_id,
+            document_id,
+            source_filename=source_filename,
+        )
+    except DocumentSourceUnavailableError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=_document_source_unavailable_detail(exc),
+        ) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=_source_not_found_detail(collection_id, document_id, exc),
+        ) from exc
+
+    filename = str(payload["filename"])
+    media_type = (
+        str(payload.get("media_type") or "").strip()
+        or mimetypes.guess_type(filename)[0]
+        or "application/octet-stream"
+    )
+    return FileResponse(
+        payload["path"],
+        media_type=media_type,
+        filename=filename,
+        content_disposition_type="inline",
+    )
+
+
+@router.get(
     "/{collection_id}/documents/{document_id}/comparison-semantics",
     response_model=DocumentComparisonSemanticListResponse,
     summary="读取 collection 内单个文档的 comparison semantic drilldown",
@@ -150,12 +231,17 @@ async def get_collection_document_comparison_semantics(
         bool,
         Query(description="是否附带按需生成的 row projection"),
     ] = False,
+    include_grouped_projections: Annotated[
+        bool,
+        Query(description="是否附带 variant dossier/result series grouped projection"),
+    ] = False,
 ) -> DocumentComparisonSemanticListResponse:
     try:
         payload = comparison_service.inspect_document_comparison_semantics(
             collection_id,
             document_id,
             include_row_projections=include_row_projections,
+            include_grouped_projections=include_grouped_projections,
         )
         if payload["count"] == 0:
             document_profile_service.get_document_profile(collection_id, document_id)

--- a/backend/controllers/schemas/core/documents.py
+++ b/backend/controllers/schemas/core/documents.py
@@ -8,6 +8,7 @@ from controllers.schemas.core.comparisons import (
     ComparisonAssessmentResponse,
     ComparisonRowItemResponse,
 )
+from controllers.schemas.core.evidence_chain import EvidenceChainVariantDossierResponse
 
 
 DocumentType = Literal["experimental", "review", "mixed", "uncertain"]
@@ -59,6 +60,23 @@ class DocumentProfileListResponse(BaseModel):
     items: list[DocumentProfileItemResponse] = Field(default_factory=list, description="文档 profile 列表")
 
 
+class DocumentCharRangeResponse(BaseModel):
+    """Document-local source text character range."""
+
+    start: int = Field(..., ge=0, description="字符范围起点")
+    end: int = Field(..., ge=0, description="字符范围终点")
+
+
+class DocumentBoundingBoxResponse(BaseModel):
+    """Document-local source page bounding box."""
+
+    x0: float = Field(..., description="左侧坐标")
+    y0: float = Field(..., description="顶部坐标")
+    x1: float = Field(..., description="右侧坐标")
+    y1: float = Field(..., description="底部坐标")
+    coord_origin: str | None = Field(default=None, description="坐标原点")
+
+
 class DocumentContentBlockResponse(BaseModel):
     """Viewer-friendly block payload for one document."""
 
@@ -71,6 +89,9 @@ class DocumentContentBlockResponse(BaseModel):
     text_unit_ids: list[str] = Field(default_factory=list, description="相关 text unit IDs")
     start_offset: int | None = Field(default=None, description="文档级起始字符偏移")
     end_offset: int | None = Field(default=None, description="文档级结束字符偏移")
+    page: int | None = Field(default=None, description="源文件页码；不可用时为 null")
+    bbox: DocumentBoundingBoxResponse | None = Field(default=None, description="源文件页面坐标框")
+    char_range: DocumentCharRangeResponse | None = Field(default=None, description="源文本字符范围")
 
 
 class DocumentContentResponse(BaseModel):
@@ -197,4 +218,8 @@ class DocumentComparisonSemanticListResponse(BaseModel):
     items: list[DocumentComparisonSemanticItemResponse] = Field(
         default_factory=list,
         description="document 对应的 comparable result 列表",
+    )
+    variant_dossiers: list[EvidenceChainVariantDossierResponse] | None = Field(
+        default=None,
+        description="按需生成的 variant dossier/result series grouped projection",
     )

--- a/backend/controllers/schemas/core/evidence_chain.py
+++ b/backend/controllers/schemas/core/evidence_chain.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from controllers.schemas.core.comparisons import ComparabilityStatus
+
+
+class EvidenceChainMaterialResponse(BaseModel):
+    """Material identity used by evidence-chain projections."""
+
+    label: str = Field(..., description="材料标签")
+    composition: str | None = Field(default=None, description="成分")
+    host_material_system: dict[str, Any] | None = Field(
+        default=None,
+        description="host material system payload",
+    )
+
+
+class EvidenceChainVariantDossierSummaryResponse(BaseModel):
+    """Parent variant dossier context for one or more result chains."""
+
+    variant_id: str | None = Field(default=None, description="样品变体 ID")
+    variant_label: str | None = Field(default=None, description="样品变体标签")
+    material: EvidenceChainMaterialResponse = Field(..., description="材料信息")
+    shared_process_state: dict[str, Any] = Field(
+        default_factory=dict,
+        description="dossier 共享的工艺或样品状态",
+    )
+    shared_missingness: list[str] = Field(
+        default_factory=list,
+        description="影响该 dossier 下所有 chains 的缺失信息",
+    )
+
+
+class EvidenceChainMeasurementResponse(BaseModel):
+    """Display-facing measurement summary for a result chain."""
+
+    property: str = Field(..., description="性质指标")
+    value: float | None = Field(default=None, description="结果数值")
+    unit: str | None = Field(default=None, description="结果单位")
+    result_type: str = Field(..., description="结果类型")
+    summary: str = Field(..., description="结果摘要")
+    statistic_type: str | None = Field(default=None, description="统计值类型")
+    uncertainty: str | None = Field(default=None, description="不确定性说明")
+
+
+class EvidenceChainTestConditionResponse(BaseModel):
+    """Chain-local test condition payload."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    test_method: str | None = Field(default=None, description="测试方法")
+    test_temperature_c: float | None = Field(default=None, description="测试温度 C")
+    strain_rate_s_1: float | str | None = Field(
+        default=None,
+        alias="strain_rate_s-1",
+        description="应变速率 s^-1",
+    )
+    loading_direction: str | None = Field(default=None, description="加载方向")
+    sample_orientation: str | None = Field(default=None, description="样品取向")
+    environment: str | None = Field(default=None, description="测试环境")
+    frequency_hz: float | None = Field(default=None, description="测试频率 Hz")
+    specimen_geometry: str | None = Field(default=None, description="试样几何")
+    surface_state: str | None = Field(default=None, description="表面状态")
+
+
+class EvidenceChainBaselineResponse(BaseModel):
+    """Baseline binding for a result chain."""
+
+    label: str | None = Field(default=None, description="baseline 标签")
+    reference: str | None = Field(default=None, description="baseline 引用")
+    baseline_type: str | None = Field(default=None, description="baseline 类型")
+    resolved: bool = Field(default=False, description="baseline 是否解析")
+
+
+class ResultBaselineDetailResponse(EvidenceChainBaselineResponse):
+    """Result detail baseline payload."""
+
+    baseline_scope: str | None = Field(default=None, description="baseline scope")
+
+
+class EvidenceChainAssessmentResponse(BaseModel):
+    """Collection-scoped assessment attached to one result chain."""
+
+    comparability_status: ComparabilityStatus = Field(..., description="可比性状态")
+    warnings: list[str] = Field(default_factory=list, description="可比性警告")
+    basis: list[str] = Field(default_factory=list, description="可比性判断依据")
+    missing_context: list[str] = Field(default_factory=list, description="缺失上下文")
+    requires_expert_review: bool = Field(default=False, description="是否需要专家复核")
+    assessment_epistemic_status: str = Field(..., description="评估认识论状态")
+
+
+class EvidenceChainValueProvenanceResponse(BaseModel):
+    """Value provenance for evidence-chain review."""
+
+    value_origin: str = Field(..., description="reported/derived/estimated")
+    source_value_text: str | None = Field(default=None, description="原文数值文本")
+    source_unit_text: str | None = Field(default=None, description="原文单位文本")
+    derivation_formula: str | None = Field(default=None, description="派生公式")
+    derivation_inputs: dict[str, Any] | None = Field(default=None, description="派生输入")
+
+
+class EvidenceChainTraceResponse(BaseModel):
+    """Traceback IDs for one result chain."""
+
+    evidence_ids: list[str] = Field(default_factory=list, description="evidence IDs")
+    direct_anchor_ids: list[str] = Field(default_factory=list, description="直接 anchor IDs")
+    contextual_anchor_ids: list[str] = Field(
+        default_factory=list,
+        description="上下文 anchor IDs",
+    )
+    structure_feature_ids: list[str] = Field(
+        default_factory=list,
+        description="结构特征 IDs",
+    )
+    characterization_observation_ids: list[str] = Field(
+        default_factory=list,
+        description="表征观察 IDs",
+    )
+    traceability_status: str = Field(..., description="可追溯性状态")
+
+
+class EvidenceChainResultResponse(BaseModel):
+    """One result chain inside a document-side series projection."""
+
+    result_id: str = Field(..., description="产品向 result ID")
+    source_result_id: str = Field(..., description="来源 measurement result ID")
+    measurement: EvidenceChainMeasurementResponse = Field(..., description="测量值")
+    test_condition: EvidenceChainTestConditionResponse = Field(..., description="测试条件")
+    baseline: EvidenceChainBaselineResponse = Field(..., description="baseline")
+    assessment: EvidenceChainAssessmentResponse = Field(..., description="collection 判断")
+    value_provenance: EvidenceChainValueProvenanceResponse = Field(..., description="数值来源")
+    evidence: EvidenceChainTraceResponse = Field(..., description="证据链追踪")
+
+
+class EvidenceChainVaryingAxisResponse(BaseModel):
+    """The explicit test-side axis used by a result series."""
+
+    axis_name: str | None = Field(default=None, description="变化轴名称")
+    axis_unit: str | None = Field(default=None, description="变化轴单位")
+
+
+class EvidenceChainSeriesResponse(BaseModel):
+    """Sibling result chains under one fixed variant dossier."""
+
+    series_key: str = Field(..., description="series key")
+    property_family: str = Field(..., description="性质族")
+    test_family: str = Field(..., description="测试族")
+    varying_axis: EvidenceChainVaryingAxisResponse = Field(..., description="变化轴")
+    chains: list[EvidenceChainResultResponse] = Field(
+        default_factory=list,
+        description="result chains",
+    )
+
+
+class EvidenceChainVariantDossierResponse(EvidenceChainVariantDossierSummaryResponse):
+    """Document-side variant dossier with grouped result series."""
+
+    series: list[EvidenceChainSeriesResponse] = Field(
+        default_factory=list,
+        description="result series",
+    )
+
+
+class ResultStructureSupportResponse(BaseModel):
+    """Structure or characterization support for one result detail."""
+
+    support_id: str = Field(..., description="support ID")
+    support_type: str = Field(..., description="support 类型")
+    summary: str = Field(..., description="support 摘要")
+    condition: dict[str, Any] = Field(default_factory=dict, description="表征条件")
+
+
+class ResultSeriesSiblingMeasurementResponse(BaseModel):
+    """Compact measurement summary for one sibling chain."""
+
+    property: str = Field(..., description="性质指标")
+    value: float | None = Field(default=None, description="结果数值")
+    unit: str | None = Field(default=None, description="结果单位")
+
+
+class ResultSeriesSiblingResponse(BaseModel):
+    """Sibling result pointer inside result-detail series navigation."""
+
+    result_id: str = Field(..., description="产品向 result ID")
+    axis_value: str | float | int | None = Field(default=None, description="轴取值")
+    axis_unit: str | None = Field(default=None, description="轴单位")
+    measurement: ResultSeriesSiblingMeasurementResponse = Field(..., description="测量摘要")
+
+
+class ResultSeriesNavigationResponse(BaseModel):
+    """Navigation across sibling chains in the same variant/property/test series."""
+
+    series_key: str = Field(..., description="series key")
+    varying_axis: EvidenceChainVaryingAxisResponse = Field(..., description="变化轴")
+    siblings: list[ResultSeriesSiblingResponse] = Field(
+        default_factory=list,
+        description="同 series 的 result siblings",
+    )

--- a/backend/controllers/schemas/core/results.py
+++ b/backend/controllers/schemas/core/results.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 from pydantic import BaseModel, Field
 
 from controllers.schemas.core.comparisons import ComparabilityStatus
+from controllers.schemas.core.evidence_chain import (
+    EvidenceChainTestConditionResponse,
+    EvidenceChainValueProvenanceResponse,
+    EvidenceChainVariantDossierSummaryResponse,
+    ResultBaselineDetailResponse,
+    ResultSeriesNavigationResponse,
+    ResultStructureSupportResponse,
+)
 
 
 class ResultListItemResponse(BaseModel):
@@ -104,6 +112,30 @@ class ResultItemResponse(BaseModel):
     assessment: ResultAssessmentResponse = Field(..., description="collection 判断")
     evidence: list[ResultEvidenceItemResponse] = Field(default_factory=list, description="证据列表")
     actions: ResultActionsResponse = Field(..., description="drilldown 动作")
+    variant_dossier: EvidenceChainVariantDossierSummaryResponse | None = Field(
+        default=None,
+        description="当前 result 的 parent variant dossier summary",
+    )
+    test_condition_detail: EvidenceChainTestConditionResponse | None = Field(
+        default=None,
+        description="chain-local 测试条件详情",
+    )
+    baseline_detail: ResultBaselineDetailResponse | None = Field(
+        default=None,
+        description="baseline 详情",
+    )
+    structure_support: list[ResultStructureSupportResponse] = Field(
+        default_factory=list,
+        description="结构/表征支撑证据摘要",
+    )
+    value_provenance: EvidenceChainValueProvenanceResponse | None = Field(
+        default=None,
+        description="数值来源与派生信息",
+    )
+    series_navigation: ResultSeriesNavigationResponse | None = Field(
+        default=None,
+        description="同 dossier 下的 sibling result series 导航",
+    )
 
 
 class ResultListResponse(BaseModel):

--- a/backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/README.md
+++ b/backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/README.md
@@ -16,6 +16,9 @@ The family keeps three live pages because this local subject now needs:
 - a backend drilldown plan that explains how Core should expose variant
   dossiers, result chains, and result-series projections without adding a new
   top-level artifact family
+- a fact-thickening plan that turns the landed evidence-chain read projection
+  into concrete PBF-metal schema, prompt, normalization, policy, and fixture
+  work
 - an implementation plan that turns that direction into executable delivery
   slices, file areas, and verification commands
 
@@ -30,6 +33,10 @@ The family keeps three live pages because this local subject now needs:
 - [`variant-dossier-and-result-chain-backend-plan.md`](variant-dossier-and-result-chain-backend-plan.md)
   Narrow backend plan for dossier, chain, and series projections over the
   existing Core semantic backbone
+- [`evidence-chain-fact-thickening-plan.md`](evidence-chain-fact-thickening-plan.md)
+  Detailed next backend plan for PBF-metal schema, prompt, normalization,
+  comparability policy, and acceptance fixture work after read projection
+  landing
 - [`implementation-plan.md`](implementation-plan.md)
   Delivery slices, owned file areas, verification commands, and acceptance
   gates for the execution wave

--- a/backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/evidence-chain-fact-thickening-plan.md
+++ b/backend/docs/plans/core/pbf-metal-extraction-and-comparison-validation/evidence-chain-fact-thickening-plan.md
@@ -1,0 +1,475 @@
+# Evidence-Chain Fact Thickening Plan
+
+## Summary
+
+This plan records the next backend Core implementation wave after the
+document/result evidence-chain read projection.
+
+The read projection now gives the frontend additive fields such as:
+
+- `variant_dossiers`
+- `series`
+- `chains`
+- `test_condition_detail`
+- `baseline_detail`
+- `structure_support`
+- `value_provenance`
+- `series_navigation`
+
+The remaining backend problem is upstream fact quality. The projection can
+read PBF-metal fields, but the current extraction schema, prompts,
+normalization, and comparability policy do not yet produce those fields
+reliably.
+
+The goal of this page is to turn the next backend work into an executable
+PBF-metal fact-thickening plan.
+
+## Scope
+
+This wave is intentionally narrow. It targets PBF-metal literature, especially
+LPBF, SLM, PBF-LB/M, and closely related metal powder-bed fusion papers.
+
+This wave should not make Lens a PBF-only product. It should add PBF-metal
+thickness inside the existing Core fact records so the evidence-chain
+projection can become stable enough for researcher review.
+
+The durable backbone remains:
+
+```text
+document_profiles
+-> paper facts family
+-> comparable_results
+-> collection_comparable_results
+-> row projection
+```
+
+This wave must not add a new permanent artifact family such as:
+
+- `variant_dossiers.parquet`
+- `result_chains.parquet`
+- `result_series.parquet`
+
+## Current Backend State
+
+The current read projection can already assemble dossier and chain payloads
+from existing artifacts.
+
+What is still too thin:
+
+- `ProcessContextPayload` mostly carries generic `temperatures_c`,
+  `durations`, and `atmosphere`.
+- `TestConditionPayloadModel` mostly carries generic method, temperature,
+  duration, and atmosphere fields.
+- `MeasurementValuePayload` does not preserve enough value provenance for
+  evidence-chain review.
+- `ComparisonAssembler` can summarize generic process and test condition
+  payloads, but it does not yet normalize PBF-metal context into stable
+  comparison identities and readable summaries.
+- `evaluate_comparison_assessment()` still uses generic missingness rules
+  instead of PBF-metal review rules.
+
+The next backend work should thicken those facts before adding broader
+collection aggregation.
+
+## PBF-Metal Field Boundary
+
+### Process And Sample State
+
+Add these fields to the process/sample-state payload carried by
+`SampleVariant.process_context` and related method payloads:
+
+- `laser_power_w`
+- `scan_speed_mm_s`
+- `layer_thickness_um`
+- `hatch_spacing_um`
+- `spot_size_um`
+- `energy_density_j_mm3`
+- `energy_density_origin`
+- `scan_strategy`
+- `build_orientation`
+- `preheat_temperature_c`
+- `shielding_gas`
+- `oxygen_level_ppm`
+- `powder_size_distribution_um`
+- `post_treatment_summary`
+
+These fields belong to the variant or process state. They should appear in
+`variant_dossier.shared_process_state` when extracted and linked.
+
+### Test Condition
+
+Add these fields to the test-condition payload carried by
+`TestCondition.condition_payload`:
+
+- `test_method`
+- `test_temperature_c`
+- `strain_rate_s-1`
+- `loading_direction`
+- `sample_orientation`
+- `environment`
+- `frequency_hz`
+- `specimen_geometry`
+- `surface_state`
+
+The Python model should use a legal internal field name for strain rate, such
+as `strain_rate_s_1`, with a Pydantic alias of `strain_rate_s-1` where needed.
+The API-facing evidence-chain contract should continue using the frozen
+`strain_rate_s-1` key.
+
+### Value Provenance
+
+Add these fields to `MeasurementResult.value_payload`:
+
+- `value_origin`
+- `source_value_text`
+- `source_unit_text`
+- `derivation_formula`
+- `derivation_inputs`
+
+Allowed `value_origin` values for this wave:
+
+- `reported`
+- `derived`
+- `estimated`
+
+This distinction is required for values such as volumetric energy density,
+where the reviewer needs to know whether the number was author-reported,
+system-derived from reported inputs, or weakly estimated.
+
+## Temperature Ownership Rules
+
+Temperature fields must remain separated by scientific role:
+
+- `preheat_temperature_c` belongs in process state.
+- `test_temperature_c` belongs in test condition.
+- characterization temperature belongs with the characterization observation
+  condition and must not be copied into process state or mechanical test
+  condition.
+
+This separation is necessary for stable series grouping. A tensile temperature
+series should group result chains under the same variant. A changed preheat or
+post-treatment state should split the variant dossier instead.
+
+## Delivery Slices
+
+### Slice 1: PBF Fact Schema Thickening
+
+Goal:
+
+Make the extraction schema legally accept the PBF-metal fields needed by the
+evidence-chain projection.
+
+Owned file areas:
+
+- `application/core/semantic_build/llm/schemas.py`
+- `application/core/semantic_build/paper_facts_service.py`
+- `tests/unit/services/test_paper_facts_services.py`
+
+Implementation notes:
+
+- Extend `ProcessContextPayload` with PBF process/sample-state fields.
+- Extend `TestConditionPayloadModel` with mechanical and physical test fields.
+- Extend `MeasurementValuePayload` with value provenance fields.
+- Keep strict model validation. Unknown extras should still be rejected.
+- Preserve storage and restore behavior through existing paper-facts artifact
+  columns.
+
+Verification:
+
+```bash
+cd backend
+uv run pytest tests/unit/services/test_paper_facts_services.py
+```
+
+Exit criteria:
+
+- PBF process fields survive model validation and artifact normalization.
+- PBF test fields survive model validation and artifact normalization.
+- value provenance fields survive model validation and artifact normalization.
+- Existing generic extraction tests remain green.
+
+### Slice 2: Prompt And JSON Guidance
+
+Goal:
+
+Teach the extractor where PBF-metal facts belong without encouraging
+ungrounded numeric extraction.
+
+Owned file areas:
+
+- `application/core/semantic_build/llm/prompts.py`
+- `application/core/semantic_build/llm/schemas.py`
+- `tests/unit/services/test_core_llm_extractor.py`
+- `tests/unit/services/test_paper_facts_services.py`
+
+Implementation notes:
+
+- Update valid JSON examples to include PBF process fields.
+- Add examples for tensile test condition fields.
+- Add examples for `value_origin`, `source_value_text`, and
+  `source_unit_text`.
+- Keep the rule that `unit` belongs at `measurement_results[*].unit`, not
+  inside `value_payload`.
+- Explicitly separate process temperature, test temperature, and
+  characterization temperature.
+- Tell the model to omit weakly grounded fields rather than infer missing
+  values.
+
+Verification:
+
+```bash
+cd backend
+uv run pytest tests/unit/services/test_core_llm_extractor.py
+uv run pytest tests/unit/services/test_paper_facts_services.py
+```
+
+Exit criteria:
+
+- Prompt examples match the schema.
+- Invalid examples still reject non-schema keys and misplaced units.
+- The extractor can emit PBF process/test/provenance fields without schema
+  errors.
+
+### Slice 3: Assembly And Normalization
+
+Goal:
+
+Make extracted PBF fields affect comparable-result identity, readable
+summaries, and evidence-chain grouping correctly.
+
+Owned file areas:
+
+- `application/core/comparison_assembly.py`
+- `domain/core/comparison.py` only if identity payloads or normalized context
+  types need domain support
+- `tests/unit/services/test_paper_facts_services.py`
+- `tests/unit/domains/test_comparison_domain.py`
+
+Implementation notes:
+
+- Update `normalize_process()` so PBF parameters produce readable process
+  summaries, for example:
+
+```text
+LPBF, P=280 W, v=1200 mm/s, h=100 um, t=30 um, HIP
+```
+
+- Update `summarize_test_condition()` so tensile and fatigue fields produce
+  readable test summaries, for example:
+
+```text
+tensile, 25 C, strain_rate=0.001 s^-1, vertical
+```
+
+- Ensure process-side changes stay in variant/process identity.
+- Ensure test-side changes stay in test-condition identity.
+- Ensure value provenance is preserved and available to result detail.
+
+Verification:
+
+```bash
+cd backend
+uv run pytest tests/unit/services/test_paper_facts_services.py
+uv run pytest tests/unit/domains/test_comparison_domain.py
+```
+
+Exit criteria:
+
+- Different `test_temperature_c` values do not create different variant
+  dossiers by themselves.
+- Different `post_treatment_summary` or other process-state changes are not
+  collapsed into one process state.
+- `strain_rate_s-1` and loading/sample directions remain test-side context.
+- `value_origin` and source-value fields are not lost during comparison
+  assembly.
+
+### Slice 4: PBF Comparability Policy
+
+Goal:
+
+Make collection-scoped assessment reflect PBF-metal review limits instead of
+only generic row readiness.
+
+Owned file areas:
+
+- `domain/core/comparison.py`
+- `application/core/comparison_assembly.py`
+- `tests/unit/domains/test_comparison_domain.py`
+- `tests/unit/services/test_paper_facts_services.py`
+
+First rules:
+
+- tensile-style results missing `strain_rate_s-1` should be `limited`
+- tensile-style results missing `loading_direction` should be `limited`
+- tensile-style results missing `sample_orientation` should be `limited`
+- orientation-sensitive results missing `build_orientation` should be
+  `limited`
+- improvement-style claims missing a resolved baseline should not be marked
+  fully comparable
+- `energy_density_origin == "derived"` should create a warning
+- `energy_density_origin == "estimated"` should require expert review
+- mixed heat-treatment state under one variant should create a warning when
+  detected
+
+These rules should populate:
+
+- `assessment.missing_critical_context`
+- `assessment.comparability_warnings`
+- `assessment.comparability_basis`
+- `assessment.requires_expert_review`
+- `assessment.comparability_status`
+
+Verification:
+
+```bash
+cd backend
+uv run pytest tests/unit/domains/test_comparison_domain.py
+uv run pytest tests/unit/services/test_paper_facts_services.py
+```
+
+Exit criteria:
+
+- Missing strain rate no longer yields a fully comparable tensile result.
+- Missing loading direction or sample orientation is visible to callers.
+- baseline gaps are explicit.
+- reported, derived, and estimated values are distinguishable in assessment
+  output.
+
+### Slice 5: PBF Acceptance Fixture
+
+Goal:
+
+Lock the fact-thickening work against one minimal PBF-metal evidence-chain
+fixture.
+
+Owned file areas:
+
+- `tests/unit/services/test_paper_facts_services.py`
+- `tests/unit/domains/test_comparison_domain.py`
+- `tests/unit/routers/test_documents_api.py`
+- `tests/unit/routers/test_results_api.py`
+- a backend-local fixture path if the fixture becomes too large for inline
+  tests
+
+Fixture shape:
+
+```text
+Material:
+Ti-6Al-4V
+
+Variant S2:
+optimized VED, no HIP
+
+Variant S3:
+optimized VED + HIP
+
+Process:
+P=280 W
+v=1200 mm/s
+h=100 um
+t=30 um
+VED=78 J/mm3
+energy_density_origin=reported
+build_orientation=vertical
+
+Tests:
+tensile at 25 C
+tensile at 200 C
+strain_rate=1e-3 s^-1
+loading_direction=vertical
+sample_orientation=vertical
+
+Structure:
+porosity=0.1%
+residual stress lower
+
+Results:
+YS=940 MPa at 25 C
+YS=820 MPa at 200 C
+EL=15%
+
+Baseline:
+S2 optimized VED without HIP
+```
+
+Acceptance assertions:
+
+- S3 becomes one `variant_dossier`.
+- 25 C and 200 C tensile results become one result series.
+- `series_key == "yield_strength:test_temperature_c"`.
+- process fields appear in `shared_process_state`.
+- test fields appear in `test_condition_detail`.
+- porosity appears in `structure_support`.
+- reported values appear in `value_provenance`.
+- S2 appears in `baseline_detail`.
+- missing strain rate triggers limited comparability.
+
+Verification:
+
+```bash
+cd backend
+uv run pytest tests/unit/services/test_paper_facts_services.py
+uv run pytest tests/unit/domains/test_comparison_domain.py
+uv run pytest tests/unit/routers/test_documents_api.py
+uv run pytest tests/unit/routers/test_results_api.py
+```
+
+Exit criteria:
+
+- The backend can reconstruct a single-paper PBF evidence chain without
+  frontend inference.
+- Missingness and provenance are visible in the API payloads.
+- The fixture can distinguish process variation from test-condition variation.
+
+## Suggested Commit Sequence
+
+The work should be split into reviewable backend commits:
+
+```text
+feat(core): thicken PBF fact schema
+feat(core): normalize PBF comparison context
+feat(core): add PBF comparability acceptance
+```
+
+The first commit should focus on schema and prompt legality. The second should
+make assembly and projection consume the new fields. The third should add
+assessment behavior and acceptance coverage.
+
+## Non-Goals
+
+This wave should not:
+
+- add a new top-level browser resource
+- add a permanent PBF-only artifact family
+- build collection-level material synthesis
+- redesign graph, report, or protocol surfaces
+- turn the parameter registry into a wide UI table
+- generalize the field set to all materials domains
+
+## Verification Summary
+
+For the full wave, run:
+
+```bash
+cd backend
+uv run pytest tests/unit/services/test_core_llm_extractor.py
+uv run pytest tests/unit/services/test_paper_facts_services.py
+uv run pytest tests/unit/domains/test_comparison_domain.py
+uv run pytest tests/unit/routers/test_documents_api.py
+uv run pytest tests/unit/routers/test_results_api.py
+python3 ../scripts/check_docs_governance.py
+```
+
+## Related Docs
+
+- [`README.md`](README.md)
+  Topic-family reading order for the PBF-metal validation wave
+- [`implementation-plan.md`](implementation-plan.md)
+  Broader executable implementation plan for the whole PBF-metal validation
+  wave
+- [`variant-dossier-and-result-chain-backend-plan.md`](variant-dossier-and-result-chain-backend-plan.md)
+  Backend-local plan for dossier, chain, and series read projections
+- [`parameter-registry-and-variant-report-scope.md`](parameter-registry-and-variant-report-scope.md)
+  First-version PBF parameter boundary and variant report scope
+- [`../../../../../docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md`](../../../../../docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md)
+  Shared additive contract freeze for document and result drilldown

--- a/backend/docs/specs/api.md
+++ b/backend/docs/specs/api.md
@@ -295,10 +295,39 @@
 
 - `GET /api/v1/collections/{collection_id}/documents/{document_id}/profile`
 - `GET /api/v1/collections/{collection_id}/documents/{document_id}/content`
+- `GET /api/v1/collections/{collection_id}/documents/{document_id}/source`
 - `GET /api/v1/collections/{collection_id}/documents/{document_id}/comparison-semantics`
 
 其中 `/profile` 返回与 list item 同语义的单项 document profile，`/content`
-返回原文阅读器内容与 section 结构。
+返回原文阅读器内容与 section fallback 结构，`/source` 以 inline file
+response 返回该 document 的原始上传文件，供浏览器 PDF/source reader
+直接展示。
+
+`/content` 的每个 block 仍是 backend source locator unit，不是前端可见
+章节模型。前端可以用这些字段做 fallback 定位，但默认 UI 不应暴露
+`block_id`、`blk_xxx` 或重复的 block-level `heading_path`。block locator
+字段：
+
+- `page`: 源文件页码；不可用或非法时为 `null`
+- `bbox`: 页面坐标框；不可用或非法时为 `null`
+  - `x0`
+  - `y0`
+  - `x1`
+  - `y1`
+  - `coord_origin`
+- `char_range`: 源文本字符范围；不可用或非法时为 `null`
+  - `start`
+  - `end`
+
+`/source` 行为：
+
+- 成功时返回 `200`，`Content-Disposition` 为 inline，`Content-Type` 优先使用
+  collection metadata 中的 `media_type`，否则按文件名推断
+- collection 或 document 无法解析时返回 `404`
+- document 存在但 source file 缺失、无法安全解析或存在歧义时返回 `409`
+  structured detail
+- endpoint 不接受任何 request path；文件路径只能从 collection-owned
+  metadata 解析，且必须位于 collection input 目录内
 
 文档页语义要求：
 
@@ -365,7 +394,7 @@
 - `evidence`
 - `actions`
 
-下一波 additive contract 冻结字段：
+已支持的 additive evidence-chain 字段：
 
 - `variant_dossier`
 - `test_condition_detail`
@@ -380,9 +409,9 @@
   `comparable_result_id`
 - 结果页必须由 `ComparableResult` 与当前 collection 的
   `CollectionComparableResult` 共同投影
-- 结果页的下一波 additive contract 已在
+- 结果页的 additive evidence-chain contract 已在
   `docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md`
-  冻结；该 contract 应把结果页提升为 chain-first drilldown，而不是继续停留在
+  冻结；该 contract 把结果页提升为 chain-first drilldown，而不是继续停留在
   generic measurement card
 - `variant_dossier` 是当前 result 对应的 parent dossier summary，不是第二个主页面模型
 - `test_condition_detail`、`baseline_detail`、`structure_support`、
@@ -417,7 +446,7 @@
 - `count`
 - `items`
 
-下一波 additive contract 冻结字段：
+已支持的 additive grouped projection 字段：
 
 - `variant_dossiers`
 
@@ -456,7 +485,7 @@
 语义要求：
 
 - 这是 `ComparableResult` 的 document-scoped inspection surface，不是 row list
-- 该路由的下一波 additive grouped drilldown contract 已在
+- 该路由的 additive grouped drilldown contract 已在
   `docs/decisions/rfc-document-result-evidence-chain-contract-freeze.md`
   冻结
 - flat `items` list 必须继续保留；grouped projections 是 additive read model，
@@ -481,7 +510,7 @@
   - `true` 时允许为 document-facing drilldown 附带按需生成的 row payload
 - `include_grouped_projections=true|false`
   - `false` 时允许省略 grouped dossier/series projection
-  - `true` 时应返回 `variant_dossiers`
+  - `true` 时返回 `variant_dossiers`
 
 ### Corpus Comparable Results
 
@@ -652,9 +681,12 @@
 
 前端降级顺序（固定）：
 
-1. `char_range`
-2. `bbox`
-3. `section`
+1. `page + bbox` when the active reader can draw PDF overlays
+2. `char_range`
+3. `page`
+4. `section`
+5. `quote`
+6. source location unavailable message
 
 comparison 对 traceback 的依赖约定：
 

--- a/backend/domain/core/comparison.py
+++ b/backend/domain/core/comparison.py
@@ -44,6 +44,40 @@ DEFAULT_COLLECTION_REASSESSMENT_TRIGGERS: Final[tuple[str, ...]] = (
     COLLECTION_REASSESSMENT_TRIGGER_NORMALIZATION_VERSION_CHANGED,
     COLLECTION_REASSESSMENT_TRIGGER_ASSESSMENT_INPUT_CHANGED,
 )
+PBF_PROCESS_CONTEXT_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "laser_power_w",
+        "scan_speed_mm_s",
+        "layer_thickness_um",
+        "hatch_spacing_um",
+        "spot_size_um",
+        "energy_density_j_mm3",
+        "energy_density_origin",
+        "scan_strategy",
+        "build_orientation",
+        "preheat_temperature_c",
+        "shielding_gas",
+        "oxygen_level_ppm",
+        "powder_size_distribution_um",
+        "post_treatment_summary",
+    }
+)
+PBF_TENSILE_STYLE_PROPERTIES: Final[frozenset[str]] = frozenset(
+    {
+        "strength",
+        "tensile_strength",
+        "yield_strength",
+        "elongation",
+        "modulus",
+    }
+)
+PBF_ORIENTATION_SENSITIVE_PROPERTIES: Final[frozenset[str]] = frozenset(
+    {
+        *PBF_TENSILE_STYLE_PROPERTIES,
+        "fatigue_life",
+        "residual_stress",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -535,12 +569,21 @@ def evaluate_collection_reassessment_reasons(
     return tuple(reasons)
 
 
-def evaluate_comparison_assessment(comparable_result: ComparableResult) -> ComparisonAssessment:
-    missing_critical_context = _derive_missing_critical_context(comparable_result)
-    comparability_basis = _derive_comparability_basis(comparable_result)
+def evaluate_comparison_assessment(
+    comparable_result: ComparableResult,
+    *,
+    assessment_context: Mapping[str, Any] | None = None,
+) -> ComparisonAssessment:
+    context = _normalize_mapping(assessment_context)
+    missing_critical_context = _derive_missing_critical_context(
+        comparable_result,
+        context,
+    )
+    comparability_basis = _derive_comparability_basis(comparable_result, context)
     comparability_warnings = _build_comparability_warnings(
         missing_critical_context=missing_critical_context,
         result_type=comparable_result.value.result_type,
+        context_warnings=_derive_context_warnings(comparable_result, context),
     )
     comparability_status = _derive_comparability_status(
         missing_critical_context=missing_critical_context,
@@ -565,7 +608,10 @@ def evaluate_comparison_assessment(comparable_result: ComparableResult) -> Compa
     )
 
 
-def _derive_missing_critical_context(comparable_result: ComparableResult) -> list[str]:
+def _derive_missing_critical_context(
+    comparable_result: ComparableResult,
+    assessment_context: Mapping[str, Any],
+) -> list[str]:
     missing: list[str] = []
     if not comparable_result.binding.variant_id:
         missing.append("variant_link")
@@ -579,10 +625,15 @@ def _derive_missing_critical_context(comparable_result: ComparableResult) -> lis
         missing.append("result_value")
     if comparable_result.value.result_type not in SCALAR_LIKE_RESULT_TYPES:
         missing.append("expert_interpretation")
+    if _is_pbf_context(comparable_result, assessment_context):
+        _append_pbf_missing_context(missing, comparable_result, assessment_context)
     return missing
 
 
-def _derive_comparability_basis(comparable_result: ComparableResult) -> list[str]:
+def _derive_comparability_basis(
+    comparable_result: ComparableResult,
+    assessment_context: Mapping[str, Any],
+) -> list[str]:
     basis: list[str] = []
     if comparable_result.binding.variant_id:
         basis.append("variant_linked")
@@ -600,6 +651,23 @@ def _derive_comparability_basis(comparable_result: ComparableResult) -> list[str
         basis.append("structure_context_available")
     if comparable_result.evidence.characterization_observation_ids:
         basis.append("characterization_context_available")
+    if _is_pbf_context(comparable_result, assessment_context):
+        basis.append("pbf_context_detected")
+        process_context = _process_context_from_assessment(assessment_context)
+        condition_payload = _condition_payload_from_assessment(assessment_context)
+        if _has_context_value(process_context.get("build_orientation")):
+            basis.append("build_orientation_reported")
+        if _has_context_value(_strain_rate_value(condition_payload)):
+            basis.append("strain_rate_reported")
+        if _has_context_value(condition_payload.get("loading_direction")):
+            basis.append("loading_direction_reported")
+        if _has_context_value(condition_payload.get("sample_orientation")):
+            basis.append("sample_orientation_reported")
+        energy_density_origin = _normalize_text(
+            process_context.get("energy_density_origin")
+        )
+        if energy_density_origin:
+            basis.append(f"energy_density_origin:{energy_density_origin}")
     return basis
 
 
@@ -607,6 +675,7 @@ def _build_comparability_warnings(
     *,
     missing_critical_context: list[str],
     result_type: str,
+    context_warnings: list[str],
 ) -> list[str]:
     warnings: list[str] = []
     warning_map = {
@@ -616,6 +685,11 @@ def _build_comparability_warnings(
         "direct_traceability": "Traceability is partial or indirect.",
         "result_value": "Result payload is incomplete for comparison display.",
         "expert_interpretation": "Result shape requires expert interpretation before comparison.",
+        "build_orientation": "PBF build orientation is missing for an orientation-sensitive result.",
+        "strain_rate_s-1": "Tensile-style PBF result is missing strain rate.",
+        "loading_direction": "Tensile-style PBF result is missing loading direction.",
+        "sample_orientation": "Tensile-style PBF result is missing sample orientation.",
+        "energy_density_estimated": "Energy density is estimated and requires expert review before comparison.",
     }
     for item in missing_critical_context:
         warning = warning_map.get(item)
@@ -625,7 +699,146 @@ def _build_comparability_warnings(
         warnings.append(
             "This comparison row summarizes a non-scalar result and should be reviewed by a domain expert."
         )
+    for warning in context_warnings:
+        if warning not in warnings:
+            warnings.append(warning)
     return warnings
+
+
+def _append_pbf_missing_context(
+    missing: list[str],
+    comparable_result: ComparableResult,
+    assessment_context: Mapping[str, Any],
+) -> None:
+    process_context = _process_context_from_assessment(assessment_context)
+    condition_payload = _condition_payload_from_assessment(assessment_context)
+    property_name = _normalize_text(comparable_result.value.property_normalized) or ""
+
+    if (
+        property_name in PBF_ORIENTATION_SENSITIVE_PROPERTIES
+        and not _has_context_value(process_context.get("build_orientation"))
+    ):
+        _append_once(missing, "build_orientation")
+
+    if _is_tensile_style_result(comparable_result, condition_payload):
+        if not _has_context_value(_strain_rate_value(condition_payload)):
+            _append_once(missing, "strain_rate_s-1")
+        if not _has_context_value(condition_payload.get("loading_direction")):
+            _append_once(missing, "loading_direction")
+        if not _has_context_value(condition_payload.get("sample_orientation")):
+            _append_once(missing, "sample_orientation")
+
+    if _normalize_text(process_context.get("energy_density_origin")) == "estimated":
+        _append_once(missing, "energy_density_estimated")
+
+
+def _derive_context_warnings(
+    comparable_result: ComparableResult,
+    assessment_context: Mapping[str, Any],
+) -> list[str]:
+    if not _is_pbf_context(comparable_result, assessment_context):
+        return []
+
+    warnings: list[str] = []
+    process_context = _process_context_from_assessment(assessment_context)
+    energy_density_origin = _normalize_text(process_context.get("energy_density_origin"))
+    if energy_density_origin == "derived":
+        warnings.append(
+            "Energy density was derived from reported inputs; verify the formula before cross-paper comparison."
+        )
+    post_treatment = (_normalize_text(process_context.get("post_treatment_summary")) or "").lower()
+    if any(token in post_treatment for token in ("mixed", "multiple", "varied")):
+        warnings.append(
+            "Post-treatment state appears mixed under one variant and should be reviewed."
+        )
+    return warnings
+
+
+def _is_pbf_context(
+    comparable_result: ComparableResult,
+    assessment_context: Mapping[str, Any],
+) -> bool:
+    variant = _normalize_mapping(assessment_context.get("variant"))
+    if _normalize_text(variant.get("domain_profile")) == "pbf_metal":
+        return True
+
+    process_context = _process_context_from_assessment(assessment_context)
+    if any(
+        _has_context_value(process_context.get(key))
+        for key in PBF_PROCESS_CONTEXT_KEYS
+    ):
+        return True
+
+    process_text = (
+        comparable_result.normalized_context.process_normalized or ""
+    ).lower()
+    return any(
+        token in process_text
+        for token in (
+            "lpbf",
+            "pbf-lb",
+            "powder bed fusion",
+            "laser powder bed",
+            "slm",
+        )
+    )
+
+
+def _is_tensile_style_result(
+    comparable_result: ComparableResult,
+    condition_payload: Mapping[str, Any],
+) -> bool:
+    property_name = _normalize_text(comparable_result.value.property_normalized) or ""
+    if property_name in PBF_TENSILE_STYLE_PROPERTIES:
+        return True
+    method_text = " ".join(
+        str(item)
+        for item in (
+            condition_payload.get("test_method"),
+            condition_payload.get("method"),
+            *_normalize_string_tuple(condition_payload.get("methods")),
+        )
+        if _normalize_text(item)
+    ).lower()
+    return "tensile" in method_text or "strain" in method_text
+
+
+def _process_context_from_assessment(
+    assessment_context: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    variant = _normalize_mapping(assessment_context.get("variant"))
+    return _normalize_mapping(variant.get("process_context"))
+
+
+def _condition_payload_from_assessment(
+    assessment_context: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    condition = _normalize_mapping(assessment_context.get("test_condition"))
+    return _normalize_mapping(condition.get("condition_payload"))
+
+
+def _strain_rate_value(condition_payload: Mapping[str, Any]) -> Any:
+    return (
+        condition_payload.get("strain_rate_s-1")
+        or condition_payload.get("strain_rate_s_1")
+        or condition_payload.get("strain_rate")
+        or condition_payload.get("rate")
+    )
+
+
+def _has_context_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, float) and math.isnan(value):
+        return False
+    if isinstance(value, (list, tuple, set, dict)):
+        return bool(value)
+    return bool(str(value).strip())
+
+
+def _append_once(items: list[str], value: str) -> None:
+    if value not in items:
+        items.append(value)
 
 
 def _derive_comparability_status(

--- a/backend/tests/support/pbf_acceptance_fixture.py
+++ b/backend/tests/support/pbf_acceptance_fixture.py
@@ -1,0 +1,595 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from domain.core.comparison import (
+    COMPARABLE_RESULT_NORMALIZATION_VERSION,
+    COLLECTION_COMPARISON_POLICY_FAMILY,
+    COLLECTION_COMPARISON_POLICY_VERSION,
+    COLLECTION_REASSESSMENT_TRIGGER_ASSESSMENT_INPUT_CHANGED,
+    COLLECTION_REASSESSMENT_TRIGGER_NORMALIZATION_VERSION_CHANGED,
+    COLLECTION_REASSESSMENT_TRIGGER_POLICY_FAMILY_CHANGED,
+    COLLECTION_REASSESSMENT_TRIGGER_POLICY_VERSION_CHANGED,
+    ComparableResult,
+    build_collection_assessment_input_fingerprint,
+    evaluate_comparison_assessment,
+)
+
+
+PBF_DOCUMENT_ID = "paper-1"
+PBF_S2_VARIANT_ID = "var-s2"
+PBF_S3_VARIANT_ID = "var-s3"
+PBF_BASELINE_ID = "base-s2"
+PBF_BASELINE_LABEL = "S2 optimized VED without HIP"
+PBF_YIELD_25_RESULT_ID = "res-s3-ys-25"
+PBF_YIELD_200_RESULT_ID = "res-s3-ys-200"
+PBF_ELONGATION_RESULT_ID = "res-s3-el-25"
+PBF_YIELD_25_COMPARABLE_ID = "cres-s3-ys-25"
+PBF_YIELD_200_COMPARABLE_ID = "cres-s3-ys-200"
+PBF_ELONGATION_COMPARABLE_ID = "cres-s3-el-25"
+PBF_YIELD_SERIES_KEY = "yield_strength:test_temperature_c"
+
+
+def write_pbf_acceptance_artifacts(
+    output_dir: Path,
+    *,
+    collection_id: str,
+    include_strain_rate: bool = True,
+) -> None:
+    """Write the Slice 5 single-paper PBF evidence-chain fixture."""
+
+    sample_variants = pbf_acceptance_sample_variants(collection_id)
+    test_conditions = pbf_acceptance_test_conditions(
+        collection_id,
+        include_strain_rate=include_strain_rate,
+    )
+    baseline_references = pbf_acceptance_baseline_references(collection_id)
+    measurement_results = pbf_acceptance_measurement_results(collection_id)
+    characterization = pbf_acceptance_characterization_observations(collection_id)
+    structure_features = pbf_acceptance_structure_features(collection_id)
+    comparable_results, scoped_results = pbf_acceptance_comparison_records(
+        collection_id,
+        sample_variants=sample_variants,
+        test_conditions=test_conditions,
+        baseline_references=baseline_references,
+        measurement_results=measurement_results,
+    )
+
+    pd.DataFrame(sample_variants).to_parquet(
+        output_dir / "sample_variants.parquet",
+        index=False,
+    )
+    pd.DataFrame(test_conditions).to_parquet(
+        output_dir / "test_conditions.parquet",
+        index=False,
+    )
+    pd.DataFrame(baseline_references).to_parquet(
+        output_dir / "baseline_references.parquet",
+        index=False,
+    )
+    pd.DataFrame(measurement_results).to_parquet(
+        output_dir / "measurement_results.parquet",
+        index=False,
+    )
+    pd.DataFrame(characterization).to_parquet(
+        output_dir / "characterization_observations.parquet",
+        index=False,
+    )
+    pd.DataFrame(structure_features).to_parquet(
+        output_dir / "structure_features.parquet",
+        index=False,
+    )
+    pd.DataFrame(comparable_results).to_parquet(
+        output_dir / "comparable_results.parquet",
+        index=False,
+    )
+    pd.DataFrame(scoped_results).to_parquet(
+        output_dir / "collection_comparable_results.parquet",
+        index=False,
+    )
+
+
+def pbf_acceptance_assessment_context(
+    *,
+    collection_id: str = "col-pbf-acceptance",
+    include_strain_rate: bool = True,
+) -> dict[str, Any]:
+    test_conditions = pbf_acceptance_test_conditions(
+        collection_id,
+        include_strain_rate=include_strain_rate,
+    )
+    return {
+        "variant": _row_by_id(
+            pbf_acceptance_sample_variants(collection_id),
+            "variant_id",
+            PBF_S3_VARIANT_ID,
+        ),
+        "test_condition": _row_by_id(test_conditions, "test_condition_id", "tc-25"),
+        "baseline": _row_by_id(
+            pbf_acceptance_baseline_references(collection_id),
+            "baseline_id",
+            PBF_BASELINE_ID,
+        ),
+        "measurement_result": _row_by_id(
+            pbf_acceptance_measurement_results(collection_id),
+            "result_id",
+            PBF_YIELD_25_RESULT_ID,
+        ),
+    }
+
+
+def pbf_acceptance_sample_variants(collection_id: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "variant_id": PBF_S2_VARIANT_ID,
+            "document_id": PBF_DOCUMENT_ID,
+            "collection_id": collection_id,
+            "domain_profile": "pbf_metal",
+            "variant_label": PBF_BASELINE_LABEL,
+            "host_material_system": {
+                "family": "titanium alloy",
+                "composition": "Ti-6Al-4V",
+            },
+            "composition": "Ti-6Al-4V",
+            "variable_axis_type": "post_treatment",
+            "variable_value": "optimized VED without HIP",
+            "process_context": _pbf_process_context(post_treatment_summary="no HIP"),
+            "profile_payload": {},
+            "structure_feature_ids": [],
+            "source_anchor_ids": ["anchor-s2-process"],
+            "confidence": 0.9,
+            "epistemic_status": "normalized_from_evidence",
+        },
+        {
+            "variant_id": PBF_S3_VARIANT_ID,
+            "document_id": PBF_DOCUMENT_ID,
+            "collection_id": collection_id,
+            "domain_profile": "pbf_metal",
+            "variant_label": "S3 optimized VED + HIP",
+            "host_material_system": {
+                "family": "titanium alloy",
+                "composition": "Ti-6Al-4V",
+            },
+            "composition": "Ti-6Al-4V",
+            "variable_axis_type": "post_treatment",
+            "variable_value": "optimized VED + HIP",
+            "process_context": _pbf_process_context(post_treatment_summary="HIP"),
+            "profile_payload": {},
+            "structure_feature_ids": ["sf-porosity", "sf-residual-stress"],
+            "source_anchor_ids": ["anchor-s3-process"],
+            "confidence": 0.9,
+            "epistemic_status": "normalized_from_evidence",
+        },
+    ]
+
+
+def pbf_acceptance_test_conditions(
+    collection_id: str,
+    *,
+    include_strain_rate: bool = True,
+) -> list[dict[str, Any]]:
+    return [
+        _test_condition_row(
+            collection_id=collection_id,
+            test_condition_id="tc-25",
+            temperature_c=25.0,
+            include_strain_rate=include_strain_rate,
+        ),
+        _test_condition_row(
+            collection_id=collection_id,
+            test_condition_id="tc-200",
+            temperature_c=200.0,
+            include_strain_rate=include_strain_rate,
+        ),
+    ]
+
+
+def pbf_acceptance_baseline_references(collection_id: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "baseline_id": PBF_BASELINE_ID,
+            "document_id": PBF_DOCUMENT_ID,
+            "collection_id": collection_id,
+            "domain_profile": "pbf_metal",
+            "variant_id": PBF_S2_VARIANT_ID,
+            "baseline_type": "same_paper_control",
+            "baseline_label": PBF_BASELINE_LABEL,
+            "baseline_scope": "current_paper",
+            "evidence_anchor_ids": ["anchor-baseline-s2"],
+            "confidence": 0.9,
+            "epistemic_status": "normalized_from_evidence",
+        }
+    ]
+
+
+def pbf_acceptance_measurement_results(collection_id: str) -> list[dict[str, Any]]:
+    return [
+        _measurement_result_row(
+            collection_id=collection_id,
+            result_id=PBF_YIELD_25_RESULT_ID,
+            property_normalized="yield_strength",
+            value=940.0,
+            source_value_text="940",
+            unit="MPa",
+            test_condition_id="tc-25",
+            anchor_id="anchor-ys-25",
+        ),
+        _measurement_result_row(
+            collection_id=collection_id,
+            result_id=PBF_YIELD_200_RESULT_ID,
+            property_normalized="yield_strength",
+            value=820.0,
+            source_value_text="820",
+            unit="MPa",
+            test_condition_id="tc-200",
+            anchor_id="anchor-ys-200",
+        ),
+        _measurement_result_row(
+            collection_id=collection_id,
+            result_id=PBF_ELONGATION_RESULT_ID,
+            property_normalized="elongation",
+            value=15.0,
+            source_value_text="15",
+            unit="%",
+            test_condition_id="tc-25",
+            anchor_id="anchor-el-25",
+        ),
+    ]
+
+
+def pbf_acceptance_characterization_observations(
+    collection_id: str,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "observation_id": "obs-porosity",
+            "document_id": PBF_DOCUMENT_ID,
+            "collection_id": collection_id,
+            "variant_id": PBF_S3_VARIANT_ID,
+            "characterization_type": "porosity",
+            "observation_text": "Porosity decreased to 0.1%.",
+            "observed_value": 0.1,
+            "observed_unit": "%",
+            "condition_context": {"process": {}, "test": {}, "baseline": {}},
+            "evidence_anchor_ids": ["anchor-porosity"],
+            "confidence": 0.9,
+            "epistemic_status": "normalized_from_evidence",
+        },
+        {
+            "observation_id": "obs-residual-stress",
+            "document_id": PBF_DOCUMENT_ID,
+            "collection_id": collection_id,
+            "variant_id": PBF_S3_VARIANT_ID,
+            "characterization_type": "residual_stress",
+            "observation_text": "Residual stress was lower after HIP.",
+            "observed_value": None,
+            "observed_unit": None,
+            "condition_context": {"process": {}, "test": {}, "baseline": {}},
+            "evidence_anchor_ids": ["anchor-residual-stress"],
+            "confidence": 0.86,
+            "epistemic_status": "normalized_from_evidence",
+        },
+    ]
+
+
+def pbf_acceptance_structure_features(collection_id: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "feature_id": "sf-porosity",
+            "document_id": PBF_DOCUMENT_ID,
+            "collection_id": collection_id,
+            "variant_id": PBF_S3_VARIANT_ID,
+            "feature_type": "porosity",
+            "feature_value": 0.1,
+            "feature_unit": "%",
+            "qualitative_descriptor": "Porosity 0.1%",
+            "source_observation_ids": ["obs-porosity"],
+            "confidence": 0.9,
+            "epistemic_status": "normalized_from_evidence",
+        },
+        {
+            "feature_id": "sf-residual-stress",
+            "document_id": PBF_DOCUMENT_ID,
+            "collection_id": collection_id,
+            "variant_id": PBF_S3_VARIANT_ID,
+            "feature_type": "residual_stress",
+            "feature_value": None,
+            "feature_unit": None,
+            "qualitative_descriptor": "Residual stress lower after HIP",
+            "source_observation_ids": ["obs-residual-stress"],
+            "confidence": 0.86,
+            "epistemic_status": "normalized_from_evidence",
+        },
+    ]
+
+
+def pbf_acceptance_comparison_records(
+    collection_id: str,
+    *,
+    sample_variants: list[dict[str, Any]] | None = None,
+    test_conditions: list[dict[str, Any]] | None = None,
+    baseline_references: list[dict[str, Any]] | None = None,
+    measurement_results: list[dict[str, Any]] | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    sample_variants = sample_variants or pbf_acceptance_sample_variants(collection_id)
+    test_conditions = test_conditions or pbf_acceptance_test_conditions(collection_id)
+    baseline_references = baseline_references or pbf_acceptance_baseline_references(
+        collection_id
+    )
+    measurement_results = measurement_results or pbf_acceptance_measurement_results(
+        collection_id
+    )
+    comparable_results = [
+        _comparable_result_record(
+            comparable_result_id=PBF_YIELD_25_COMPARABLE_ID,
+            source_result_id=PBF_YIELD_25_RESULT_ID,
+            property_normalized="yield_strength",
+            numeric_value=940.0,
+            unit="MPa",
+            summary="YS 940 MPa at 25 C",
+            test_condition_id="tc-25",
+            evidence_id="ev-ys-25",
+        ),
+        _comparable_result_record(
+            comparable_result_id=PBF_YIELD_200_COMPARABLE_ID,
+            source_result_id=PBF_YIELD_200_RESULT_ID,
+            property_normalized="yield_strength",
+            numeric_value=820.0,
+            unit="MPa",
+            summary="YS 820 MPa at 200 C",
+            test_condition_id="tc-200",
+            evidence_id="ev-ys-200",
+        ),
+        _comparable_result_record(
+            comparable_result_id=PBF_ELONGATION_COMPARABLE_ID,
+            source_result_id=PBF_ELONGATION_RESULT_ID,
+            property_normalized="elongation",
+            numeric_value=15.0,
+            unit="%",
+            summary="EL 15% at 25 C",
+            test_condition_id="tc-25",
+            evidence_id="ev-el-25",
+        ),
+    ]
+    scoped_results = [
+        _scoped_result_record(
+            collection_id=collection_id,
+            comparable_result=comparable_result,
+            sort_order=sort_order,
+            assessment_context=_assessment_context_for_record(
+                comparable_result,
+                sample_variants=sample_variants,
+                test_conditions=test_conditions,
+                baseline_references=baseline_references,
+                measurement_results=measurement_results,
+            ),
+        )
+        for sort_order, comparable_result in enumerate(comparable_results)
+    ]
+    return comparable_results, scoped_results
+
+
+def _pbf_process_context(*, post_treatment_summary: str) -> dict[str, Any]:
+    return {
+        "laser_power_w": 280,
+        "scan_speed_mm_s": 1200,
+        "hatch_spacing_um": 100,
+        "layer_thickness_um": 30,
+        "energy_density_j_mm3": 78,
+        "energy_density_origin": "reported",
+        "build_orientation": "vertical",
+        "post_treatment_summary": post_treatment_summary,
+    }
+
+
+def _test_condition_row(
+    *,
+    collection_id: str,
+    test_condition_id: str,
+    temperature_c: float,
+    include_strain_rate: bool,
+) -> dict[str, Any]:
+    condition_payload: dict[str, Any] = {
+        "test_method": "tensile",
+        "test_temperature_c": temperature_c,
+        "loading_direction": "vertical",
+        "sample_orientation": "vertical",
+    }
+    if include_strain_rate:
+        condition_payload["strain_rate_s-1"] = 0.001
+    return {
+        "test_condition_id": test_condition_id,
+        "document_id": PBF_DOCUMENT_ID,
+        "collection_id": collection_id,
+        "domain_profile": "pbf_metal",
+        "property_type": "yield_strength",
+        "template_type": "tensile_mechanics",
+        "scope_level": "result",
+        "condition_payload": condition_payload,
+        "condition_completeness": "complete" if include_strain_rate else "partial",
+        "missing_fields": [] if include_strain_rate else ["strain_rate_s-1"],
+        "evidence_anchor_ids": [f"anchor-test-{int(temperature_c)}"],
+        "confidence": 0.9,
+        "epistemic_status": "normalized_from_evidence",
+    }
+
+
+def _measurement_result_row(
+    *,
+    collection_id: str,
+    result_id: str,
+    property_normalized: str,
+    value: float,
+    source_value_text: str,
+    unit: str,
+    test_condition_id: str,
+    anchor_id: str,
+) -> dict[str, Any]:
+    return {
+        "result_id": result_id,
+        "document_id": PBF_DOCUMENT_ID,
+        "collection_id": collection_id,
+        "domain_profile": "pbf_metal",
+        "variant_id": PBF_S3_VARIANT_ID,
+        "property_normalized": property_normalized,
+        "result_type": "scalar",
+        "claim_scope": "current_work",
+        "value_payload": {
+            "value": value,
+            "source_value_text": source_value_text,
+            "source_unit_text": unit,
+            "value_origin": "reported",
+        },
+        "unit": unit,
+        "test_condition_id": test_condition_id,
+        "baseline_id": PBF_BASELINE_ID,
+        "structure_feature_ids": ["sf-porosity", "sf-residual-stress"],
+        "characterization_observation_ids": ["obs-porosity", "obs-residual-stress"],
+        "evidence_anchor_ids": [anchor_id],
+        "traceability_status": "direct",
+        "result_source_type": "table",
+        "epistemic_status": "normalized_from_evidence",
+    }
+
+
+def _comparable_result_record(
+    *,
+    comparable_result_id: str,
+    source_result_id: str,
+    property_normalized: str,
+    numeric_value: float,
+    unit: str,
+    summary: str,
+    test_condition_id: str,
+    evidence_id: str,
+) -> dict[str, Any]:
+    return {
+        "comparable_result_id": comparable_result_id,
+        "source_result_id": source_result_id,
+        "source_document_id": PBF_DOCUMENT_ID,
+        "binding": {
+            "variant_id": PBF_S3_VARIANT_ID,
+            "baseline_id": PBF_BASELINE_ID,
+            "test_condition_id": test_condition_id,
+        },
+        "normalized_context": {
+            "material_system_normalized": "Ti-6Al-4V",
+            "process_normalized": (
+                "P=280 W, v=1200 mm/s, h=100 um, t=30 um, "
+                "VED=78 J/mm3, VED_origin=reported, build=vertical, HIP"
+            ),
+            "baseline_normalized": PBF_BASELINE_LABEL,
+            "test_condition_normalized": "tensile",
+        },
+        "axis": {
+            "axis_name": None,
+            "axis_value": None,
+            "axis_unit": None,
+        },
+        "value": {
+            "property_normalized": property_normalized,
+            "result_type": "scalar",
+            "numeric_value": numeric_value,
+            "unit": unit,
+            "summary": summary,
+            "statistic_type": None,
+            "uncertainty": None,
+        },
+        "evidence": {
+            "direct_anchor_ids": [f"anchor-{comparable_result_id}"],
+            "contextual_anchor_ids": ["anchor-s3-process", "anchor-baseline-s2"],
+            "evidence_ids": [evidence_id],
+            "structure_feature_ids": ["sf-porosity", "sf-residual-stress"],
+            "characterization_observation_ids": [
+                "obs-porosity",
+                "obs-residual-stress",
+            ],
+            "traceability_status": "direct",
+        },
+        "variant_label": "S3 optimized VED + HIP",
+        "baseline_reference": PBF_BASELINE_LABEL,
+        "result_source_type": "table",
+        "epistemic_status": "normalized_from_evidence",
+        "normalization_version": COMPARABLE_RESULT_NORMALIZATION_VERSION,
+    }
+
+
+def _scoped_result_record(
+    *,
+    collection_id: str,
+    comparable_result: dict[str, Any],
+    sort_order: int,
+    assessment_context: dict[str, Any],
+) -> dict[str, Any]:
+    record = ComparableResult.from_mapping(comparable_result)
+    assessment = evaluate_comparison_assessment(
+        record,
+        assessment_context=assessment_context,
+    )
+    return {
+        "collection_id": collection_id,
+        "comparable_result_id": comparable_result["comparable_result_id"],
+        "assessment": {
+            "missing_critical_context": list(assessment.missing_critical_context),
+            "comparability_basis": list(assessment.comparability_basis),
+            "comparability_warnings": list(assessment.comparability_warnings),
+            "comparability_status": assessment.comparability_status,
+            "requires_expert_review": assessment.requires_expert_review,
+            "assessment_epistemic_status": assessment.assessment_epistemic_status,
+        },
+        "epistemic_status": "normalized_from_evidence",
+        "included": True,
+        "sort_order": sort_order,
+        "policy_family": COLLECTION_COMPARISON_POLICY_FAMILY,
+        "policy_version": COLLECTION_COMPARISON_POLICY_VERSION,
+        "comparable_result_normalization_version": COMPARABLE_RESULT_NORMALIZATION_VERSION,
+        "assessment_input_fingerprint": build_collection_assessment_input_fingerprint(
+            record
+        ),
+        "reassessment_triggers": [
+            COLLECTION_REASSESSMENT_TRIGGER_POLICY_FAMILY_CHANGED,
+            COLLECTION_REASSESSMENT_TRIGGER_POLICY_VERSION_CHANGED,
+            COLLECTION_REASSESSMENT_TRIGGER_NORMALIZATION_VERSION_CHANGED,
+            COLLECTION_REASSESSMENT_TRIGGER_ASSESSMENT_INPUT_CHANGED,
+        ],
+    }
+
+
+def _assessment_context_for_record(
+    comparable_result: dict[str, Any],
+    *,
+    sample_variants: list[dict[str, Any]],
+    test_conditions: list[dict[str, Any]],
+    baseline_references: list[dict[str, Any]],
+    measurement_results: list[dict[str, Any]],
+) -> dict[str, Any]:
+    binding = comparable_result["binding"]
+    return {
+        "variant": _row_by_id(sample_variants, "variant_id", binding["variant_id"]),
+        "test_condition": _row_by_id(
+            test_conditions,
+            "test_condition_id",
+            binding["test_condition_id"],
+        ),
+        "baseline": _row_by_id(
+            baseline_references,
+            "baseline_id",
+            binding["baseline_id"],
+        ),
+        "measurement_result": _row_by_id(
+            measurement_results,
+            "result_id",
+            comparable_result["source_result_id"],
+        ),
+    }
+
+
+def _row_by_id(
+    rows: list[dict[str, Any]],
+    key: str,
+    value: str,
+) -> dict[str, Any]:
+    return next(row for row in rows if row[key] == value)

--- a/backend/tests/unit/domains/test_comparison_domain.py
+++ b/backend/tests/unit/domains/test_comparison_domain.py
@@ -34,6 +34,13 @@ from domain.shared.enums import (
     TRACEABILITY_STATUS_MISSING,
     TRACEABILITY_STATUS_PARTIAL,
 )
+from tests.support.pbf_acceptance_fixture import (
+    PBF_BASELINE_ID,
+    PBF_BASELINE_LABEL,
+    PBF_S3_VARIANT_ID,
+    PBF_YIELD_25_COMPARABLE_ID,
+    pbf_acceptance_assessment_context,
+)
 
 
 def _build_comparable_result(
@@ -44,6 +51,7 @@ def _build_comparable_result(
     baseline_reference: str | None = "untreated baseline",
     test_condition_id: str | None = "tc-1",
     traceability_status: str = TRACEABILITY_STATUS_DIRECT,
+    property_normalized: str = "strength",
     result_type: str = "scalar",
     result_summary: str = "97 MPa",
     numeric_value: float | None = 97.0,
@@ -71,7 +79,7 @@ def _build_comparable_result(
             axis_unit=None,
         ),
         value=ResultValue(
-            property_normalized="strength",
+            property_normalized=property_normalized,
             result_type=result_type,
             numeric_value=numeric_value,
             unit="MPa",
@@ -142,6 +150,165 @@ def test_evaluate_comparison_assessment_detects_not_comparable_without_baseline_
     assert assessment.comparability_status == COMPARABILITY_STATUS_NOT_COMPARABLE
     assert "baseline_reference" in assessment.missing_critical_context
     assert "test_condition" in assessment.missing_critical_context
+
+
+def test_evaluate_comparison_assessment_applies_pbf_tensile_missingness() -> None:
+    context = {
+        "variant": {
+            "domain_profile": "pbf_metal",
+            "process_context": {
+                "laser_power_w": 280,
+                "scan_speed_mm_s": 1200,
+                "layer_thickness_um": 30,
+                "hatch_spacing_um": 100,
+                "energy_density_j_mm3": 78,
+                "energy_density_origin": "reported",
+                "build_orientation": "vertical",
+                "post_treatment_summary": "HIP",
+            },
+        },
+        "test_condition": {
+            "condition_payload": {
+                "test_method": "tensile",
+                "test_temperature_c": 25,
+                "strain_rate_s-1": 0.001,
+                "loading_direction": "vertical",
+                "sample_orientation": "vertical",
+            }
+        },
+        "measurement_result": {
+            "value_payload": {
+                "value": 940,
+                "value_origin": "reported",
+            }
+        },
+    }
+
+    complete = evaluate_comparison_assessment(
+        _build_comparable_result(property_normalized="yield_strength"),
+        assessment_context=context,
+    )
+    missing_strain_rate = evaluate_comparison_assessment(
+        _build_comparable_result(property_normalized="yield_strength"),
+        assessment_context={
+            **context,
+            "test_condition": {
+                "condition_payload": {
+                    "test_method": "tensile",
+                    "test_temperature_c": 25,
+                    "loading_direction": "vertical",
+                    "sample_orientation": "vertical",
+                }
+            },
+        },
+    )
+
+    assert complete.comparability_status == COMPARABILITY_STATUS_COMPARABLE
+    assert "pbf_context_detected" in complete.comparability_basis
+    assert "strain_rate_reported" in complete.comparability_basis
+    assert missing_strain_rate.comparability_status == COMPARABILITY_STATUS_LIMITED
+    assert "strain_rate_s-1" in missing_strain_rate.missing_critical_context
+    assert any(
+        "missing strain rate" in warning
+        for warning in missing_strain_rate.comparability_warnings
+    )
+
+
+def test_pbf_acceptance_fixture_missing_strain_rate_is_limited() -> None:
+    complete = evaluate_comparison_assessment(
+        _build_comparable_result(
+            comparable_result_id=PBF_YIELD_25_COMPARABLE_ID,
+            variant_id=PBF_S3_VARIANT_ID,
+            baseline_id=PBF_BASELINE_ID,
+            baseline_reference=PBF_BASELINE_LABEL,
+            test_condition_id="tc-25",
+            property_normalized="yield_strength",
+            result_summary="YS 940 MPa at 25 C",
+            numeric_value=940.0,
+        ),
+        assessment_context=pbf_acceptance_assessment_context(),
+    )
+    missing_strain_rate = evaluate_comparison_assessment(
+        _build_comparable_result(
+            comparable_result_id=PBF_YIELD_25_COMPARABLE_ID,
+            variant_id=PBF_S3_VARIANT_ID,
+            baseline_id=PBF_BASELINE_ID,
+            baseline_reference=PBF_BASELINE_LABEL,
+            test_condition_id="tc-25",
+            property_normalized="yield_strength",
+            result_summary="YS 940 MPa at 25 C",
+            numeric_value=940.0,
+        ),
+        assessment_context=pbf_acceptance_assessment_context(
+            include_strain_rate=False,
+        ),
+    )
+
+    assert complete.comparability_status == COMPARABILITY_STATUS_COMPARABLE
+    assert "pbf_context_detected" in complete.comparability_basis
+    assert "strain_rate_reported" in complete.comparability_basis
+    assert missing_strain_rate.comparability_status == COMPARABILITY_STATUS_LIMITED
+    assert "strain_rate_s-1" in missing_strain_rate.missing_critical_context
+
+
+def test_evaluate_comparison_assessment_flags_energy_density_provenance() -> None:
+    base_context = {
+        "variant": {
+            "domain_profile": "pbf_metal",
+            "process_context": {
+                "laser_power_w": 280,
+                "scan_speed_mm_s": 1200,
+                "layer_thickness_um": 30,
+                "hatch_spacing_um": 100,
+                "energy_density_j_mm3": 78,
+                "build_orientation": "vertical",
+            },
+        },
+        "test_condition": {
+            "condition_payload": {
+                "test_method": "tensile",
+                "test_temperature_c": 25,
+                "strain_rate_s-1": 0.001,
+                "loading_direction": "vertical",
+                "sample_orientation": "vertical",
+            }
+        },
+    }
+
+    derived = evaluate_comparison_assessment(
+        _build_comparable_result(property_normalized="yield_strength"),
+        assessment_context={
+            **base_context,
+            "variant": {
+                **base_context["variant"],
+                "process_context": {
+                    **base_context["variant"]["process_context"],
+                    "energy_density_origin": "derived",
+                },
+            },
+        },
+    )
+    estimated = evaluate_comparison_assessment(
+        _build_comparable_result(property_normalized="yield_strength"),
+        assessment_context={
+            **base_context,
+            "variant": {
+                **base_context["variant"],
+                "process_context": {
+                    **base_context["variant"]["process_context"],
+                    "energy_density_origin": "estimated",
+                },
+            },
+        },
+    )
+
+    assert derived.comparability_status == COMPARABILITY_STATUS_COMPARABLE
+    assert derived.requires_expert_review is False
+    assert "energy_density_origin:derived" in derived.comparability_basis
+    assert any("Energy density was derived" in warning for warning in derived.comparability_warnings)
+    assert estimated.comparability_status == COMPARABILITY_STATUS_LIMITED
+    assert estimated.requires_expert_review is True
+    assert "energy_density_estimated" in estimated.missing_critical_context
 
 
 def test_comparison_row_record_normalizes_lists_and_defaults() -> None:

--- a/backend/tests/unit/routers/test_documents_api.py
+++ b/backend/tests/unit/routers/test_documents_api.py
@@ -18,6 +18,16 @@ from application.core.comparison_service import ComparisonService
 from application.core.semantic_build.document_profile_service import DocumentProfileService
 from controllers.core import documents as documents_controller
 from infra.source.runtime.source_evidence import build_blocks
+from tests.support.pbf_acceptance_fixture import (
+    PBF_BASELINE_LABEL,
+    PBF_DOCUMENT_ID,
+    PBF_ELONGATION_COMPARABLE_ID,
+    PBF_S3_VARIANT_ID,
+    PBF_YIELD_25_COMPARABLE_ID,
+    PBF_YIELD_200_COMPARABLE_ID,
+    PBF_YIELD_SERIES_KEY,
+    write_pbf_acceptance_artifacts,
+)
 
 
 def _patch_parquet(monkeypatch) -> None:  # noqa: ANN001
@@ -283,6 +293,251 @@ def test_document_profile_route_normalizes_invalid_profile_status_values(
     assert payload.protocol_extractable == "uncertain"
 
 
+def test_document_content_route_includes_source_locators(
+    document_services,
+    monkeypatch,
+):
+    _patch_parquet(monkeypatch)
+
+    collection_service, artifact_registry, _document_profile_service, _comparison_service = document_services
+    record = collection_service.create_collection(name="Document Locator Collection")
+    collection_id = record["collection_id"]
+    output_dir = collection_service.get_paths(collection_id).output_dir
+
+    pd.DataFrame(
+        [
+            {
+                "id": "paper-1",
+                "title": "Locator Paper",
+                "source_filename": "paper-1.pdf",
+                "text": "The optimized sample reached 940 MPa. Missing locator paragraph.",
+            }
+        ]
+    ).to_parquet(output_dir / "documents.parquet", index=False)
+    pd.DataFrame(
+        [
+            {
+                "document_id": "paper-1",
+                "collection_id": collection_id,
+                "title": "Locator Paper",
+                "source_filename": "paper-1.pdf",
+                "doc_type": "experimental",
+                "protocol_extractable": "yes",
+                "protocol_extractability_signals": [],
+                "parsing_warnings": [],
+                "confidence": 0.91,
+            }
+        ]
+    ).to_parquet(output_dir / "document_profiles.parquet", index=False)
+    pd.DataFrame(
+        [
+            {
+                "document_id": "paper-1",
+                "block_id": "blk-result",
+                "block_type": "paragraph",
+                "heading_path": "Results",
+                "heading_level": 1,
+                "block_order": 1,
+                "text": "The optimized sample reached 940 MPa.",
+                "text_unit_ids": [],
+                "page": 6,
+                "bbox": json.dumps(
+                    {"l": 72.4, "t": 182.1, "r": 512.8, "b": 228.6, "coord_origin": "top_left"}
+                ),
+                "char_range": json.dumps({"start": 0, "end": 37}),
+            },
+            {
+                "document_id": "paper-1",
+                "block_id": "blk-invalid",
+                "block_type": "paragraph",
+                "heading_path": "Results",
+                "heading_level": 1,
+                "block_order": 2,
+                "text": "Missing locator paragraph.",
+                "text_unit_ids": [],
+                "page": 0,
+                "bbox": "not-json",
+                "char_range": json.dumps({"start": 20, "end": 10}),
+            },
+        ]
+    ).to_parquet(output_dir / "blocks.parquet", index=False)
+    artifact_registry.upsert(collection_id, output_dir)
+
+    payload = asyncio.run(
+        documents_controller.get_collection_document_content(collection_id, "paper-1")
+    )
+
+    first = payload.blocks[0]
+    assert first.page == 6
+    assert first.bbox is not None
+    assert first.bbox.x0 == 72.4
+    assert first.bbox.y0 == 182.1
+    assert first.bbox.x1 == 512.8
+    assert first.bbox.y1 == 228.6
+    assert first.bbox.coord_origin == "top_left"
+    assert first.char_range is not None
+    assert first.char_range.start == 0
+    assert first.char_range.end == 37
+
+    second = payload.blocks[1]
+    assert second.page is None
+    assert second.bbox is None
+    assert second.char_range is None
+
+
+def test_document_source_route_streams_manifest_source_file(document_services):
+    collection_service, _artifact_registry, _document_profile_service, _comparison_service = document_services
+    record = collection_service.create_collection(name="Source File Collection")
+    collection_id = record["collection_id"]
+    paths = collection_service.get_paths(collection_id)
+    source_path = paths.input_dir / "paper-1.pdf"
+    source_path.write_bytes(b"%PDF-1.4\nfixture\n")
+    collection_service.repository.write_import_manifest(
+        collection_id,
+        {
+            "collection_id": collection_id,
+            "imports": [
+                {
+                    "documents": [
+                        {
+                            "source_document_id": "paper-1",
+                            "original_filename": "paper-1.pdf",
+                            "stored_filename": "paper-1.pdf",
+                            "storage_relpath": "input/paper-1.pdf",
+                            "media_type": "application/pdf",
+                        }
+                    ]
+                }
+            ],
+        },
+    )
+
+    response = asyncio.run(
+        documents_controller.get_collection_document_source(collection_id, "paper-1")
+    )
+
+    assert Path(response.path).read_bytes() == b"%PDF-1.4\nfixture\n"
+    assert response.media_type == "application/pdf"
+    assert response.headers["content-disposition"].startswith("inline;")
+
+
+def test_document_source_route_resolves_profile_document_id_by_source_filename(
+    document_services,
+    monkeypatch,
+):
+    _patch_parquet(monkeypatch)
+
+    collection_service, artifact_registry, _document_profile_service, _comparison_service = document_services
+    record = collection_service.create_collection(name="Profile Source File Collection")
+    collection_id = record["collection_id"]
+    paths = collection_service.get_paths(collection_id)
+    output_dir = paths.output_dir
+    source_path = paths.input_dir / "stored-paper.pdf"
+    source_path.write_bytes(b"%PDF-1.4\nprofile fixture\n")
+    pd.DataFrame(
+        [
+            {
+                "document_id": "profile-hash-doc",
+                "collection_id": collection_id,
+                "title": "Profile Paper",
+                "source_filename": "paper.pdf",
+                "doc_type": "experimental",
+                "protocol_extractable": "yes",
+                "protocol_extractability_signals": [],
+                "parsing_warnings": [],
+                "confidence": 0.91,
+            }
+        ]
+    ).to_parquet(output_dir / "document_profiles.parquet", index=False)
+    artifact_registry.upsert(collection_id, output_dir)
+    collection_service.repository.write_import_manifest(
+        collection_id,
+        {
+            "collection_id": collection_id,
+            "imports": [
+                {
+                    "documents": [
+                        {
+                            "source_document_id": "srcdoc-from-upload",
+                            "original_filename": "paper.pdf",
+                            "stored_filename": "stored-paper.pdf",
+                            "storage_relpath": "input/stored-paper.pdf",
+                            "media_type": "application/pdf",
+                        }
+                    ]
+                }
+            ],
+        },
+    )
+
+    response = asyncio.run(
+        documents_controller.get_collection_document_source(
+            collection_id,
+            "profile-hash-doc",
+        )
+    )
+
+    assert Path(response.path).read_bytes() == b"%PDF-1.4\nprofile fixture\n"
+    assert response.media_type == "application/pdf"
+
+
+def test_document_source_route_returns_409_when_source_is_unavailable(document_services):
+    collection_service, _artifact_registry, _document_profile_service, _comparison_service = document_services
+    record = collection_service.create_collection(name="Missing Source Collection")
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            documents_controller.get_collection_document_source(
+                record["collection_id"],
+                "paper-1",
+            )
+        )
+
+    exc = exc_info.value
+    assert exc.status_code == 409
+    assert exc.detail["code"] == "document_source_unavailable"
+    assert exc.detail["document_id"] == "paper-1"
+
+
+def test_document_source_route_rejects_manifest_path_outside_collection(
+    document_services,
+    tmp_path,
+):
+    collection_service, _artifact_registry, _document_profile_service, _comparison_service = document_services
+    record = collection_service.create_collection(name="Unsafe Source Collection")
+    collection_id = record["collection_id"]
+    outside_path = tmp_path / "outside.pdf"
+    outside_path.write_bytes(b"%PDF-1.4\noutside\n")
+    collection_service.repository.write_import_manifest(
+        collection_id,
+        {
+            "collection_id": collection_id,
+            "imports": [
+                {
+                    "documents": [
+                        {
+                            "source_document_id": "paper-1",
+                            "original_filename": "paper-1.pdf",
+                            "stored_path": str(outside_path),
+                            "media_type": "application/pdf",
+                        }
+                    ]
+                }
+            ],
+        },
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            documents_controller.get_collection_document_source(collection_id, "paper-1")
+        )
+
+    exc = exc_info.value
+    assert exc.status_code == 409
+    assert exc.detail["code"] == "document_source_path_invalid"
+    assert "outside.pdf" not in str(exc.detail)
+
+
 def test_document_comparison_semantics_route_returns_409_when_semantics_are_not_ready(
     document_services,
 ):
@@ -429,3 +684,71 @@ def test_document_comparison_semantics_route_can_include_projected_rows(
     assert len(payload.items[0].projected_rows) == 1
     assert payload.items[0].projected_rows[0].row_id.startswith("cmp_")
     assert payload.items[0].projected_rows[0].source_document_id == "paper-1"
+
+
+def test_document_comparison_semantics_route_returns_pbf_acceptance_chain(
+    document_services,
+    monkeypatch,
+):
+    _patch_parquet(monkeypatch)
+
+    collection_service, artifact_registry, _document_profile_service, _comparison_service = document_services
+    record = collection_service.create_collection(name="Document Evidence Chain")
+    collection_id = record["collection_id"]
+    output_dir = collection_service.get_paths(collection_id).output_dir
+
+    write_pbf_acceptance_artifacts(output_dir, collection_id=collection_id)
+    artifact_registry.upsert(collection_id, output_dir)
+
+    payload = asyncio.run(
+        documents_controller.get_collection_document_comparison_semantics(
+            collection_id,
+            PBF_DOCUMENT_ID,
+            include_grouped_projections=True,
+        )
+    )
+
+    assert payload.total == 3
+    assert payload.variant_dossiers is not None
+    assert len(payload.variant_dossiers) == 1
+    dossier = payload.variant_dossiers[0]
+    assert dossier.variant_id == PBF_S3_VARIANT_ID
+    assert dossier.variant_label == "S3 optimized VED + HIP"
+    assert dossier.material.label == "Ti-6Al-4V"
+    assert dossier.material.composition == "Ti-6Al-4V"
+    assert dossier.shared_process_state["laser_power_w"] == 280
+    assert dossier.shared_process_state["scan_speed_mm_s"] == 1200
+    assert dossier.shared_process_state["hatch_spacing_um"] == 100
+    assert dossier.shared_process_state["layer_thickness_um"] == 30
+    assert dossier.shared_process_state["energy_density_j_mm3"] == 78
+    assert dossier.shared_process_state["energy_density_origin"] == "reported"
+    assert dossier.shared_process_state["build_orientation"] == "vertical"
+    assert dossier.shared_process_state["post_treatment_summary"] == "HIP"
+    series_by_key = {series.series_key: series for series in dossier.series}
+    assert PBF_YIELD_SERIES_KEY in series_by_key
+    yield_series = series_by_key[PBF_YIELD_SERIES_KEY]
+    assert yield_series.varying_axis.axis_name == "test_temperature_c"
+    assert [chain.result_id for chain in yield_series.chains] == [
+        PBF_YIELD_25_COMPARABLE_ID,
+        PBF_YIELD_200_COMPARABLE_ID,
+    ]
+    assert [chain.test_condition.test_temperature_c for chain in yield_series.chains] == [
+        25.0,
+        200.0,
+    ]
+    assert [chain.test_condition.strain_rate_s_1 for chain in yield_series.chains] == [
+        0.001,
+        0.001,
+    ]
+    assert [chain.measurement.value for chain in yield_series.chains] == [940.0, 820.0]
+    assert yield_series.chains[0].baseline.reference == PBF_BASELINE_LABEL
+    assert yield_series.chains[0].value_provenance.value_origin == "reported"
+    assert yield_series.chains[0].value_provenance.source_value_text == "940"
+    elongation_chain = next(
+        chain
+        for series in dossier.series
+        for chain in series.chains
+        if chain.result_id == PBF_ELONGATION_COMPARABLE_ID
+    )
+    assert elongation_chain.measurement.property == "elongation"
+    assert elongation_chain.measurement.value == 15.0

--- a/backend/tests/unit/routers/test_results_api.py
+++ b/backend/tests/unit/routers/test_results_api.py
@@ -20,6 +20,14 @@ from domain.core.comparison import (
     ComparableResult,
     build_collection_assessment_input_fingerprint,
 )
+from tests.support.pbf_acceptance_fixture import (
+    PBF_BASELINE_LABEL,
+    PBF_DOCUMENT_ID,
+    PBF_S3_VARIANT_ID,
+    PBF_YIELD_25_COMPARABLE_ID,
+    PBF_YIELD_SERIES_KEY,
+    write_pbf_acceptance_artifacts,
+)
 
 
 def _patch_parquet(monkeypatch) -> None:  # noqa: ANN001
@@ -351,6 +359,75 @@ def test_result_detail_route_returns_document_assessment_evidence_and_actions(
         f"/collections/{collection_id}/comparisons?"
     )
     assert payload.actions.open_evidence == f"/collections/{collection_id}/evidence"
+
+
+def test_result_detail_route_returns_pbf_acceptance_chain_fields(
+    result_services,
+    monkeypatch,
+):
+    _patch_parquet(monkeypatch)
+
+    collection_service, artifact_registry, _comparison_service = result_services
+    collection = collection_service.create_collection(name="Result Evidence Chain")
+    collection_id = collection["collection_id"]
+    output_dir = collection_service.get_paths(collection_id).output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    pd.DataFrame(
+        [
+            {
+                "document_id": PBF_DOCUMENT_ID,
+                "collection_id": collection_id,
+                "title": "Ti64 Tensile Study",
+                "source_filename": "ti64.txt",
+                "doc_type": "experimental",
+                "protocol_extractable": "yes",
+                "protocol_extractability_signals": [],
+                "parsing_warnings": [],
+                "confidence": 0.93,
+            }
+        ]
+    ).to_parquet(output_dir / "document_profiles.parquet", index=False)
+    write_pbf_acceptance_artifacts(output_dir, collection_id=collection_id)
+    artifact_registry.upsert(collection_id, output_dir)
+
+    payload = asyncio.run(
+        results_controller.get_collection_result(collection_id, PBF_YIELD_25_COMPARABLE_ID)
+    )
+
+    assert payload.variant_dossier is not None
+    assert payload.variant_dossier.variant_id == PBF_S3_VARIANT_ID
+    assert payload.variant_dossier.variant_label == "S3 optimized VED + HIP"
+    assert payload.variant_dossier.material.composition == "Ti-6Al-4V"
+    assert payload.variant_dossier.shared_process_state["laser_power_w"] == 280
+    assert payload.variant_dossier.shared_process_state["scan_speed_mm_s"] == 1200
+    assert payload.variant_dossier.shared_process_state["hatch_spacing_um"] == 100
+    assert payload.variant_dossier.shared_process_state["layer_thickness_um"] == 30
+    assert payload.variant_dossier.shared_process_state["energy_density_j_mm3"] == 78
+    assert payload.variant_dossier.shared_process_state["energy_density_origin"] == "reported"
+    assert payload.variant_dossier.shared_process_state["build_orientation"] == "vertical"
+    assert payload.test_condition_detail is not None
+    assert payload.test_condition_detail.test_method == "tensile"
+    assert payload.test_condition_detail.test_temperature_c == 25.0
+    assert payload.test_condition_detail.strain_rate_s_1 == 0.001
+    assert payload.test_condition_detail.loading_direction == "vertical"
+    assert payload.test_condition_detail.sample_orientation == "vertical"
+    assert payload.baseline_detail is not None
+    assert payload.baseline_detail.reference == PBF_BASELINE_LABEL
+    assert payload.baseline_detail.baseline_type == "same_paper_control"
+    assert payload.baseline_detail.baseline_scope == "current_paper"
+    support_by_id = {support.support_id: support for support in payload.structure_support}
+    assert support_by_id["sf-porosity"].summary == "Porosity 0.1%"
+    assert support_by_id["sf-residual-stress"].summary == "Residual stress lower after HIP"
+    assert payload.value_provenance is not None
+    assert payload.value_provenance.value_origin == "reported"
+    assert payload.value_provenance.source_value_text == "940"
+    assert payload.series_navigation is not None
+    assert payload.series_navigation.series_key == PBF_YIELD_SERIES_KEY
+    assert [sibling.axis_value for sibling in payload.series_navigation.siblings] == [
+        25.0,
+        200.0,
+    ]
 
 
 def test_result_detail_route_returns_404_when_missing(

--- a/backend/tests/unit/services/test_paper_facts_services.py
+++ b/backend/tests/unit/services/test_paper_facts_services.py
@@ -19,6 +19,8 @@ from application.core.semantic_build.llm.prompts import (
 from application.core.semantic_build.paper_facts_service import PaperFactsService
 from application.core.semantic_build.llm.schemas import (
     EvidenceAnchorPayload,
+    ExtractedTestConditionPayload,
+    MeasurementResultPayload,
     MethodFactPayload,
     SampleVariantPayload,
     StructuredDocumentProfile,
@@ -294,6 +296,85 @@ def test_paper_facts_prompt_payloads_exclude_internal_ids():
     assert '"unit": "MPa"' in table_row_prompt
     assert "Use `supporting_text_windows` only when they are required to interpret the row." in table_row_prompt
     assert "Emit at most 2 `method_facts`" in table_row_prompt
+    assert '"laser_power_w": null' in table_row_prompt
+    assert '"strain_rate_s-1": null' in table_row_prompt
+    assert '"value_origin": "reported"' in table_row_prompt
+
+
+def test_pbf_fact_schema_accepts_process_test_and_value_provenance_fields():
+    bundle = StructuredExtractionBundle(
+        method_facts=[
+            MethodFactPayload(
+                method_role="process",
+                method_name="LPBF",
+                method_payload={
+                    "laser_power_w": 280,
+                    "scan_speed_mm_s": 1200,
+                    "layer_thickness_um": 30,
+                    "hatch_spacing_um": 100,
+                    "energy_density_j_mm3": 78,
+                    "energy_density_origin": "reported",
+                    "build_orientation": "vertical",
+                    "post_treatment_summary": "HIP",
+                },
+            )
+        ],
+        sample_variants=[
+            SampleVariantPayload(
+                variant_label="S3",
+                host_material_system={
+                    "family": "titanium alloy",
+                    "composition": "Ti-6Al-4V",
+                },
+                composition="Ti-6Al-4V",
+                variable_axis_type="post_treatment",
+                variable_value="optimized VED + HIP",
+                process_context={
+                    "laser_power_w": 280,
+                    "scan_speed_mm_s": 1200,
+                    "layer_thickness_um": 30,
+                    "hatch_spacing_um": 100,
+                    "energy_density_j_mm3": 78,
+                    "energy_density_origin": "reported",
+                    "build_orientation": "vertical",
+                    "post_treatment_summary": "HIP",
+                },
+            )
+        ],
+        test_conditions=[
+            ExtractedTestConditionPayload(
+                property_type="yield_strength",
+                condition_payload={
+                    "test_method": "tensile",
+                    "test_temperature_c": 25,
+                    "strain_rate_s-1": 0.001,
+                    "loading_direction": "vertical",
+                    "sample_orientation": "vertical",
+                },
+            )
+        ],
+        measurement_results=[
+            MeasurementResultPayload(
+                claim_text="S3 showed a yield strength of 940 MPa.",
+                property_normalized="yield_strength",
+                result_type="scalar",
+                value_payload={
+                    "value": 940,
+                    "value_origin": "reported",
+                    "source_value_text": "940",
+                    "source_unit_text": "MPa",
+                },
+                unit="MPa",
+                variant_label="S3",
+                baseline_label="S2",
+            )
+        ],
+    )
+
+    assert bundle.method_facts[0].method_payload.laser_power_w == 280
+    assert bundle.sample_variants[0].process_context.energy_density_origin == "reported"
+    assert bundle.test_conditions[0].condition_payload.strain_rate_s_1 == 0.001
+    assert bundle.measurement_results[0].value_payload.source_value_text == "940"
 
 
 def test_paper_facts_service_reads_extraction_concurrency_from_env(monkeypatch):
@@ -1755,6 +1836,146 @@ def test_comparison_service_builds_rows_from_array_backed_nested_contexts(tmp_pa
         "result_type:scalar",
     ]
     assert row.assessment_epistemic_status == "normalized_from_evidence"
+
+
+def test_pbf_comparison_assembly_uses_process_test_and_value_context():
+    assembler = ComparableResultAssembler()
+    result_row = pd.Series(
+        {
+            "result_id": "res-s3-25",
+            "document_id": "paper-1",
+            "variant_id": "var-s3",
+            "property_normalized": "yield_strength",
+            "result_type": "scalar",
+            "value_payload": {
+                "value": 940.0,
+                "statement": "S3 showed a yield strength of 940 MPa at 25 C.",
+                "value_origin": "reported",
+                "source_value_text": "940",
+                "source_unit_text": "MPa",
+            },
+            "unit": "MPa",
+            "test_condition_id": "tc-25",
+            "baseline_id": "base-s2",
+            "structure_feature_ids": ["sf-porosity"],
+            "characterization_observation_ids": [],
+            "evidence_anchor_ids": ["anchor-s3-25"],
+            "traceability_status": "direct",
+            "result_source_type": "table",
+            "claim_scope": "current_work",
+        }
+    )
+    sample_lookup = {
+        "var-s3": {
+            "variant_id": "var-s3",
+            "domain_profile": "pbf_metal",
+            "variant_label": "S3",
+            "variable_axis_type": "post_treatment",
+            "variable_value": "optimized VED + HIP",
+            "host_material_system": {
+                "family": "titanium alloy",
+                "composition": "Ti-6Al-4V",
+            },
+            "process_context": {
+                "laser_power_w": 280,
+                "scan_speed_mm_s": 1200,
+                "hatch_spacing_um": 100,
+                "layer_thickness_um": 30,
+                "energy_density_j_mm3": 78,
+                "energy_density_origin": "reported",
+                "build_orientation": "vertical",
+                "post_treatment_summary": "HIP",
+            },
+            "source_anchor_ids": ["anchor-process"],
+        }
+    }
+    test_condition_lookup = {
+        "tc-25": {
+            "test_condition_id": "tc-25",
+            "condition_payload": {
+                "test_method": "tensile",
+                "test_temperature_c": 25,
+                "strain_rate_s-1": 0.001,
+                "loading_direction": "vertical",
+                "sample_orientation": "vertical",
+            },
+            "evidence_anchor_ids": ["anchor-test"],
+        }
+    }
+    baseline_lookup = {
+        "base-s2": {
+            "baseline_id": "base-s2",
+            "baseline_label": "S2 optimized VED without HIP",
+            "baseline_type": "same_paper_control",
+            "baseline_scope": "current_paper",
+            "evidence_anchor_ids": ["anchor-baseline"],
+        }
+    }
+
+    comparable_result = assembler.assemble_comparable_result(
+        result_row=result_row,
+        sample_lookup=sample_lookup,
+        test_condition_lookup=test_condition_lookup,
+        baseline_lookup=baseline_lookup,
+    )
+    assert comparable_result is not None
+    assessment_context = assembler.build_assessment_context(
+        result_row=result_row,
+        sample_lookup=sample_lookup,
+        test_condition_lookup=test_condition_lookup,
+        baseline_lookup=baseline_lookup,
+    )
+    scoped_result = assembler.build_collection_comparable_result(
+        collection_id="col-1",
+        comparable_result=comparable_result,
+        sort_order=0,
+        assessment_context=assessment_context,
+    )
+
+    assert comparable_result.normalized_context.process_normalized == (
+        "P=280 W, v=1200 mm/s, h=100 um, t=30 um, VED=78 J/mm3, "
+        "VED_origin=reported, build=vertical, HIP"
+    )
+    assert comparable_result.normalized_context.test_condition_normalized == (
+        "tensile, 25 C, strain_rate=0.001 s^-1, loading=vertical, sample=vertical"
+    )
+    assert scoped_result.assessment.comparability_status == "comparable"
+    assert "pbf_context_detected" in scoped_result.assessment.comparability_basis
+    assert "build_orientation_reported" in scoped_result.assessment.comparability_basis
+    assert "strain_rate_reported" in scoped_result.assessment.comparability_basis
+
+    missing_strain_lookup = {
+        "tc-25": {
+            **test_condition_lookup["tc-25"],
+            "condition_payload": {
+                "test_method": "tensile",
+                "test_temperature_c": 25,
+                "loading_direction": "vertical",
+                "sample_orientation": "vertical",
+            },
+        }
+    }
+    limited_result = assembler.assemble_comparable_result(
+        result_row=result_row,
+        sample_lookup=sample_lookup,
+        test_condition_lookup=missing_strain_lookup,
+        baseline_lookup=baseline_lookup,
+    )
+    assert limited_result is not None
+    limited_scope = assembler.build_collection_comparable_result(
+        collection_id="col-1",
+        comparable_result=limited_result,
+        sort_order=0,
+        assessment_context=assembler.build_assessment_context(
+            result_row=result_row,
+            sample_lookup=sample_lookup,
+            test_condition_lookup=missing_strain_lookup,
+            baseline_lookup=baseline_lookup,
+        ),
+    )
+
+    assert limited_scope.assessment.comparability_status == "limited"
+    assert "strain_rate_s-1" in limited_scope.assessment.missing_critical_context
 
 
 def test_comparison_service_collapses_duplicate_comparable_results(tmp_path):


### PR DESCRIPTION
## Summary
- Add backend evidence-chain schemas and drilldown fields for document/result APIs.
- Thicken PBF extraction and comparison assembly with source-backed acceptance signals.
- Update backend API docs and focused tests for the new chain payloads.

## Verification
- uv run pytest tests/unit/domains/test_comparison_domain.py tests/unit/routers/test_documents_api.py tests/unit/routers/test_results_api.py tests/unit/services/test_paper_facts_services.py tests/integration/services/test_task_runner.py tests/integration/test_app_layer_api.py
- python3 scripts/check_docs_governance.py
- git diff --check

## Split Notes
- Source branch: pre-release
- Target branch: origin/main
- This is the prerequisite backend slice for the frontend evidence workbench PR.