### PR TITLE
chore(release): prepare v0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,10 @@ For backend and frontend setup, see:
 - [`backend/README.md`](backend/README.md)
 - [`frontend/README.md`](frontend/README.md)
 
+For self-hosted deployment with published Docker images, see:
+
+- [`deploy/README.md`](deploy/README.md)
+
 ## Development Status
 
 Lens is under active development.

--- a/backend/main.py
+++ b/backend/main.py
@@ -50,7 +50,7 @@ def _parse_cors_allowed_origins() -> list[str]:
 def create_app() -> FastAPI:
     app = FastAPI(
         title="TsingAI-Lens API",
-        version="0.8.0",
+        version="0.8.1",
         docs_url=f"{PUBLIC_API_PREFIX}/docs",
         redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
         openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsingai-lens"
-version = "0.8.0"
+version = "0.8.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -6281,7 +6281,7 @@ wheels = [
 
 [[package]]
 name = "tsingai-lens"
-version = "0.8.0"
+version = "0.8.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -14,7 +14,7 @@ Install the deploy bundle with:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/JeanphiloGong/tsingai-lens/main/deploy/install.sh \
-  | sh -s -- --version v0.8.0 --ref v0.8.0
+  | sh -s -- --version v0.8.1 --ref v0.8.1
 ```
 
 Use `--ref <git-ref>` when you want the deploy files themselves to come from a
@@ -73,11 +73,11 @@ cp backend.env.example backend.env
 Edit `.env` to choose the published image tag and host port:
 
 ```bash
-LENS_VERSION=v0.8.0
+LENS_VERSION=v0.8.1
 LENS_HTTP_PORT=8080
 ```
 
-Edit `backend.env` before the first v0.8.0 start to create the initial login
+Edit `backend.env` before the first v0.8.1 start to create the initial login
 user:
 
 ```bash
@@ -129,7 +129,7 @@ http://localhost:8080
 ./scripts/lens logs
 ./scripts/lens ps
 ./scripts/lens pull
-./scripts/lens upgrade v0.8.0
+./scripts/lens upgrade v0.8.1
 ```
 
 Command mapping:
@@ -154,7 +154,7 @@ cp -a data/backend data/backend.backup.$(date +%Y%m%d%H%M%S)
 Then upgrade:
 
 ```bash
-./scripts/lens upgrade v0.8.0
+./scripts/lens upgrade v0.8.1
 ./scripts/lens doctor
 ```
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,7 +13,8 @@ published Docker images instead of building from the source tree.
 Install the deploy bundle with:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/JeanphiloGong/tsingai-lens/main/deploy/install.sh | sh -s -- --version v0.4.0
+curl -fsSL https://raw.githubusercontent.com/JeanphiloGong/tsingai-lens/main/deploy/install.sh \
+  | sh -s -- --version v0.8.0 --ref v0.8.0
 ```
 
 Use `--ref <git-ref>` when you want the deploy files themselves to come from a
@@ -27,6 +28,41 @@ cd lens-deploy
 ./scripts/lens up
 ```
 
+Open:
+
+```text
+http://localhost:8080
+```
+
+## How The Script Works
+
+`./scripts/lens` is a small POSIX shell command wrapper, not a Makefile.
+
+It keeps the deploy commands short and always calls Docker Compose with the
+same env file and compose file:
+
+```bash
+docker compose --env-file .env -f compose.yml <command>
+```
+
+For example:
+
+```bash
+./scripts/lens up
+```
+
+is the deployment wrapper around:
+
+```bash
+docker compose --env-file .env -f compose.yml up -d
+```
+
+The wrapper also creates missing runtime files and directories when needed:
+
+- `.env`
+- `backend.env`
+- `data/backend/`
+
 ## Manual Configure
 
 ```bash
@@ -34,13 +70,44 @@ cp .env.example .env
 cp backend.env.example backend.env
 ```
 
-Edit `backend.env` when you want Lens to call an OpenAI-compatible LLM or
-embedding endpoint.
+Edit `.env` to choose the published image tag and host port:
+
+```bash
+LENS_VERSION=v0.8.0
+LENS_HTTP_PORT=8080
+```
+
+Edit `backend.env` before the first v0.8.0 start to create the initial login
+user:
+
+```bash
+BOOTSTRAP_ADMIN_EMAIL=admin@example.com
+BOOTSTRAP_ADMIN_PASSWORD=change-this-password
+BOOTSTRAP_ADMIN_NAME=Admin
+```
+
+`BOOTSTRAP_ADMIN_EMAIL` and `BOOTSTRAP_ADMIN_PASSWORD` are read only when the
+backend starts. If the user already exists, the backend keeps the existing
+account.
+
+Also edit `backend.env` when you want Lens to call an OpenAI-compatible LLM or
+embedding endpoint:
+
+```bash
+LLM_BASE_URL=
+LLM_MODEL=
+LLM_API_KEY=
+
+EMBEDDING_BASE_URL=
+EMBEDDING_MODEL=
+EMBEDDING_API_KEY=
+```
 
 ## Run
 
 ```bash
 ./scripts/lens up
+./scripts/lens ps
 ```
 
 Open:
@@ -62,7 +129,33 @@ http://localhost:8080
 ./scripts/lens logs
 ./scripts/lens ps
 ./scripts/lens pull
-./scripts/lens upgrade v0.4.0
+./scripts/lens upgrade v0.8.0
+```
+
+Command mapping:
+
+- `doctor` checks Docker, Compose, config files, the data directory, and
+  frontend/backend reachability.
+- `up` runs `docker compose up -d`.
+- `down` runs `docker compose down`.
+- `logs` follows `docker compose logs`.
+- `ps` runs `docker compose ps`.
+- `pull` pulls the configured images.
+- `upgrade TAG` writes `LENS_VERSION=TAG`, pulls images, and restarts Lens.
+
+## Upgrade
+
+Back up runtime data before changing versions:
+
+```bash
+cp -a data/backend data/backend.backup.$(date +%Y%m%d%H%M%S)
+```
+
+Then upgrade:
+
+```bash
+./scripts/lens upgrade v0.8.0
+./scripts/lens doctor
 ```
 
 ## Data

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "0.8.0",
+			"version": "0.8.1",
 			"dependencies": {
 				"cytoscape": "^3.33.2",
 				"cytoscape-fcose": "^2.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## Summary
- Add self-hosted deployment documentation for the published release bundle.
- Explain the scripts/lens shell wrapper and its Docker Compose command mapping.
- Add v0.8.1 version surface alignment for the patch release.

## Verification
- python3 scripts/check_docs_governance.py
- git diff --check
- npm run check
- uv run python -m py_compile main.py

## Notes
- This PR intentionally excludes develop commit 0e118acf (workbench source text toggle).
- After this PR merges, create the v0.8.1 tag from the resulting main commit.