### PR TITLE
bugfix: 修复研究分析与文献预览可靠性

### DIFF
--- a/backend/application/core/semantic_build/llm/extractor.py
+++ b/backend/application/core/semantic_build/llm/extractor.py
@@ -401,6 +401,7 @@ class CoreLLMStructuredExtractor:
             )
         elif response_model is StructuredPaperSkim:
             request_kwargs["max_completion_tokens"] = _PAPER_SKIM_MAX_COMPLETION_TOKENS
+            request_kwargs["response_format"] = {"type": "json_object"}
         elif response_model is StructuredResearchObjectives:
             request_kwargs["max_completion_tokens"] = (
                 _RESEARCH_OBJECTIVE_DISCOVERY_MAX_COMPLETION_TOKENS
@@ -422,16 +423,29 @@ class CoreLLMStructuredExtractor:
             attempt_kwargs = dict(request_kwargs)
             attempt_messages = messages
             if attempt:
+                if response_model is StructuredPaperSkim:
+                    retry_instruction = (
+                        "Previous PaperSkim output failed validation: "
+                        f"{_trace_text(last_error, 400)}. Return one compact JSON "
+                        "object with exactly these keys: doc_role, "
+                        "candidate_materials, candidate_processes, "
+                        "candidate_properties, changed_variables, "
+                        "possible_objectives, evidence_density, confidence, and "
+                        "warnings. Remove every other key. Do not output analysis, "
+                        "markdown, or copied input."
+                    )
+                else:
+                    retry_instruction = (
+                        "Previous output was invalid. Return only the smallest valid "
+                        "JSON object matching the schema. Do not explain, repeat the "
+                        "prompt, or include markdown. For finding synthesis, return "
+                        "at most one finding."
+                    )
                 attempt_messages = [
                     *messages,
                     {
                         "role": "user",
-                        "content": (
-                            "Previous output was invalid. Return only the smallest valid "
-                            "JSON object matching the schema. Do not explain, repeat the "
-                            "prompt, or include markdown. For finding synthesis, return "
-                            "at most one finding."
-                        ),
+                        "content": retry_instruction,
                     },
                 ]
                 attempt_kwargs["messages"] = attempt_messages

--- a/backend/application/core/semantic_build/llm/prompts.py
+++ b/backend/application/core/semantic_build/llm/prompts.py
@@ -50,6 +50,104 @@ Non-negotiable rules:
 """.strip()
 
 
+_PAPER_SKIM_SYSTEM_PROMPT = """
+TASK MODEL
+You are the paper-screening judge for an evidence-backed literature comparison
+backend. Produce one coarse PaperSkim used only to discover candidate research
+questions for this paper. This is classification and research-map extraction,
+not final fact extraction, paper summarization, evidence synthesis, or a final
+research conclusion. Use only the supplied compact paper content.
+
+INPUT SCHEMA
+- `title`: paper title; useful context but potentially incomplete.
+- `profile_hint.role_hint`: prior coarse classification hint. Treat it as a
+  hint, not as an output field or unquestionable evidence.
+- `profile_hint.source_quality_warnings`: parser/classifier quality warnings.
+- `profile_hint.role_hint_confidence`: confidence in the prior role hint, not
+  the confidence of your PaperSkim.
+- `text_preview`: short source excerpt. It may be truncated or noisy.
+- `headings`: bounded section labels.
+- `table_captions`: bounded caption, section, and column-header context.
+- `figure_captions`: bounded caption and section context.
+
+DECISION PROCESS
+1. Judge whether the supplied content is sufficient and whether the role hint
+   conflicts with the paper content.
+2. Choose `doc_role`: use `experimental` for reported physical experiments,
+   `review` for literature synthesis, `modeling` for simulation-only studies,
+   `mixed` for genuinely mixed roles, and `uncertain` when evidence is weak or
+   conflicting.
+3. Extract only explicitly named material systems and process families.
+4. Extract changed variables only when the paper indicates that they vary or
+   are compared. Do not turn fixed conditions into changed variables.
+5. Extract concrete measured or evaluated properties. Do not return broad
+   background topics as properties.
+6. Return a possible objective only when the supplied content supports a
+   question connecting a process or changed variable to a property in a
+   material scope. Keep it question-shaped and concise. Review-only,
+   modeling-only without comparable outputs, and insufficient inputs may use
+   an empty objective list.
+7. Set evidence density to `high` when several supplied elements directly
+   support the map, `medium` for partial support, `low` for sparse or indirect
+   support, and `unknown` when content is insufficient.
+8. Set confidence for this complete PaperSkim and add only applicable warning
+   codes from the output contract.
+
+HARD RULES
+- Make decisions silently. Return one JSON object and no analysis, markdown,
+  copied input, backend ids, source locators, measurements, or extra fields.
+- Return at most 3 materials, 3 processes, 4 properties, 4 changed variables,
+  2 possible objectives, and 2 warnings.
+- Prefer empty arrays and `uncertain` over unsupported inference.
+- Do not infer a material from a filename or title alone.
+
+FEW-SHOTS
+1. Common experimental paper
+Input:
+{"title":"LPBF 316L density","profile_hint":{"role_hint":"experimental",
+"source_quality_warnings":[],"role_hint_confidence":0.9},"text_preview":
+"Laser energy density was varied for 316L and relative density was measured.",
+"headings":["Methods","Results"],"table_captions":[],"figure_captions":[]}
+Output:
+{"doc_role":"experimental","candidate_materials":["316L stainless steel"],
+"candidate_processes":["LPBF"],"candidate_properties":["relative density"],
+"changed_variables":["laser energy density"],"possible_objectives":
+["How does laser energy density affect relative density of LPBF 316L stainless steel?"],
+"evidence_density":"high","confidence":0.9,"warnings":[]}
+
+2. Review paper
+Input:
+{"title":"Review of corrosion in additively manufactured steels","profile_hint":
+{"role_hint":"review","source_quality_warnings":[],"role_hint_confidence":0.9},
+"text_preview":"This review summarizes prior LPBF 316L corrosion studies.",
+"headings":["Literature review"],"table_captions":[],"figure_captions":[]}
+Output:
+{"doc_role":"review","candidate_materials":["316L stainless steel"],
+"candidate_processes":["LPBF"],"candidate_properties":["corrosion behavior"],
+"changed_variables":[],"possible_objectives":[],"evidence_density":"low",
+"confidence":0.9,"warnings":["review_only"]}
+
+3. Insufficient or conflicting input
+Input:
+{"title":"Material study","profile_hint":{"role_hint":"experimental",
+"source_quality_warnings":["insufficient_content"],"role_hint_confidence":0.4},
+"text_preview":"Results are discussed.","headings":[],"table_captions":[],
+"figure_captions":[]}
+Output:
+{"doc_role":"uncertain","candidate_materials":[],"candidate_processes":[],
+"candidate_properties":[],"changed_variables":[],"possible_objectives":[],
+"evidence_density":"unknown","confidence":0.2,
+"warnings":["insufficient_content","classification_uncertain"]}
+
+OUTPUT CONTRACT
+Return exactly these keys: `doc_role`, `candidate_materials`,
+`candidate_processes`, `candidate_properties`, `changed_variables`,
+`possible_objectives`, `evidence_density`, `confidence`, and `warnings`.
+Use empty arrays when no supported value exists. The response ends immediately
+after the JSON object.
+""".strip()
+
+
 _OBJECTIVE_PAPER_FRAME_SYSTEM_PROMPT = """
 You are framing one paper against one research objective for an evidence-backed literature comparison backend.
 
@@ -617,15 +715,10 @@ def _build_objective_context_guidance(payload: dict[str, Any]) -> str:
 
 def build_paper_skim_prompt(payload: dict[str, Any]) -> tuple[str, str]:
     user_prompt = (
-        "Extract a compact research map from this one paper.\n\n"
-        f"Input JSON:\n{json.dumps(payload, ensure_ascii=False, indent=2)}\n\n"
-        "Return only the schema object and start with `{` immediately. "
-        "Return at most 3 materials, 3 processes, 4 properties, 4 changed "
-        "variables, 2 possible objectives, and 2 warnings. "
-        "Do not extract final measurements. Include process family plus changed "
-        "axes, concrete measured properties, and question-shaped objectives."
+        "Evaluate this compact paper input using the PaperSkim contract.\n"
+        f"Input JSON:\n{json.dumps(payload, ensure_ascii=False, separators=(',', ':'))}"
     )
-    return _RESEARCH_OBJECTIVE_SYSTEM_PROMPT, user_prompt
+    return _PAPER_SKIM_SYSTEM_PROMPT, user_prompt
 
 
 def build_research_objective_discovery_prompt(

--- a/backend/application/core/semantic_build/llm/schemas.py
+++ b/backend/application/core/semantic_build/llm/schemas.py
@@ -667,18 +667,55 @@ class StructuredTableMatrixRepair(_StrictModel):
         return _normalize_list_container(value)
 
 
+PaperSkimWarning = Literal[
+    "classification_uncertain",
+    "insufficient_content",
+    "modeling_only",
+    "objective_uncertain",
+    "profile_content_conflict",
+    "review_only",
+]
+
+
 class StructuredPaperSkim(_StrictModel):
-    doc_role: Literal["experimental", "review", "modeling", "mixed", "uncertain"] = (
-        "uncertain"
+    doc_role: Literal["experimental", "review", "modeling", "mixed", "uncertain"] = Field(
+        default="uncertain",
+        description="Coarse role of this paper based on the supplied compact content.",
     )
-    candidate_materials: list[str] = Field(default_factory=list)
-    candidate_processes: list[str] = Field(default_factory=list)
-    candidate_properties: list[str] = Field(default_factory=list)
-    changed_variables: list[str] = Field(default_factory=list)
-    possible_objectives: list[str] = Field(default_factory=list)
-    evidence_density: Literal["high", "medium", "low", "unknown"] = "unknown"
-    confidence: float = 0.0
-    warnings: list[str] = Field(default_factory=list)
+    candidate_materials: list[str] = Field(
+        default_factory=list,
+        description="Explicitly named material systems relevant to candidate questions.",
+    )
+    candidate_processes: list[str] = Field(
+        default_factory=list,
+        description="Explicit process families relevant to candidate questions.",
+    )
+    candidate_properties: list[str] = Field(
+        default_factory=list,
+        description="Concrete measured or evaluated properties named in the input.",
+    )
+    changed_variables: list[str] = Field(
+        default_factory=list,
+        description="Variables explicitly varied or compared in this paper.",
+    )
+    possible_objectives: list[str] = Field(
+        default_factory=list,
+        description="Concise question-shaped process-property comparisons supported by the input.",
+    )
+    evidence_density: Literal["high", "medium", "low", "unknown"] = Field(
+        default="unknown",
+        description="Coverage of the proposed research map in the supplied compact content.",
+    )
+    confidence: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Confidence in the complete PaperSkim, from 0 to 1.",
+    )
+    warnings: list[PaperSkimWarning] = Field(
+        default_factory=list,
+        description="Applicable bounded warning codes; empty when no warning applies.",
+    )
 
     @field_validator(
         "candidate_materials",

--- a/backend/application/core/semantic_build/research_objective_service.py
+++ b/backend/application/core/semantic_build/research_objective_service.py
@@ -1070,7 +1070,6 @@ class ResearchObjectiveService:
                 len(document_figures),
             )
             payload = self._build_paper_skim_payload(
-                collection_id=collection_id,
                 document=document,
                 profile=profiles_by_document_id.get(document.document_id),
                 blocks=document_blocks,
@@ -9557,7 +9556,6 @@ class ResearchObjectiveService:
     def _build_paper_skim_payload(
         self,
         *,
-        collection_id: str,
         document: Any,
         profile: Any,
         blocks: list[Any],
@@ -9576,14 +9574,12 @@ class ResearchObjectiveService:
         if not text_preview:
             text_preview = self._build_text_preview(document, ordered_blocks)
         return {
-            "collection_id": collection_id,
-            "document_id": document.document_id,
             "title": str(document.title or "")[:160],
-            "document_profile": (
+            "profile_hint": (
                 {
-                    "doc_type": profile.doc_type,
-                    "parsing_warnings": list(profile.parsing_warnings)[:2],
-                    "confidence": profile.confidence,
+                    "role_hint": profile.doc_type,
+                    "source_quality_warnings": list(profile.parsing_warnings)[:2],
+                    "role_hint_confidence": profile.confidence,
                 }
                 if profile
                 else {}
@@ -9592,7 +9588,6 @@ class ResearchObjectiveService:
             "headings": headings[:4],
             "table_captions": [
                 {
-                    "table_id": table.table_id,
                     "caption_text": str(table.caption_text or "")[:160],
                     "heading_path": str(table.heading_path or "")[:120],
                     "column_headers": [
@@ -9605,7 +9600,6 @@ class ResearchObjectiveService:
             ],
             "figure_captions": [
                 {
-                    "figure_id": figure.figure_id,
                     "caption_text": str(figure.caption_text or "")[:160],
                     "heading_path": str(figure.heading_path or "")[:120],
                 }

--- a/backend/application/goal/session_service.py
+++ b/backend/application/goal/session_service.py
@@ -54,7 +54,12 @@ _GENERAL_FALLBACK_PREFIX = (
 _MAX_CONTEXT_CHARS = 18000
 _MAX_ROLLING_SUMMARY_CHARS = 1600
 _MAX_SOURCE_LINKS = 12
-_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>\s*", re.IGNORECASE | re.DOTALL)
+_THINK_BLOCK_RE = re.compile(
+    r"<think\b[^>]*>.*?</think\s*>\s*",
+    re.IGNORECASE | re.DOTALL,
+)
+_THINK_OPEN_RE = re.compile(r"<think\b[^>]*>", re.IGNORECASE)
+_THINK_CLOSE_RE = re.compile(r"</think\s*>", re.IGNORECASE)
 _UNSET = object()
 PROTOCOL_READY_REVIEW_GATE = "protocol_ready_findings"
 
@@ -379,8 +384,8 @@ class GoalSessionService:
                 warnings.append("goal_copilot_missing_source_citation")
                 answer = (
                     "Lens could not verify source citations in the generated answer, "
-                    "so do not treat it as a traceable collection conclusion.\n\n"
-                    f"{answer}"
+                    "so do not treat it as a traceable collection conclusion. Review "
+                    "the published findings and evidence directly, then retry."
                 )
                 used_evidence_ids = []
                 source_links = []
@@ -1808,7 +1813,14 @@ class GoalSessionService:
         return "\n".join(parts).strip()
 
     def _strip_thinking_blocks(self, answer: str) -> str:
-        return _THINK_BLOCK_RE.sub("", answer).strip()
+        cleaned = _THINK_BLOCK_RE.sub("", answer)
+        closing_tags = list(_THINK_CLOSE_RE.finditer(cleaned))
+        if closing_tags:
+            cleaned = cleaned[closing_tags[-1].end() :]
+        opening_tag = _THINK_OPEN_RE.search(cleaned)
+        if opening_tag:
+            cleaned = cleaned[: opening_tag.start()]
+        return cleaned.strip()
 
     def _answer_cites_source_link(
         self,

--- a/backend/tests/support/fake_core_llm_extractor.py
+++ b/backend/tests/support/fake_core_llm_extractor.py
@@ -146,7 +146,11 @@ class FakeCoreLLMStructuredExtractor:
 
     def extract_paper_skim(self, payload: dict[str, Any]) -> StructuredPaperSkim:
         title = str(payload.get("title") or "").strip()
-        profile = payload.get("document_profile") if isinstance(payload.get("document_profile"), dict) else {}
+        profile_hint = (
+            payload.get("profile_hint")
+            if isinstance(payload.get("profile_hint"), dict)
+            else {}
+        )
         headings = payload.get("headings") if isinstance(payload.get("headings"), list) else []
         text_preview = str(payload.get("text_preview") or "")
         table_text = " ".join(
@@ -210,7 +214,7 @@ class FakeCoreLLMStructuredExtractor:
                 f"How does {process_phrase} affect {candidate_properties[0]} of {candidate_materials[0]}?"
             )
 
-        doc_role = str(profile.get("doc_type") or "").strip() or "uncertain"
+        doc_role = str(profile_hint.get("role_hint") or "").strip() or "uncertain"
         if doc_role not in {"experimental", "review", "mixed", "uncertain"}:
             doc_role = "uncertain"
         evidence_density = (

--- a/backend/tests/unit/services/test_core_llm_extractor.py
+++ b/backend/tests/unit/services/test_core_llm_extractor.py
@@ -10,6 +10,7 @@ from application.core.semantic_build.llm.extractor import CoreLLMStructuredExtra
 from application.core.semantic_build.llm.prompts import (
     build_objective_evidence_prompt,
     build_finding_synthesis_prompt,
+    build_paper_skim_prompt,
 )
 from application.core.semantic_build.llm.schemas import (
     StructuredAxisCanonicalizationPlan,
@@ -383,6 +384,57 @@ def test_core_llm_extractor_validates_paper_skim_response():
     assert isinstance(skim, StructuredPaperSkim)
     assert skim.doc_role == "experimental"
     assert skim.candidate_materials == ["316L stainless steel"]
+    text_call = client.chat.completions.calls[0]
+    assert text_call["response_format"] == {"type": "json_object"}
+    assert text_call["max_completion_tokens"] == 1024
+
+
+def test_paper_skim_prompt_defines_standalone_task_contract():
+    system_prompt, user_prompt = build_paper_skim_prompt(
+        {
+            "title": "LPBF 316L density study",
+            "profile_hint": {
+                "role_hint": "experimental",
+                "source_quality_warnings": [],
+                "role_hint_confidence": 0.9,
+            },
+            "text_preview": "Laser energy density was varied and density was measured.",
+            "headings": ["Methods", "Results"],
+            "table_captions": [],
+            "figure_captions": [],
+        }
+    )
+    prompt = f"{system_prompt}\n{user_prompt}"
+
+    assert "TASK MODEL" in system_prompt
+    assert "INPUT SCHEMA" in system_prompt
+    assert "DECISION PROCESS" in system_prompt
+    assert "HARD RULES" in system_prompt
+    assert "FEW-SHOTS" in system_prompt
+    assert "OUTPUT CONTRACT" in system_prompt
+    assert "profile_hint.role_hint" in system_prompt
+    assert "document_profile" not in prompt
+    assert '"doc_type"' not in prompt
+    assert "common experimental paper" in system_prompt.lower()
+    assert "review paper" in system_prompt.lower()
+    assert "insufficient or conflicting input" in system_prompt.lower()
+
+
+def test_paper_skim_schema_defines_warning_and_confidence_contract():
+    schema = StructuredPaperSkim.model_json_schema()
+
+    assert schema["properties"]["doc_role"]["description"]
+    assert schema["properties"]["evidence_density"]["description"]
+    assert schema["properties"]["confidence"]["minimum"] == 0
+    assert schema["properties"]["confidence"]["maximum"] == 1
+    assert set(schema["properties"]["warnings"]["items"]["enum"]) == {
+        "classification_uncertain",
+        "insufficient_content",
+        "modeling_only",
+        "objective_uncertain",
+        "profile_content_conflict",
+        "review_only",
+    }
 
 
 def test_core_llm_extractor_validates_research_objective_response():
@@ -969,6 +1021,44 @@ def test_core_llm_extractor_logs_invalid_json_output_diagnostics(caplog):
 
     assert "response_model=StructuredPaperSkim attempt=2" in caplog.text
     assert "raw_output_length=69" in caplog.text
+
+
+def test_paper_skim_retry_uses_task_specific_validation_contract():
+    client = _FakeOpenAIClient(
+        """
+        {
+          "doc_type": "experimental",
+          "doc_role": "experimental",
+          "candidate_materials": ["316L stainless steel"],
+          "candidate_processes": ["LPBF"],
+          "candidate_properties": ["density"],
+          "changed_variables": ["laser energy density"],
+          "possible_objectives": ["How does laser energy density affect density?"],
+          "evidence_density": "high",
+          "confidence": 0.9,
+          "warnings": []
+        }
+        """
+    )
+    extractor = _json_text_extractor(client)
+
+    with pytest.raises(ValidationError, match="doc_type"):
+        extractor.extract_paper_skim(
+            {
+                "title": "LPBF 316L density study",
+                "profile_hint": {"role_hint": "experimental"},
+                "text_preview": "Laser energy density was varied and density was measured.",
+                "headings": ["Methods", "Results"],
+                "table_captions": [],
+                "figure_captions": [],
+            }
+        )
+
+    retry_instruction = client.chat.completions.calls[1]["messages"][-1]["content"]
+    assert "Previous PaperSkim output failed validation" in retry_instruction
+    assert "doc_type" in retry_instruction
+    assert "exactly these keys" in retry_instruction
+    assert "For finding synthesis" not in retry_instruction
 
 
 def test_core_llm_extractor_can_opt_in_to_provider_thinking(monkeypatch):

--- a/backend/tests/unit/services/test_goal_session_service.py
+++ b/backend/tests/unit/services/test_goal_session_service.py
@@ -787,6 +787,7 @@ def test_goal_chat_downgrades_uncited_grounded_answer(tmp_path):
     assert response["source_links"] == []
     assert "goal_copilot_missing_source_citation" in response["warnings"]
     assert "do not treat it as a traceable collection conclusion" in response["answer"]
+    assert "The objective is supported by the collection evidence." not in response["answer"]
     assert loaded["last_evidence_ids"] == []
 
 
@@ -898,6 +899,22 @@ def test_goal_chat_uses_protocol_ready_findings_for_protocol_context(tmp_path):
     assert "paper-unreviewed" not in prompt
     assert "ev_preheat_ductility" not in prompt
     assert "finding_review_candidate" not in prompt
+
+
+def test_goal_chat_strips_incomplete_thinking_markup(tmp_path):
+    service, _ = _service(tmp_path)
+
+    assert service._strip_thinking_blocks("</think>\nVisible answer.") == "Visible answer."
+    assert (
+        service._strip_thinking_blocks(
+            "Hidden reasoning that must not leak.</think>\nVisible answer."
+        )
+        == "Visible answer."
+    )
+    assert (
+        service._strip_thinking_blocks("Visible answer.\n<think>Hidden reasoning")
+        == "Visible answer."
+    )
 
 
 def test_goal_chat_repairs_protocol_contract_before_returning_grounded_answer(tmp_path):

--- a/backend/tests/unit/services/test_research_objective_service.py
+++ b/backend/tests/unit/services/test_research_objective_service.py
@@ -10013,7 +10013,19 @@ def test_research_objective_service_builds_and_persists_objective_records(
     assert extractor.skim_payloads[0]["headings"] == ["Abstract", "References"]
     assert "Additional abstract context" in extractor.skim_payloads[0]["text_preview"]
     assert "Reference text should not" not in extractor.skim_payloads[0]["text_preview"]
-    assert extractor.skim_payloads[0]["table_captions"][0]["table_id"] == "table-1"
+    assert extractor.skim_payloads[0]["profile_hint"] == {
+        "role_hint": "experimental",
+        "source_quality_warnings": [],
+        "role_hint_confidence": 0.9,
+    }
+    assert "collection_id" not in extractor.skim_payloads[0]
+    assert "document_id" not in extractor.skim_payloads[0]
+    assert "document_profile" not in extractor.skim_payloads[0]
+    assert "table_id" not in extractor.skim_payloads[0]["table_captions"][0]
+    assert all(
+        "figure_id" not in item
+        for item in extractor.skim_payloads[0]["figure_captions"]
+    )
     assert extractor.discovery_payloads[0]["paper_skims"][0]["document_id"] == "paper-1"
     discovery_skim = extractor.discovery_payloads[0]["paper_skims"][0]
     assert set(discovery_skim) == {

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -7,6 +7,13 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  location ~ ^/_app/.*\.mjs$ {
+    try_files $uri =404;
+    default_type application/javascript;
+    expires 1y;
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
+
   location /_app/ {
     try_files $uri =404;
     expires 1y;


### PR DESCRIPTION
## 背景

v0.11.4/v0.11.5 的真实发布验收仍有三类可靠性问题：PaperSkim 在 `json_text` 模式下耗尽输出预算并返回额外字段，Copilot 可能保留无引用回答或泄露不完整推理标记，前端发布镜像对 PDF worker 的 `.mjs` 返回错误 MIME 类型。

## 修改

- 为 PaperSkim 建立独立任务提示词、严格 schema 和精简输入 payload。
- 在 PaperSkim `json_text` 请求上启用 JSON object 约束，并提供任务专用重试反馈。
- 未通过来源引用校验时不再返回模型原回答，并清理完整或不完整的 `<think>` 内容。
- 为 `/_app/*.mjs` 显式返回 `application/javascript`。

## 验证

- `37 passed`: `tests/unit/services/test_core_llm_extractor.py`
- `135 passed`: `tests/unit/services/test_research_objective_service.py`
- `21 passed`: `tests/unit/services/test_goal_session_service.py`
- 真实 `qwen3-vl-cpt-sft`: experimental 112、review 104、insufficient 81 completion tokens，均单次 `finish_reason=stop` 并通过严格校验
- 发布前端镜像挂载新配置后 `nginx -t` 通过
- Python `py_compile` 通过
- `git diff --check` 通过

## 影响

不修改 API、数据库或迁移合同。重新构建发布镜像后，失败的集合任务需要由用户重新执行。

Refs #265