### PR TITLE
chore(release): 准备 v0.11.4

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -302,7 +302,7 @@ def create_app(
 
     app = FastAPI(
         title="TsingAI-Lens API",
-        version="0.11.3",
+        version="0.11.4",
         docs_url=f"{PUBLIC_API_PREFIX}/docs",
         redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
         openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsingai-lens"
-version = "0.11.3"
+version = "0.11.4"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.11.3",
+	"version": "0.11.4",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## 用户说明

使用本地推理模型构建文献集合时，论文概览不再因为输出被提前截断而导致研究目标处理失败。现有使用流程不变。

## Bug Fixes

- 提高论文概览结构化生成的输出预算。
- 限制论文概览候选条目数量，减少无效长输出。
- 补充结构化输出失败的结束原因、token 使用量和输出长度诊断。

## Chores

- 将后端、API 和前端版本统一更新为 `0.11.4`。

## 验证

- Extractor 单元测试：34 passed
- ResearchObjectiveService 单元测试：135 passed
- 真实 `qwen3-vl-cpt-sft` PaperSkim provider parse 通过
- 版本一致性检查与 `git diff --check` 通过

Refs #274
Refs #265