### PR TITLE
chore(release): 准备 v0.11.6

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -302,7 +302,7 @@ def create_app(
 
     app = FastAPI(
         title="TsingAI-Lens API",
-        version="0.11.5",
+        version="0.11.6",
         docs_url=f"{PUBLIC_API_PREFIX}/docs",
         redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
         openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsingai-lens"
-version = "0.11.5"
+version = "0.11.6"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.11.5",
+	"version": "0.11.6",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## 发布内容

将后端包、FastAPI 应用和前端包版本统一更新为 `0.11.6`，发布已合并的研究分析、Copilot 证据保护和 PDF worker MIME 修复。

## 验证

- `193 passed`: Core extractor、research objective service、goal session service
- `npm run check`: 0 errors and 0 warnings
- `npm run build`
- 构建产物 `_app/version.json` 为 `0.11.6`
- 后端包、FastAPI 和前端版本一致
- `git diff --check`

## 发布后

合并后创建并推送 `v0.11.6` tag，触发后端和前端 Docker 镜像发布及 `latest` 更新。

Fix PR #278
Refs #265