### PR TITLE
hotfix(deploy): restore OpenCV runtime libraries

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -68,6 +68,8 @@ RUN set -eux; \
         /etc/apt/sources.list.d/debian.sources; \
     fi; \
     apt-get update && apt-get install -y --no-install-recommends \
+    libgl1 \
+    libglib2.0-0t64 \
     libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -78,6 +80,8 @@ COPY . .
 ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH" \
     PYTHONPATH=/app
+
+RUN /app/.venv/bin/python -c "import cv2"
 
 EXPOSE 8010
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -183,7 +183,7 @@ def create_app(
 
     app = FastAPI(
         title="TsingAI-Lens API",
-        version="0.10.0",
+        version="0.10.1",
         docs_url=f"{PUBLIC_API_PREFIX}/docs",
         redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
         openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsingai-lens"
-version = "0.10.0"
+version = "0.10.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -6529,7 +6529,7 @@ wheels = [
 
 [[package]]
 name = "tsingai-lens"
-version = "0.10.0"
+version = "0.10.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,7 +1,7 @@
 COMPOSE_PROJECT_NAME=tsingai-lens
 
 # Use a released Lens tag. The same tag is used for backend and frontend images.
-LENS_VERSION=v0.10.0
+LENS_VERSION=v0.10.1
 
 # Browser entrypoint exposed on the host.
 LENS_HTTP_PORT=8080

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,7 +22,7 @@ Install the deploy bundle with:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/JeanphiloGong/tsingai-lens/main/deploy/install.sh \
-  | sh -s -- --version v0.10.0 --ref v0.10.0
+  | sh -s -- --version v0.10.1 --ref v0.10.1
 ```
 
 Use `--ref <git-ref>` when you want the deploy files themselves to come from a
@@ -155,7 +155,7 @@ Edit `.env` to set that generated value, the published image tag, and the host
 port:
 
 ```bash
-LENS_VERSION=v0.10.0
+LENS_VERSION=v0.10.1
 LENS_HTTP_PORT=8080
 POSTGRES_PASSWORD=<generated-64-character-hex-value>
 ```
@@ -164,7 +164,7 @@ The password initializes the `lens` database user only when the PostgreSQL
 volume is empty. Changing `.env` later does not rotate an existing database
 password. Keep `.env` private and do not commit it.
 
-Edit `backend.env` before the first v0.10.0 start to create the initial login
+Edit `backend.env` before the first v0.10.1 start to create the initial login
 user:
 
 ```bash
@@ -233,7 +233,7 @@ http://localhost:8080
 ./scripts/lens logs
 ./scripts/lens ps
 ./scripts/lens pull
-./scripts/lens upgrade v0.10.0
+./scripts/lens upgrade v0.10.1
 ```
 
 Command mapping:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "0.10.0",
+			"version": "0.10.1",
 			"dependencies": {
 				"cytoscape": "^3.33.2",
 				"cytoscape-fcose": "^2.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## Summary

- install the Debian runtime libraries required by the locked OpenCV wheel
- fail backend image builds when the runtime environment cannot import `cv2`
- align release and deploy version surfaces on `v0.10.1`

## Impact

Restores PDF Source artifact builds in release containers. No API, database schema, or Python dependency changes.

## Verification

- reproduced `libGL.so.1` failure in the published `v0.10.0` backend image
- built the fixed backend image with the release workflow build context
- verified runtime `cv2` import (`4.11.0`), no missing `ldd` entries, app version `0.10.1`, and Docling converter construction
- focused Source tests: 12 passed
- backend suite: 1095 passed, 2 existing baseline failures, 5 skipped
- frontend check: passed
- frontend unit suite: 231 passed, 2 existing baseline failures
- frontend production build: passed
- docs governance: passed
- Compose config validation: passed

Refs #253