### PR TITLE
release: v0.11.2

### DIFF
--- a/backend/infra/persistence/postgres/collection_repository.py
+++ b/backend/infra/persistence/postgres/collection_repository.py
@@ -29,12 +29,49 @@ from infra.persistence.postgres.models.collection import (
     StoredObject,
 )
 from infra.persistence.postgres.models.build import CollectionBuild
+from infra.persistence.postgres.models.comparison import (
+    CollectionComparableResultRecord,
+    ComparableResultRecord,
+    ComparisonBuild,
+    PairwiseComparisonRelationRecord,
+    comparable_result_anchor_links,
+    comparable_result_evidence_links,
+    comparable_result_feature_links,
+    comparable_result_observation_links,
+    pairwise_comparison_anchor_links,
+)
 from infra.persistence.postgres.models.document import (
     CollectionDocument,
     Document,
     DocumentVersion,
 )
-from infra.persistence.postgres.models.source import SourceDocument
+from infra.persistence.postgres.models.evaluation import (
+    EvaluationGoldSetRecord,
+    EvaluationPredictionSnapshotRecord,
+    EvaluationRunRecord,
+)
+from infra.persistence.postgres.models.objective import (
+    ObjectiveAnalysisRecord,
+    ObjectiveBuild,
+    ObjectivePaperContributionRecord,
+    ObjectivePaperSkim,
+    ObjectiveResearchRecord,
+    objective_build_candidates,
+    objective_document_scope,
+    objective_finding_evidence_links,
+    objective_finding_relation_evidence_links,
+)
+from infra.persistence.postgres.models.objective_workspace import (
+    ObjectiveExperimentPlan,
+    ObjectiveSession,
+)
+from infra.persistence.postgres.models.source import (
+    SourceDocument,
+    SourceReferenceCandidate,
+    SourceReferenceEntry,
+    SourceReferenceMention,
+    SourceReferenceResolution,
+)
 
 
 class PostgresCollectionRepository:
@@ -398,6 +435,140 @@ class PostgresCollectionRepository:
                 membership.document_version_id for membership in memberships
             }
             document_ids = {membership.document_id for membership in memberships}
+            build_ids = tuple(
+                session.scalars(
+                    select(CollectionBuild.build_id).where(
+                        CollectionBuild.collection_id == collection_id
+                    )
+                )
+            )
+
+            # Remove collection-scoped derived records before their RESTRICTed
+            # source/build parents. Everything remains in this transaction.
+            session.execute(
+                delete(objective_finding_relation_evidence_links).where(
+                    objective_finding_relation_evidence_links.c.collection_id
+                    == collection_id
+                )
+            )
+            session.execute(
+                delete(objective_finding_evidence_links).where(
+                    objective_finding_evidence_links.c.collection_id == collection_id
+                )
+            )
+            session.execute(
+                delete(ObjectivePaperContributionRecord).where(
+                    ObjectivePaperContributionRecord.collection_id == collection_id
+                )
+            )
+            session.execute(
+                delete(ObjectiveAnalysisRecord).where(
+                    ObjectiveAnalysisRecord.collection_id == collection_id
+                )
+            )
+            session.execute(
+                delete(objective_build_candidates).where(
+                    objective_build_candidates.c.collection_id == collection_id
+                )
+            )
+            session.execute(
+                delete(objective_document_scope).where(
+                    objective_document_scope.c.collection_id == collection_id
+                )
+            )
+            session.execute(
+                delete(ObjectivePaperSkim).where(
+                    ObjectivePaperSkim.collection_id == collection_id
+                )
+            )
+            session.execute(
+                delete(ObjectiveBuild).where(
+                    ObjectiveBuild.collection_id == collection_id
+                )
+            )
+            session.execute(
+                delete(ObjectiveExperimentPlan).where(
+                    ObjectiveExperimentPlan.collection_id == collection_id
+                )
+            )
+            session.execute(
+                delete(ObjectiveSession).where(
+                    ObjectiveSession.collection_id == collection_id
+                )
+            )
+            session.execute(
+                delete(ObjectiveResearchRecord).where(
+                    ObjectiveResearchRecord.collection_id == collection_id
+                )
+            )
+
+            for table in (
+                pairwise_comparison_anchor_links,
+                comparable_result_anchor_links,
+                comparable_result_evidence_links,
+                comparable_result_feature_links,
+                comparable_result_observation_links,
+            ):
+                if build_ids:
+                    session.execute(delete(table).where(table.c.build_id.in_(build_ids)))
+            if build_ids:
+                session.execute(
+                    delete(CollectionComparableResultRecord).where(
+                        CollectionComparableResultRecord.build_id.in_(build_ids)
+                    )
+                )
+                session.execute(
+                    delete(PairwiseComparisonRelationRecord).where(
+                        PairwiseComparisonRelationRecord.build_id.in_(build_ids)
+                    )
+                )
+                session.execute(
+                    delete(ComparableResultRecord).where(
+                        ComparableResultRecord.build_id.in_(build_ids)
+                    )
+                )
+                session.execute(
+                    delete(ComparisonBuild).where(
+                        ComparisonBuild.build_id.in_(build_ids)
+                    )
+                )
+
+            session.execute(
+                delete(EvaluationRunRecord).where(
+                    EvaluationRunRecord.collection_id == collection_id
+                )
+            )
+            session.execute(
+                delete(EvaluationGoldSetRecord).where(
+                    EvaluationGoldSetRecord.collection_id == collection_id
+                )
+            )
+            session.execute(
+                delete(EvaluationPredictionSnapshotRecord).where(
+                    EvaluationPredictionSnapshotRecord.collection_id
+                    == collection_id
+                )
+            )
+            session.execute(
+                delete(SourceReferenceCandidate).where(
+                    SourceReferenceCandidate.collection_id == collection_id
+                )
+            )
+            session.execute(
+                delete(SourceReferenceResolution).where(
+                    SourceReferenceResolution.collection_id == collection_id
+                )
+            )
+            session.execute(
+                delete(SourceReferenceMention).where(
+                    SourceReferenceMention.collection_id == collection_id
+                )
+            )
+            session.execute(
+                delete(SourceReferenceEntry).where(
+                    SourceReferenceEntry.collection_id == collection_id
+                )
+            )
             session.execute(
                 delete(SourceDocument).where(
                     SourceDocument.collection_id == collection_id

--- a/backend/main.py
+++ b/backend/main.py
@@ -302,7 +302,7 @@ def create_app(
 
     app = FastAPI(
         title="TsingAI-Lens API",
-        version="0.11.0",
+        version="0.11.2",
         docs_url=f"{PUBLIC_API_PREFIX}/docs",
         redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
         openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsingai-lens"
-version = "0.11.0"
+version = "0.11.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.11.0",
+	"version": "0.11.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## 用户说明
本版本修复已完成分析的集合无法删除的问题。用户无需修改现有使用方式，升级后删除集合会先清理分析和比较结果，再清理原始文档。

## Bug Fixes
- 完整清理 objective、comparison、evaluation 和 source reference 派生数据，避免 PostgreSQL 外键阻断集合删除。

## Chores
- 对齐 backend、API 和 frontend 版本号到 0.11.2。

## Verification
- backend/.venv/bin/python -m pytest backend/tests/integration/persistence -q
- 52 persistence tests passed

## Changelog
Full Changelog: https://github.com/JeanphiloGong/tsingai-lens/compare/v0.11.1...v0.11.2