### PR TITLE
Release v0.8.2 deploy runtime fixes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -50,7 +50,7 @@ def _parse_cors_allowed_origins() -> list[str]:
 def create_app() -> FastAPI:
     app = FastAPI(
         title="TsingAI-Lens API",
-        version="0.8.1",
+        version="0.8.2",
         docs_url=f"{PUBLIC_API_PREFIX}/docs",
         redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
         openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsingai-lens"
-version = "0.8.1"
+version = "0.8.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -6281,7 +6281,7 @@ wheels = [
 
 [[package]]
 name = "tsingai-lens"
-version = "0.8.1"
+version = "0.8.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -5,8 +5,11 @@ published Docker images instead of building from the source tree.
 
 ## Prerequisites
 
-- Docker Engine
-- Docker Compose plugin (`docker compose`)
+- Docker Engine with the Docker Compose plugin (`docker compose`) is the
+  default runtime.
+- Podman can be used with `podman compose`; use the
+  [Podman Runtime](#podman-runtime) commands because `./scripts/lens` calls
+  Docker Compose.
 
 ## One-Line Install
 
@@ -14,11 +17,14 @@ Install the deploy bundle with:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/JeanphiloGong/tsingai-lens/main/deploy/install.sh \
-  | sh -s -- --version v0.8.1 --ref v0.8.1
+  | sh -s -- --version v0.8.2 --ref v0.8.2
 ```
 
 Use `--ref <git-ref>` when you want the deploy files themselves to come from a
 specific branch or tag.
+
+Before the first start, edit `backend.env` to set the bootstrap admin account
+and any LLM or embedding environment variables. See [Manual Configure](#manual-configure).
 
 Then run:
 
@@ -63,6 +69,54 @@ The wrapper also creates missing runtime files and directories when needed:
 - `backend.env`
 - `data/backend/`
 
+## Podman Runtime
+
+Use this path on machines without Docker. Run the Compose commands directly
+with Podman from the deploy bundle directory:
+
+```bash
+cd lens-deploy
+podman compose --env-file .env -f compose.yml pull
+podman compose --env-file .env -f compose.yml up -d
+podman compose --env-file .env -f compose.yml ps
+```
+
+Useful Podman equivalents:
+
+```bash
+podman compose --env-file .env -f compose.yml logs -f
+podman compose --env-file .env -f compose.yml restart backend
+podman compose --env-file .env -f compose.yml down
+```
+
+The backend data volume uses the SELinux relabel option `:Z`:
+
+```yaml
+./data/backend:/app/data:Z
+```
+
+This lets Podman write runtime data on SELinux Enforcing hosts such as Fedora,
+RHEL, and CentOS. Without that label the backend can fail with
+`PermissionError` while creating `/app/data/collections`, and the frontend will
+show `502 Bad Gateway` because nginx cannot reach the backend.
+
+When the backend container needs to call a vLLM server running on the host,
+start vLLM so it listens beyond host-local loopback, then point Lens at the
+Podman host gateway:
+
+```bash
+uv run vllm-control start --host 0.0.0.0
+```
+
+```bash
+LLM_BASE_URL=http://host.containers.internal:8008/v1
+LLM_MODEL=<served-model-name>
+LLM_API_KEY=not-needed
+```
+
+Keep `EMBEDDING_BASE_URL`, `EMBEDDING_MODEL`, and `EMBEDDING_API_KEY` empty
+unless the configured service exposes an OpenAI-compatible embeddings endpoint.
+
 ## Manual Configure
 
 ```bash
@@ -73,11 +127,11 @@ cp backend.env.example backend.env
 Edit `.env` to choose the published image tag and host port:
 
 ```bash
-LENS_VERSION=v0.8.1
+LENS_VERSION=v0.8.2
 LENS_HTTP_PORT=8080
 ```
 
-Edit `backend.env` before the first v0.8.1 start to create the initial login
+Edit `backend.env` before the first v0.8.2 start to create the initial login
 user:
 
 ```bash
@@ -129,7 +183,7 @@ http://localhost:8080
 ./scripts/lens logs
 ./scripts/lens ps
 ./scripts/lens pull
-./scripts/lens upgrade v0.8.1
+./scripts/lens upgrade v0.8.2
 ```
 
 Command mapping:
@@ -154,7 +208,7 @@ cp -a data/backend data/backend.backup.$(date +%Y%m%d%H%M%S)
 Then upgrade:
 
 ```bash
-./scripts/lens upgrade v0.8.1
+./scripts/lens upgrade v0.8.2
 ./scripts/lens doctor
 ```
 

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -4,7 +4,7 @@ services:
     env_file:
       - ./backend.env
     volumes:
-      - ./data/backend:/app/data
+      - ./data/backend:/app/data:Z
     expose:
       - "8010"
     restart: unless-stopped

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -112,6 +112,14 @@ mkdir -p "$TARGET_DIR/data/backend"
 cat <<EOF
 Lens deploy bundle installed in $TARGET_DIR
 
+Runtime:
+  Install Docker Engine with the Docker Compose plugin before starting Lens.
+  Podman can also be used if it provides a Docker-compatible "docker compose" command.
+
+Before startup:
+  Edit $TARGET_DIR/backend.env for BOOTSTRAP_ADMIN_EMAIL / BOOTSTRAP_ADMIN_PASSWORD
+  and optional LLM / embedding environment variables.
+
 Next steps:
   cd $TARGET_DIR
   ./scripts/lens doctor
@@ -119,4 +127,7 @@ Next steps:
 
 Open:
   http://localhost:$(grep '^LENS_HTTP_PORT=' "$TARGET_DIR/.env" | cut -d= -f2-)
+
+More details:
+  $TARGET_DIR/README.md
 EOF

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -1,6 +1,6 @@
 services:
   backend:
-    image: ${LENS_BACKEND_IMAGE:-jeanphilo/tsingai-lens-backend}:${LENS_VERSION:-v0.7.1}
+    image: ${LENS_BACKEND_IMAGE:-jeanphilo/tsingai-lens-backend}:${LENS_VERSION:-v0.8.2}
     env_file:
       - ./backend/.env
     volumes:
@@ -10,7 +10,7 @@ services:
     restart: unless-stopped
 
   frontend:
-    image: ${LENS_FRONTEND_IMAGE:-jeanphilo/tsingai-lens-frontend}:${LENS_VERSION:-v0.7.1}
+    image: ${LENS_FRONTEND_IMAGE:-jeanphilo/tsingai-lens-frontend}:${LENS_VERSION:-v0.8.2}
     ports:
       - "${LENS_HTTP_PORT:-8080}:80"
     depends_on:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "0.8.1",
+	"version": "0.8.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "0.8.1",
+			"version": "0.8.2",
 			"dependencies": {
 				"cytoscape": "^3.33.2",
 				"cytoscape-fcose": "^2.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.8.1",
+	"version": "0.8.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## Summary
- Add Podman runtime guidance to the deploy bundle docs.
- Add the SELinux `:Z` relabel option for backend runtime data in the deploy compose file.
- Prepare release metadata for v0.8.2.

## Scope
This is a deployment-focused release branch from `main`. It intentionally does not include unrelated `develop` feature work.

## Verification
- `python3 scripts/check_docs_governance.py`
- `git diff --check`
- `podman compose --env-file .env -f compose.yml config` in a temporary deploy bundle
- backend version check for `0.8.2`
- frontend package version check for `0.8.2`
