### PR TITLE
bugfix(core): 修复论文概览结构化输出截断

### DIFF
--- a/backend/application/core/semantic_build/llm/extractor.py
+++ b/backend/application/core/semantic_build/llm/extractor.py
@@ -48,7 +48,7 @@ _EXTRACTION_MODE_PROVIDER_PARSE = "provider_parse"
 _DEFAULT_EXTRACTION_MODE = _EXTRACTION_MODE_PROVIDER_PARSE
 _TABLE_BATCH_PROVIDER_PARSE_MAX_COMPLETION_TOKENS = 4096
 _DOCUMENT_PROFILE_MAX_COMPLETION_TOKENS = 1024
-_PAPER_SKIM_MAX_COMPLETION_TOKENS = 256
+_PAPER_SKIM_MAX_COMPLETION_TOKENS = 1024
 _RESEARCH_OBJECTIVE_DISCOVERY_MAX_COMPLETION_TOKENS = 1400
 _OBJECTIVE_EVIDENCE_SELECTION_MAX_COMPLETION_TOKENS = 512
 _OBJECTIVE_EVIDENCE_MAX_COMPLETION_TOKENS = 1024
@@ -440,10 +440,18 @@ class CoreLLMStructuredExtractor:
                     self.model,
                     response_model.__name__,
                 )
+            raw_content = None
+            finish_reason = None
+            usage = None
             try:
                 completion = self.client.chat.completions.create(**attempt_kwargs)
+                choice = completion.choices[0] if completion.choices else None
+                finish_reason = getattr(choice, "finish_reason", None)
+                usage = getattr(completion, "usage", None)
+                if hasattr(usage, "model_dump"):
+                    usage = usage.model_dump()
                 raw_content = self._coerce_message_content(
-                    completion.choices[0].message.content if completion.choices else None
+                    choice.message.content if choice is not None else None
                 )
                 if not raw_content:
                     raise RuntimeError(
@@ -467,6 +475,26 @@ class CoreLLMStructuredExtractor:
                     raise
             except (RuntimeError, ValueError, ValidationError, json.JSONDecodeError) as exc:
                 last_error = exc
+                logger.warning(
+                    "Structured JSON response invalid model=%s response_model=%s "
+                    "attempt=%s finish_reason=%s usage=%s error=%s "
+                    "raw_output_length=%s",
+                    self.model,
+                    response_model.__name__,
+                    attempt + 1,
+                    finish_reason,
+                    usage,
+                    _trace_text(exc, 500),
+                    len(raw_content or ""),
+                )
+                logger.debug(
+                    "Structured JSON invalid raw output model=%s "
+                    "response_model=%s attempt=%s raw_output=%r",
+                    self.model,
+                    response_model.__name__,
+                    attempt + 1,
+                    _trace_text(raw_content, 1000),
+                )
                 if attempt == 0:
                     continue
                 raise

--- a/backend/application/core/semantic_build/llm/prompts.py
+++ b/backend/application/core/semantic_build/llm/prompts.py
@@ -619,7 +619,9 @@ def build_paper_skim_prompt(payload: dict[str, Any]) -> tuple[str, str]:
     user_prompt = (
         "Extract a compact research map from this one paper.\n\n"
         f"Input JSON:\n{json.dumps(payload, ensure_ascii=False, indent=2)}\n\n"
-        "Return only the schema object. Use at most a few high-signal values. "
+        "Return only the schema object and start with `{` immediately. "
+        "Return at most 3 materials, 3 processes, 4 properties, 4 changed "
+        "variables, 2 possible objectives, and 2 warnings. "
         "Do not extract final measurements. Include process family plus changed "
         "axes, concrete measured properties, and question-shaped objectives."
     )

--- a/backend/tests/unit/services/test_core_llm_extractor.py
+++ b/backend/tests/unit/services/test_core_llm_extractor.py
@@ -912,6 +912,65 @@ def test_core_llm_extractor_routes_document_profiles_directly_to_bounded_json_te
     assert extractor.consume_last_trace()["extraction_mode"] == "json_text"
 
 
+def test_core_llm_extractor_uses_provider_parse_with_sufficient_paper_skim_budget(
+    monkeypatch,
+):
+    monkeypatch.setenv("CORE_LLM_EXTRACTION_MODE", "provider_parse")
+    client = _FakeOpenAIClient(
+        "unused",
+        parsed=StructuredPaperSkim(
+            doc_role="experimental",
+            candidate_materials=["316L stainless steel"],
+            candidate_processes=["LPBF"],
+            candidate_properties=["density"],
+            changed_variables=["laser energy density"],
+            possible_objectives=[
+                "How does laser energy density affect LPBF 316L density?"
+            ],
+            evidence_density="high",
+            confidence=0.9,
+            warnings=[],
+        ),
+    )
+    extractor = CoreLLMStructuredExtractor(client=client, model="fake-model")
+
+    skim = extractor.extract_paper_skim(
+        {
+            "document_id": "paper-1",
+            "title": "LPBF 316L density study",
+            "text_preview": "Laser energy density was varied for LPBF 316L.",
+            "table_captions": [],
+        }
+    )
+
+    assert skim.doc_role == "experimental"
+    assert client.chat.completions.calls == []
+    parse_call = client.beta.chat.completions.calls[0]
+    assert parse_call["max_completion_tokens"] == 1024
+    assert parse_call["response_format"] is StructuredPaperSkim
+    assert extractor.consume_last_trace()["extraction_mode"] == "provider_parse"
+
+
+def test_core_llm_extractor_logs_invalid_json_output_diagnostics(caplog):
+    client = _FakeOpenAIClient(
+        "I need to analyze the paper before producing the requested structure."
+    )
+    extractor = _json_text_extractor(client)
+
+    with pytest.raises(RuntimeError, match="no JSON object"):
+        extractor.extract_paper_skim(
+            {
+                "document_id": "paper-1",
+                "title": "LPBF 316L density study",
+                "text_preview": "Laser energy density was varied for LPBF 316L.",
+                "table_captions": [],
+            }
+        )
+
+    assert "response_model=StructuredPaperSkim attempt=2" in caplog.text
+    assert "raw_output_length=69" in caplog.text
+
+
 def test_core_llm_extractor_can_opt_in_to_provider_thinking(monkeypatch):
     monkeypatch.setenv("CORE_LLM_EXTRACTION_MODE", "provider_parse")
     monkeypatch.setenv("LLM_ENABLE_THINKING", "true")


### PR DESCRIPTION
## 背景

v0.11.3 在真实模型上生成 `StructuredPaperSkim` 时只允许 256 个 completion tokens。输出被截断后，研究目标候选节点失败，集合任务只能进入 `partial_success`。

## 修改

- 将 PaperSkim provider parse 输出预算提高到 1024。
- 明确限制材料、工艺、性能、变量、研究问题和 warning 数量。
- JSON 文本降级失败时记录 finish reason、token usage、错误和输出长度，原始输出仅进入 DEBUG。
- 增加 provider parse 预算与无 JSON 响应诊断测试。

## 验证

- `34 passed`: `tests/unit/services/test_core_llm_extractor.py`
- `135 passed`: `tests/unit/services/test_research_objective_service.py`
- Python `compileall` 通过
- `git diff --check` 通过
- 真实 `qwen3-vl-cpt-sft` 通过公开 `extract_paper_skim()` 一次完成 provider parse，耗时 3.77 秒并通过 Pydantic 校验

## 影响

不修改 API、数据库或管线状态契约，不需要数据迁移。

Refs #265