### PR TITLE
bugfix: 收紧研究目标发现结构化契约

### DIFF
--- a/backend/application/core/semantic_build/llm/extractor.py
+++ b/backend/application/core/semantic_build/llm/extractor.py
@@ -406,6 +406,7 @@ class CoreLLMStructuredExtractor:
             request_kwargs["max_completion_tokens"] = (
                 _RESEARCH_OBJECTIVE_DISCOVERY_MAX_COMPLETION_TOKENS
             )
+            request_kwargs["response_format"] = {"type": "json_object"}
         elif response_model is StructuredEvidenceSelections:
             request_kwargs["max_completion_tokens"] = (
                 _OBJECTIVE_EVIDENCE_SELECTION_MAX_COMPLETION_TOKENS
@@ -433,6 +434,19 @@ class CoreLLMStructuredExtractor:
                         "possible_objectives, evidence_density, confidence, and "
                         "warnings. Remove every other key. Do not output analysis, "
                         "markdown, or copied input."
+                    )
+                elif response_model is StructuredResearchObjectives:
+                    retry_instruction = (
+                        "Previous ResearchObjective discovery output failed "
+                        f"validation: {_trace_text(last_error, 400)}. Return one "
+                        "compact JSON object with exactly one top-level key: "
+                        "objectives. Each item must have exactly these objective "
+                        "keys: question, material_scope, process_axes, "
+                        "property_axes, comparison_intent, seed_document_ids, "
+                        "excluded_document_ids, confidence, and reason. Use "
+                        '{"objectives":[]} when no complete candidate exists. '
+                        "Do not output analysis, markdown, copied input, or extra "
+                        "fields."
                     )
                 else:
                     retry_instruction = (

--- a/backend/application/core/semantic_build/llm/prompts.py
+++ b/backend/application/core/semantic_build/llm/prompts.py
@@ -148,6 +148,120 @@ after the JSON object.
 """.strip()
 
 
+_RESEARCH_OBJECTIVE_DISCOVERY_SYSTEM_PROMPT = """
+TASK MODEL
+You are the candidate-selection judge for an evidence-backed literature
+comparison backend. Perform candidate selection and binding: select supported
+research questions already proposed by PaperSkim records and bind each selected
+question to the papers and axes that support it. This is candidate selection,
+not final evidence extraction, not axis canonicalization, not objective merge,
+and not free-form research-question generation.
+
+INPUT SCHEMA
+- `collection_id`: collection context only. Never return it.
+- `paper_skims`: compact candidate records from the papers in this collection.
+- `paper_skims[].document_id`: exact identifier for one input paper. This is the
+  only source for `seed_document_ids` and `excluded_document_ids`.
+- `paper_skims[].doc_role`: coarse paper role. Experimental and genuinely mixed
+  papers may seed an objective; review, modeling-only, or uncertain papers do
+  not seed a directly comparable experimental objective.
+- `paper_skims[].candidate_materials`: material labels explicitly found in that
+  paper.
+- `paper_skims[].candidate_processes`: process-family labels explicitly found in
+  that paper.
+- `paper_skims[].changed_variables`: variables explicitly varied or compared in
+  that paper. These may be selected as process axes.
+- `paper_skims[].candidate_properties`: measured or evaluated property labels
+  explicitly found in that paper.
+- `paper_skims[].possible_objectives`: question-shaped candidates already
+  supported by that paper. This is the only source for output `question`.
+
+DECISION PROCESS
+1. Ignore a skim as a seed when it has no possible objective or lacks a
+   material, a process or changed variable, or a measured property.
+2. Select only a question copied exactly from an input
+   `possible_objectives` value. Never rewrite or expand it.
+3. Bind seed papers that directly support that same material-process-property
+   comparison. Copy their exact `document_id` values.
+4. Copy `material_scope`, `process_axes`, and `property_axes` values exactly
+   from the union of the selected seed skims. Do not normalize synonyms here.
+5. Bind papers to one objective only when their candidate relationship is the
+   same. Keep different process-property relationships as separate candidates;
+   the downstream merge step decides whether separate candidates can merge.
+6. Put a paper in `excluded_document_ids` only when its skim is clearly outside
+   that objective's relationship. An empty exclusion list is valid.
+7. If more than 6 candidates remain, rank them by number of supporting
+   experimental papers, then by completeness of the material, process, and
+   property binding. Keep the first 6.
+8. Write a short comparison intent and a short grounding reason. Set confidence
+   from the clarity and agreement of the selected skims, not from outside
+   knowledge.
+9. Return no objective when the input contains no complete, supported
+   candidate. Use exactly `{"objectives":[]}` for that reject result.
+
+HARD RULES
+- Decide silently. Return one JSON object with no analysis, markdown, copied
+  input, measurements, evidence claims, source locators, or extra fields.
+- Return at most 6 objectives. Each objective has 1-3 materials, 1-8 process
+  axes, 1-8 property axes, 1-12 seed ids, and 0-12 excluded ids.
+- Every question and axis must be copied exactly from the selected seed skims.
+- Every document id must be copied exactly from an input skim. Seed and
+  excluded ids must be disjoint.
+- Prefer the empty reject result over an unsupported or incomplete objective.
+
+FEW-SHOTS
+1. Shared objective across papers
+Input:
+{"collection_id":"c1","paper_skims":[{"document_id":"p1","doc_role":
+"experimental","candidate_materials":["316L stainless steel"],
+"candidate_processes":["LPBF"],"changed_variables":["laser energy density"],
+"candidate_properties":["relative density"],"possible_objectives":
+["How does laser energy density affect relative density of LPBF 316L stainless steel?"]},
+{"document_id":"p2","doc_role":"experimental","candidate_materials":
+["316L stainless steel"],"candidate_processes":["LPBF"],"changed_variables":
+["laser energy density"],"candidate_properties":["relative density"],
+"possible_objectives":["How does laser energy density affect relative density of LPBF 316L stainless steel?"]}]}
+Output:
+{"objectives":[{"question":"How does laser energy density affect relative density of LPBF 316L stainless steel?","material_scope":["316L stainless steel"],
+"process_axes":["LPBF","laser energy density"],"property_axes":["relative density"],
+"comparison_intent":"Compare relative density across reported laser energy densities.",
+"seed_document_ids":["p1","p2"],"excluded_document_ids":[],"confidence":0.95,
+"reason":"Both experimental skims propose the same material-process-property question."}]}
+
+2. Unrelated candidates stay separate
+Input:
+{"collection_id":"c2","paper_skims":[{"document_id":"p1","doc_role":
+"experimental","candidate_materials":["Ti-6Al-4V"],"candidate_processes":
+["heat treatment"],"changed_variables":["aging temperature"],
+"candidate_properties":["yield strength"],"possible_objectives":
+["How does aging temperature affect yield strength of Ti-6Al-4V?"]},
+{"document_id":"p2","doc_role":"experimental","candidate_materials":
+["Ti-6Al-4V"],"candidate_processes":["surface treatment"],"changed_variables":
+["surface roughness"],"candidate_properties":["corrosion resistance"],
+"possible_objectives":["How does surface roughness affect corrosion resistance of Ti-6Al-4V?"]}]}
+Output:
+{"objectives":[{"question":"How does aging temperature affect yield strength of Ti-6Al-4V?","material_scope":["Ti-6Al-4V"],"process_axes":["heat treatment","aging temperature"],"property_axes":["yield strength"],"comparison_intent":"Compare yield strength across aging temperatures.","seed_document_ids":["p1"],"excluded_document_ids":["p2"],"confidence":0.9,"reason":"Only p1 supports the aging-temperature and yield-strength relationship."},{"question":"How does surface roughness affect corrosion resistance of Ti-6Al-4V?","material_scope":["Ti-6Al-4V"],"process_axes":["surface treatment","surface roughness"],"property_axes":["corrosion resistance"],"comparison_intent":"Compare corrosion resistance across surface roughness conditions.","seed_document_ids":["p2"],"excluded_document_ids":["p1"],"confidence":0.9,"reason":"Only p2 supports the surface-roughness and corrosion relationship."}]}
+
+3. Review or insufficient candidates
+Input:
+{"collection_id":"c3","paper_skims":[{"document_id":"p1","doc_role":"review",
+"candidate_materials":["316L stainless steel"],"candidate_processes":["LPBF"],
+"changed_variables":[],"candidate_properties":["corrosion behavior"],
+"possible_objectives":[]},{"document_id":"p2","doc_role":"uncertain",
+"candidate_materials":[],"candidate_processes":[],"changed_variables":[],
+"candidate_properties":[],"possible_objectives":[]}]}
+Output:
+{"objectives":[]}
+
+OUTPUT CONTRACT
+Return exactly one top-level key: `objectives`. Each objective must contain
+exactly these keys: `question`, `material_scope`, `process_axes`,
+`property_axes`, `comparison_intent`, `seed_document_ids`,
+`excluded_document_ids`, `confidence`, and `reason`. Empty `objectives` is the
+only reject form. The response ends immediately after the JSON object.
+""".strip()
+
+
 _OBJECTIVE_PAPER_FRAME_SYSTEM_PROMPT = """
 You are framing one paper against one research objective for an evidence-backed literature comparison backend.
 
@@ -725,17 +839,10 @@ def build_research_objective_discovery_prompt(
     payload: dict[str, Any],
 ) -> tuple[str, str]:
     user_prompt = (
-        "Create a small set of comparison questions from these compact paper skims.\n"
-        f"Input JSON:\n{json.dumps(payload, ensure_ascii=False, separators=(',', ':'))}\n\n"
-        "Return only the schema object. Keep objectives few and question-shaped. "
-        "Use exact document_id values for seed/excluded ids. Group related "
-        "properties, but keep distinct process-property comparisons separate."
+        "Select and bind research-objective candidates using the contract.\n"
+        f"Input JSON:\n{json.dumps(payload, ensure_ascii=False, separators=(',', ':'))}"
     )
-    system_prompt = (
-        "Build concise research-objective questions for literature comparison. "
-        "Use only the supplied skims. Return one JSON object, no commentary."
-    )
-    return system_prompt, user_prompt
+    return _RESEARCH_OBJECTIVE_DISCOVERY_SYSTEM_PROMPT, user_prompt
 
 
 def build_research_axis_canonicalization_prompt(

--- a/backend/application/core/semantic_build/llm/schemas.py
+++ b/backend/application/core/semantic_build/llm/schemas.py
@@ -750,15 +750,50 @@ class StructuredPaperSkim(_StrictModel):
 
 
 class StructuredResearchObjective(_StrictModel):
-    question: str
-    material_scope: list[str] = Field(default_factory=list)
-    process_axes: list[str] = Field(default_factory=list)
-    property_axes: list[str] = Field(default_factory=list)
-    comparison_intent: str | None = None
-    seed_document_ids: list[str] = Field(default_factory=list)
-    excluded_document_ids: list[str] = Field(default_factory=list)
-    confidence: float = 0.0
-    reason: str | None = None
+    question: str = Field(
+        min_length=8,
+        max_length=240,
+        description="Exact question copied from a selected skim's possible_objectives.",
+    )
+    material_scope: list[str] = Field(
+        min_length=1,
+        max_length=3,
+        description="Material labels copied from the selected seed skims.",
+    )
+    process_axes: list[str] = Field(
+        min_length=1,
+        max_length=8,
+        description="Process or changed-variable labels copied from the seed skims.",
+    )
+    property_axes: list[str] = Field(
+        min_length=1,
+        max_length=8,
+        description="Measured property labels copied from the selected seed skims.",
+    )
+    comparison_intent: str = Field(
+        min_length=1,
+        max_length=240,
+        description="Concise comparison represented by this candidate objective.",
+    )
+    seed_document_ids: list[str] = Field(
+        min_length=1,
+        max_length=12,
+        description="Exact input document ids that directly support this candidate.",
+    )
+    excluded_document_ids: list[str] = Field(
+        max_length=12,
+        description="Exact input document ids clearly outside this candidate's scope.",
+    )
+    confidence: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="Confidence in candidate selection and paper binding, from 0 to 1.",
+    )
+    reason: str = Field(
+        min_length=1,
+        max_length=200,
+        description="Short explanation grounded in the selected PaperSkim records.",
+    )
 
     @field_validator(
         "material_scope",
@@ -772,9 +807,21 @@ class StructuredResearchObjective(_StrictModel):
     def _normalize_lists(cls, value: object) -> object:
         return _normalize_list_container(value)
 
+    @model_validator(mode="after")
+    def _validate_disjoint_document_ids(self) -> "StructuredResearchObjective":
+        overlap = set(self.seed_document_ids) & set(self.excluded_document_ids)
+        if overlap:
+            raise ValueError(
+                "seed_document_ids and excluded_document_ids must be disjoint"
+            )
+        return self
+
 
 class StructuredResearchObjectives(_StrictModel):
-    objectives: list[StructuredResearchObjective] = Field(default_factory=list)
+    objectives: list[StructuredResearchObjective] = Field(
+        max_length=6,
+        description="Bounded supported candidates; empty when none are reviewable.",
+    )
 
     @field_validator("objectives", mode="before")
     @classmethod

--- a/backend/application/core/semantic_build/research_objective_service.py
+++ b/backend/application/core/semantic_build/research_objective_service.py
@@ -334,6 +334,7 @@ _SKIM_CAPTION_LIMIT = 12
 _DISCOVERY_AXIS_VALUE_LIMIT = 2
 _DISCOVERY_OBJECTIVE_LIMIT = 1
 _DISCOVERY_TEXT_VALUE_CHARS = 80
+_DISCOVERY_OBJECTIVE_TEXT_CHARS = 240
 _FRAME_SECTION_SNIPPET_LIMIT = 12
 _FRAME_SECTION_TEXT_CHARS = 420
 _FRAME_SECTION_OVERVIEW_LIMIT = 4
@@ -1195,9 +1196,13 @@ class ResearchObjectiveService:
     def _build_objective_discovery_skim(skim: PaperSkim) -> dict[str, Any]:
         """Keep collection-level discovery input within the model context budget."""
 
-        def values(items: tuple[str, ...], limit: int) -> list[str]:
+        def values(
+            items: tuple[str, ...],
+            limit: int,
+            text_chars: int = _DISCOVERY_TEXT_VALUE_CHARS,
+        ) -> list[str]:
             return [
-                str(item).strip()[:_DISCOVERY_TEXT_VALUE_CHARS]
+                str(item).strip()[:text_chars]
                 for item in items[:limit]
                 if str(item).strip()
             ]
@@ -1224,6 +1229,7 @@ class ResearchObjectiveService:
             "possible_objectives": values(
                 skim.possible_objectives,
                 _DISCOVERY_OBJECTIVE_LIMIT,
+                _DISCOVERY_OBJECTIVE_TEXT_CHARS,
             ),
         }
 

--- a/backend/tests/unit/services/test_core_llm_extractor.py
+++ b/backend/tests/unit/services/test_core_llm_extractor.py
@@ -11,6 +11,7 @@ from application.core.semantic_build.llm.prompts import (
     build_objective_evidence_prompt,
     build_finding_synthesis_prompt,
     build_paper_skim_prompt,
+    build_research_objective_discovery_prompt,
 )
 from application.core.semantic_build.llm.schemas import (
     StructuredAxisCanonicalizationPlan,
@@ -21,6 +22,7 @@ from application.core.semantic_build.llm.schemas import (
     StructuredObjectiveMergePlan,
     StructuredPaperContributionDraft,
     StructuredPaperSkim,
+    StructuredResearchObjective,
     StructuredResearchObjectives,
     StructuredFindingSynthesisOutcome,
     StructuredFindingSynthesis,
@@ -468,7 +470,95 @@ def test_core_llm_extractor_validates_research_objective_response():
 
     assert isinstance(objectives, StructuredResearchObjectives)
     assert objectives.objectives[0].question.startswith("How does heat treatment")
-    assert client.chat.completions.calls[0]["max_completion_tokens"] == 1400
+    text_call = client.chat.completions.calls[0]
+    assert text_call["max_completion_tokens"] == 1400
+    assert text_call["response_format"] == {"type": "json_object"}
+
+
+def test_research_objective_discovery_prompt_defines_selection_contract():
+    system_prompt, user_prompt = build_research_objective_discovery_prompt(
+        {
+            "collection_id": "col-1",
+            "paper_skims": [
+                {
+                    "document_id": "paper-1",
+                    "doc_role": "experimental",
+                    "candidate_materials": ["316L stainless steel"],
+                    "candidate_processes": ["LPBF"],
+                    "changed_variables": ["laser energy density"],
+                    "candidate_properties": ["relative density"],
+                    "possible_objectives": [
+                        "How does laser energy density affect relative density of LPBF 316L stainless steel?"
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert "TASK MODEL" in system_prompt
+    assert "INPUT SCHEMA" in system_prompt
+    assert "DECISION PROCESS" in system_prompt
+    assert "HARD RULES" in system_prompt
+    assert "FEW-SHOTS" in system_prompt
+    assert "OUTPUT CONTRACT" in system_prompt
+    assert "candidate selection and binding" in system_prompt
+    assert "not final evidence extraction" in system_prompt
+    assert "not axis canonicalization" in system_prompt
+    assert "not objective merge" in system_prompt
+    assert "`collection_id`" in system_prompt
+    assert "`paper_skims[].document_id`" in system_prompt
+    assert "`paper_skims[].possible_objectives`" in system_prompt
+    assert "copy" in system_prompt.lower()
+    assert "If more than 6 candidates remain" in system_prompt
+    assert "Shared objective across papers" in system_prompt
+    assert "Unrelated candidates stay separate" in system_prompt
+    assert "Review or insufficient candidates" in system_prompt
+    assert '{"objectives":[]}' in system_prompt
+    assert "Input JSON:" in user_prompt
+
+
+def test_research_objective_schema_requires_bounded_complete_records():
+    schema = StructuredResearchObjectives.model_json_schema()
+    objective_schema = schema["$defs"]["StructuredResearchObjective"]
+
+    assert schema["required"] == ["objectives"]
+    assert schema["properties"]["objectives"]["maxItems"] == 6
+    assert set(objective_schema["required"]) == {
+        "question",
+        "material_scope",
+        "process_axes",
+        "property_axes",
+        "comparison_intent",
+        "seed_document_ids",
+        "excluded_document_ids",
+        "confidence",
+        "reason",
+    }
+    assert objective_schema["properties"]["material_scope"]["maxItems"] == 3
+    assert objective_schema["properties"]["process_axes"]["maxItems"] == 8
+    assert objective_schema["properties"]["property_axes"]["maxItems"] == 8
+    assert objective_schema["properties"]["seed_document_ids"]["maxItems"] == 12
+    assert objective_schema["properties"]["excluded_document_ids"]["maxItems"] == 12
+    assert objective_schema["properties"]["confidence"]["minimum"] == 0
+    assert objective_schema["properties"]["confidence"]["maximum"] == 1
+
+    with pytest.raises(ValidationError, match="objectives"):
+        StructuredResearchObjectives.model_validate({})
+
+
+def test_research_objective_schema_rejects_overlapping_document_roles():
+    with pytest.raises(ValidationError, match="must be disjoint"):
+        StructuredResearchObjective(
+            question="How does laser energy density affect relative density?",
+            material_scope=["316L stainless steel"],
+            process_axes=["laser energy density"],
+            property_axes=["relative density"],
+            comparison_intent="Compare relative density across energy densities.",
+            seed_document_ids=["paper-1"],
+            excluded_document_ids=["paper-1"],
+            confidence=0.9,
+            reason="The skim provides a direct process-property candidate.",
+        )
 
 
 def test_core_llm_extractor_validates_axis_canonicalization_response():
@@ -1058,6 +1148,37 @@ def test_paper_skim_retry_uses_task_specific_validation_contract():
     assert "Previous PaperSkim output failed validation" in retry_instruction
     assert "doc_type" in retry_instruction
     assert "exactly these keys" in retry_instruction
+    assert "For finding synthesis" not in retry_instruction
+
+
+def test_research_objective_retry_uses_task_specific_validation_contract():
+    client = _FakeOpenAIClient(
+        """
+        {
+          "objectives": [
+            {
+              "question": "How does laser energy density affect relative density?",
+              "material_scope": ["316L stainless steel"]
+            }
+          ]
+        }
+        """
+    )
+    extractor = _json_text_extractor(client)
+
+    with pytest.raises(ValidationError, match="process_axes"):
+        extractor.discover_research_objectives(
+            {
+                "collection_id": "col-1",
+                "paper_skims": [],
+            }
+        )
+
+    retry_instruction = client.chat.completions.calls[1]["messages"][-1]["content"]
+    assert "Previous ResearchObjective discovery output failed validation" in retry_instruction
+    assert "process_axes" in retry_instruction
+    assert "exactly one top-level key: objectives" in retry_instruction
+    assert "exactly these objective keys" in retry_instruction
     assert "For finding synthesis" not in retry_instruction
 
 

--- a/backend/tests/unit/services/test_research_objective_service.py
+++ b/backend/tests/unit/services/test_research_objective_service.py
@@ -57,6 +57,29 @@ def _research_objective(payload: dict[str, Any]) -> ResearchObjective:
     )
 
 
+def test_objective_discovery_skim_preserves_complete_candidate_question():
+    question = (
+        "How do laser energy density and scanning strategy affect relative density "
+        "and microstructure of laser powder bed fused 316L stainless steel?"
+    )
+    skim = PaperSkim.from_mapping(
+        {
+            "document_id": "paper-1",
+            "doc_role": "experimental",
+            "candidate_materials": ["316L stainless steel"],
+            "candidate_processes": ["laser powder bed fusion"],
+            "candidate_properties": ["relative density", "microstructure"],
+            "changed_variables": ["laser energy density", "scanning strategy"],
+            "possible_objectives": [question],
+        }
+    )
+
+    compact_skim = _ResearchObjectiveService._build_objective_discovery_skim(skim)
+
+    assert len(question) > 80
+    assert compact_skim["possible_objectives"] == [question]
+
+
 def _build_research_objective_service(
     *,
     collection_service,
@@ -255,17 +278,6 @@ class _ObjectiveExtractor:
                     excluded_document_ids=["paper-2"],
                     confidence=0.88,
                     reason="paper skims share a clear material-process-property axis",
-                ),
-                StructuredResearchObjective(
-                    question="316L stainless steel",
-                    material_scope=["316L stainless steel"],
-                    process_axes=[],
-                    property_axes=[],
-                    comparison_intent=None,
-                    seed_document_ids=[],
-                    excluded_document_ids=[],
-                    confidence=0.4,
-                    reason="plain material list should be filtered",
                 ),
             ]
         )
@@ -623,7 +635,9 @@ class _BroadObjectiveExtractor(_ObjectiveExtractor):
                     material_scope=["316L stainless steel"],
                     process_axes=["Selective Laser Melting"],
                     property_axes=["mechanical properties"],
-                    comparison_intent=None,
+                    comparison_intent=(
+                        "Compare mechanical properties across SLM processing parameters."
+                    ),
                     seed_document_ids=["paper-1"],
                     excluded_document_ids=[],
                     confidence=0.88,


### PR DESCRIPTION
## 背景

真实构建任务中的 Objective Discovery 连续两次耗尽 1400 completion tokens，最终没有返回 JSON 对象，导致集合构建停在研究目标候选阶段。

## 修改

- 将 Objective Discovery 明确为 PaperSkim 候选选择与文档绑定，不再承担开放式研究问题生成、轴规范化或目标合并。
- 定义输入字段、顺序决策、跨论文/分离/拒绝示例和精确输出契约。
- 要求完整且有边界的 Objective 字段，校验置信度及 seed/excluded 文档互斥。
- 为该任务启用 `json_object` 响应模式和专用重试指令。
- 将候选问题压缩上限从通用 80 字符独立提升到 240，避免问题在 Discovery 前被截断。

## 影响

- 不改变 HTTP API、持久化结构或前端契约。
- 单篇、双篇和无有效候选场景均可一次返回严格 JSON。

## 验证

- `uv run --frozen pytest tests/unit/services/test_core_llm_extractor.py tests/unit/services/test_research_objective_service.py -q --tb=short`：177 passed
- Python compileall：通过
- `qwen3-vl-cpt-sft` 真实请求：单篇 135、双篇 158、拒绝 9 completion tokens，均 `attempts=1`、`finish_reason=stop`
- Prompt Architecture Review：pass

Refs: #265
