### PR TITLE
chore(release): 准备 v0.11.5

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -302,7 +302,7 @@ def create_app(
 
     app = FastAPI(
         title="TsingAI-Lens API",
-        version="0.11.4",
+        version="0.11.5",
         docs_url=f"{PUBLIC_API_PREFIX}/docs",
         redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
         openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsingai-lens"
-version = "0.11.4"
+version = "0.11.5"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.11.4",
+	"version": "0.11.5",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## 用户说明

升级后，页面左上角的 Lens 品牌旁会直接显示当前版本号，便于确认正在使用的发布版本。日常使用方式不变。

## New Features

- 在全局 Lens 品牌区显示当前应用版本
- 支持中英文版本提示、明暗主题和移动端布局

## Chores

- 将后端包、FastAPI 应用和前端包版本统一更新为 0.11.5

## Verification

- npm run check
- npm run build
- 三个版本面一致性检查
- 构建产物 version.json 为 0.11.5
- Chrome DevTools 桌面端、移动端、中英文及深色主题验收

## Changelog

Full Changelog: https://github.com/JeanphiloGong/tsingai-lens/compare/v0.11.4...release/v0.11.5
Feature PR #276: https://github.com/JeanphiloGong/tsingai-lens/pull/276