### PR TITLE
feat(frontend): 在品牌区显示应用版本

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import './layout.css';
-  import { browser } from '$app/environment';
+  import { browser, version } from '$app/environment';
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import { onMount } from 'svelte';
@@ -18,6 +18,7 @@
   let themeMenu: HTMLDivElement | null = null;
   let globalSearch = '';
   let authError = '';
+  const appVersion = `v${version}`;
 
   $: isLoginRoute = $page.url.pathname === '/login';
   $: authenticatedUser = $authState.user;
@@ -141,7 +142,14 @@
       <a class="brand" href="/">
         <div class="brand-mark">L</div>
         <div class="brand-text">
-          <div class="brand-title">{$t('brand.title')}</div>
+          <div class="brand-heading">
+            <div class="brand-title">{$t('brand.title')}</div>
+            <span
+              class="brand-version"
+              aria-label={`${$t('brand.version')}: ${appVersion}`}
+              title={`${$t('brand.version')}: ${appVersion}`}
+            >{appVersion}</span>
+          </div>
           {#if $t('brand.sub')}
             <div class="brand-sub">{$t('brand.sub')}</div>
           {/if}

--- a/frontend/src/routes/_shared/i18n.ts
+++ b/frontend/src/routes/_shared/i18n.ts
@@ -13,7 +13,8 @@ const translations: Record<Language, Translations> = {
 	en: {
 		brand: {
 			title: 'Lens',
-			sub: ''
+			sub: '',
+			version: 'Version'
 		},
 		nav: {
 			home: 'Collections',
@@ -2321,7 +2322,8 @@ const translations: Record<Language, Translations> = {
 	zh: {
 		brand: {
 			title: 'Lens',
-			sub: ''
+			sub: '',
+			version: '版本'
 		},
 		nav: {
 			home: '集合',

--- a/frontend/src/routes/layout.css
+++ b/frontend/src/routes/layout.css
@@ -237,12 +237,36 @@ textarea {
   gap: 0;
 }
 
+.brand-heading {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
 .brand-title {
   color: var(--text-primary);
   font-size: 16px;
   font-weight: 700;
   line-height: 24px;
   letter-spacing: 0;
+}
+
+.brand-version {
+  display: inline-flex;
+  min-width: 48px;
+  height: 18px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 5px;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  background: var(--bg-subtle);
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  line-height: 16px;
+  white-space: nowrap;
 }
 
 .brand-sub {

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,5 +1,10 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { readFileSync } from 'node:fs';
+
+const packageMetadata = JSON.parse(
+	readFileSync(new URL('./package.json', import.meta.url), 'utf8')
+);
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -7,7 +12,10 @@ const config = {
 	// for more information about preprocessors
 	preprocess: vitePreprocess(),
 	kit: {
-		adapter: adapter({ fallback: 'index.html' })
+		adapter: adapter({ fallback: 'index.html' }),
+		version: {
+			name: packageMetadata.version
+		}
 	}
 };
 


### PR DESCRIPTION
## Why

用户需要在主界面直接确认当前部署版本，避免仅依赖镜像标签或发布记录判断运行版本。

## What

- 使用 frontend/package.json 配置 SvelteKit 构建版本
- 在全局 Lens 品牌旁展示 v0.11.4 版本标记
- 补充中英文可访问标签及明暗主题样式

## Impact

只影响全局品牌区展示；不新增后端接口、运行时请求或环境变量。

## Tests

- npm run check
- npm run build
- git diff --cached --check
- Chrome DevTools：1440x900、390x844、中英文、深色主题