### PR TITLE
bugfix: 稳定研究分析与 Finding 证据

### DIFF
--- a/backend/application/core/finding_synthesis_service.py
+++ b/backend/application/core/finding_synthesis_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from collections import defaultdict
 from hashlib import sha1
 from typing import Any, Mapping
@@ -19,6 +20,40 @@ from domain.core import (
 _MAX_DIRECT_EVIDENCE = 48
 _MAX_CONTEXT_EVIDENCE = 24
 _MAX_EXCERPT_CHARS = 900
+_NON_RESULT_SOURCE_MARKERS = (
+    "aims to",
+    "aim of this study",
+    "goal of this study",
+    "objective of this study",
+    "assumed to",
+    "is assumed to",
+    "was assumed to",
+    "are assumed to",
+    "were assumed to",
+    "will be investigated",
+    "we are investigating",
+    "is investigated",
+    "was investigated",
+    "are investigated",
+    "were investigated",
+    "has been reported",
+    "have been reported",
+    "in the next step",
+    "future work",
+)
+_RESULT_VALUE_METADATA_KEYS = {
+    "comparison_axis",
+    "controlled_axes",
+    "evidence_quote",
+    "method_family",
+    "notes",
+    "source_value_role",
+    "unit",
+    "value_notes",
+    "value_role",
+    "value_type",
+    "value_unit",
+}
 logger = logging.getLogger(__name__)
 
 
@@ -56,6 +91,7 @@ class FindingSynthesisService:
             if evidence.supports_finding
             and evidence.evidence_role == "direct_result"
             and evidence.property_normalized
+            and self._is_reviewable_direct_evidence(evidence)
         )
         comparison_keys = {
             (evidence.document_id, evidence.property_normalized.casefold())
@@ -171,6 +207,53 @@ class FindingSynthesisService:
                     findings.append(finding)
                     break
         return tuple(findings)
+
+    @staticmethod
+    def _is_reviewable_direct_evidence(evidence: ObjectiveEvidence) -> bool:
+        source_text = " ".join(evidence.source_excerpt.casefold().split())
+        if not source_text or any(
+            marker in source_text for marker in _NON_RESULT_SOURCE_MARKERS
+        ):
+            return False
+        if str(evidence.value_payload.get("value_role") or "").casefold() in {
+            "condition",
+            "control",
+            "control_value",
+            "method",
+            "process_condition",
+        }:
+            return False
+
+        candidates: list[Any] = []
+
+        def collect(value: Any, key: str | None = None) -> None:
+            if key and key.casefold() in _RESULT_VALUE_METADATA_KEYS:
+                return
+            if isinstance(value, Mapping):
+                for nested_key, nested_value in value.items():
+                    collect(nested_value, str(nested_key))
+            elif isinstance(value, (list, tuple)):
+                for nested_value in value:
+                    collect(nested_value)
+            elif value not in (None, "", [], {}):
+                candidates.append(value)
+
+        collect(evidence.value_payload)
+        for candidate in candidates:
+            candidate_text = " ".join(str(candidate).casefold().split())
+            if not candidate_text:
+                continue
+            if len(candidate_text) <= 3 or re.fullmatch(
+                r"[-+]?\d+(?:\.\d+)?", candidate_text
+            ):
+                if re.search(
+                    rf"(?<![\w.]){re.escape(candidate_text)}(?![\w.])",
+                    source_text,
+                ):
+                    return True
+            elif candidate_text in source_text:
+                return True
+        return False
 
     @staticmethod
     def _fallback_candidate(result_set: Mapping[str, Any]) -> dict[str, Any]:
@@ -436,6 +519,12 @@ class FindingSynthesisService:
             evidence_by_id=evidence_by_id,
             supporting_document_ids=set(contributing_documents),
         )
+        mechanism_ids = {
+            evidence_id
+            for evidence_id in _strings(candidate.get("mechanism_evidence_ids"))
+            if evidence_id in context_ids
+            and evidence_by_id[evidence_id].evidence_role == "mechanism_context"
+        }
         variables = tuple(_strings(result_set.get("source_axes")))
         statement = _text(candidate.get("statement"))
         if not variables or not statement:
@@ -446,12 +535,96 @@ class FindingSynthesisService:
         )
         directions = _dedupe(_text(item.get("direction")) for item in outcomes)
         direction = directions[0] if len(directions) == 1 else "mixed"
+        outcome_statements: list[str] = []
+        for item in outcomes:
+            outcome = _text(item.get("concept"))
+            if not outcome or not any(
+                _terms_match(outcome, allowed) for allowed in outcome_names
+            ):
+                continue
+            outcome_statement = _text(item.get("statement"))
+            matching_evidence = [
+                evidence_by_id[evidence_id]
+                for evidence_id in supporting_ids
+                if _terms_match(
+                    evidence_by_id[evidence_id].property_normalized,
+                    outcome,
+                )
+            ]
+            source_text = " ".join(
+                evidence.source_excerpt.casefold() for evidence in matching_evidence
+            )
+            if (
+                outcome_statement
+                and "significant" in outcome_statement.casefold()
+                and "significant" not in source_text
+            ):
+                values = _dedupe(
+                    _text(value)
+                    for evidence in matching_evidence
+                    for key in (
+                        "source_value_text",
+                        "value",
+                        "baseline_value",
+                        "current_value",
+                    )
+                    if (value := evidence.value_payload.get(key)) is not None
+                )
+                if values:
+                    value_text = (
+                        values[0]
+                        if len(values) == 1
+                        else f"{', '.join(values[:-1])} and {values[-1]}"
+                    )
+                    unit = next(
+                        (evidence.unit for evidence in matching_evidence if evidence.unit),
+                        None,
+                    )
+                    separator = "" if unit == "%" else " "
+                    outcome_statement = (
+                        f"The reported {', '.join(variables)} comparison measured "
+                        f"{outcome} values of {value_text}"
+                        f"{separator}{unit or ''}."
+                    )
+                else:
+                    outcome_statement = (
+                        f"The reported {', '.join(variables)} comparison included "
+                        f"a change in {outcome}."
+                    )
+            if outcome_statement:
+                outcome_statements.append(outcome_statement)
+        outcome_statements = _dedupe(outcome_statements)
         if coupled_variables:
             direction = "changes"
             statement = (
                 "In the reported comparison, the coupled condition defined by "
                 f"{', '.join(variables)} was associated with changes in "
                 f"{', '.join(outcome_names)}."
+            )
+        elif not mechanism_ids:
+            statement = " ".join(outcome_statements) or (
+                f"{', '.join(variables)} was associated with changes in "
+                f"{', '.join(outcome_names)}."
+            )
+        elif "significant" in statement.casefold() and not any(
+            "significant" in evidence.source_excerpt.casefold()
+            for evidence in [
+                *[evidence_by_id[value] for value in supporting_ids],
+                *[
+                    evidence_by_id[value]
+                    for value in context_ids
+                    if value in evidence_by_id
+                ],
+            ]
+        ):
+            statement = " ".join(outcome_statements) or (
+                f"{', '.join(variables)} was associated with changes in "
+                f"{', '.join(outcome_names)}."
+            )
+        if finding_level == "paper":
+            statement = (
+                f"{statement.rstrip()} This relationship is directly supported "
+                "by one paper."
             )
         conditions = _dedupe(_text(value) for value in _strings(candidate.get("common_conditions")))
         limitations = _dedupe(
@@ -501,7 +674,11 @@ class FindingSynthesisService:
                 "finding_level": finding_level,
                 "statement": statement,
                 "variables": variables,
-                "mediators": _strings(candidate.get("mediator_concepts")),
+                "mediators": (
+                    _strings(candidate.get("mediator_concepts"))
+                    if mechanism_ids
+                    else ()
+                ),
                 "outcomes": outcome_names,
                 "direction": direction,
                 "scope_summary": "; ".join(conditions)

--- a/backend/application/core/semantic_build/llm/extractor.py
+++ b/backend/application/core/semantic_build/llm/extractor.py
@@ -50,8 +50,11 @@ _TABLE_BATCH_PROVIDER_PARSE_MAX_COMPLETION_TOKENS = 4096
 _DOCUMENT_PROFILE_MAX_COMPLETION_TOKENS = 1024
 _PAPER_SKIM_MAX_COMPLETION_TOKENS = 1024
 _RESEARCH_OBJECTIVE_DISCOVERY_MAX_COMPLETION_TOKENS = 1400
+_RESEARCH_AXIS_CANONICALIZATION_MAX_COMPLETION_TOKENS = 2048
+_RESEARCH_OBJECTIVE_MERGE_MAX_COMPLETION_TOKENS = 2048
+_OBJECTIVE_PAPER_FRAME_MAX_COMPLETION_TOKENS = 1024
 _OBJECTIVE_EVIDENCE_SELECTION_MAX_COMPLETION_TOKENS = 512
-_OBJECTIVE_EVIDENCE_MAX_COMPLETION_TOKENS = 1024
+_OBJECTIVE_EVIDENCE_MAX_COMPLETION_TOKENS = 2048
 _FINDING_SYNTHESIS_MAX_COMPLETION_TOKENS = 2048
 _TRACE_TEXT_LIMIT = 8000
 _TRACE_JSON_LIMIT = 12000
@@ -59,6 +62,51 @@ _SUPPORTED_EXTRACTION_MODES = {
     _EXTRACTION_MODE_JSON_TEXT,
     _EXTRACTION_MODE_PROVIDER_PARSE,
 }
+_EVIDENCE_CONTEXT_FIELDS = (
+    "material_system",
+    "sample_context",
+    "process_context",
+    "resolved_condition",
+    "test_condition",
+    "value_payload",
+    "baseline_context",
+)
+
+
+def _filter_source_supported_mapping(
+    value: dict[str, Any],
+    *,
+    authority_text: str,
+) -> dict[str, Any]:
+    normalized_authority = re.sub(r"\s+", " ", authority_text.casefold())
+
+    def is_supported(candidate: Any) -> bool:
+        text = re.sub(r"\s+", " ", str(candidate).strip().casefold())
+        if not text:
+            return False
+        if len(text) <= 3 or re.fullmatch(r"[-+]?\d+(?:\.\d+)?", text):
+            return re.search(
+                rf"(?<![\w.]){re.escape(text)}(?![\w.])",
+                normalized_authority,
+            ) is not None
+        return text in normalized_authority
+
+    filtered: dict[str, Any] = {}
+    for key, candidate in value.items():
+        if isinstance(candidate, dict):
+            nested = _filter_source_supported_mapping(
+                candidate,
+                authority_text=authority_text,
+            )
+            if nested:
+                filtered[key] = nested
+        elif isinstance(candidate, list):
+            supported_items = [item for item in candidate if is_supported(item)]
+            if supported_items:
+                filtered[key] = supported_items
+        elif candidate is not None and is_supported(candidate):
+            filtered[key] = candidate
+    return filtered
 
 
 class CoreLLMStructuredExtractor:
@@ -231,7 +279,32 @@ class CoreLLMStructuredExtractor:
         )
         if not isinstance(response, StructuredEvidenceExtractions):
             raise TypeError("unexpected objective evidence extraction response type")
-        return response
+        authority_text = json.dumps(
+            {
+                "source": payload.get("source"),
+                "retained_evidence": (
+                    payload.get("document_state", {}).get("retained_evidence")
+                    if isinstance(payload.get("document_state"), dict)
+                    else None
+                ),
+            },
+            ensure_ascii=False,
+            default=str,
+        )
+        return StructuredEvidenceExtractions(
+            extractions=[
+                extraction.model_copy(
+                    update={
+                        field: _filter_source_supported_mapping(
+                            getattr(extraction, field),
+                            authority_text=authority_text,
+                        )
+                        for field in _EVIDENCE_CONTEXT_FIELDS
+                    }
+                )
+                for extraction in response.extractions
+            ]
+        )
 
     def synthesize_findings(
         self,
@@ -270,9 +343,8 @@ class CoreLLMStructuredExtractor:
         try:
             use_provider_parse = (
                 self.extraction_mode == _EXTRACTION_MODE_PROVIDER_PARSE
-                and response_model is not StructuredEvidenceExtractions
                 and response_model is not StructuredDocumentProfile
-                and response_model is not StructuredEvidenceSelections
+                and response_model is not StructuredFindingSynthesis
             )
             if use_provider_parse:
                 try:
@@ -407,18 +479,36 @@ class CoreLLMStructuredExtractor:
                 _RESEARCH_OBJECTIVE_DISCOVERY_MAX_COMPLETION_TOKENS
             )
             request_kwargs["response_format"] = {"type": "json_object"}
+        elif response_model is StructuredAxisCanonicalizationPlan:
+            request_kwargs["max_completion_tokens"] = (
+                _RESEARCH_AXIS_CANONICALIZATION_MAX_COMPLETION_TOKENS
+            )
+            request_kwargs["response_format"] = {"type": "json_object"}
+        elif response_model is StructuredObjectiveMergePlan:
+            request_kwargs["max_completion_tokens"] = (
+                _RESEARCH_OBJECTIVE_MERGE_MAX_COMPLETION_TOKENS
+            )
+            request_kwargs["response_format"] = {"type": "json_object"}
+        elif response_model is StructuredPaperContributionDraft:
+            request_kwargs["max_completion_tokens"] = (
+                _OBJECTIVE_PAPER_FRAME_MAX_COMPLETION_TOKENS
+            )
+            request_kwargs["response_format"] = {"type": "json_object"}
         elif response_model is StructuredEvidenceSelections:
             request_kwargs["max_completion_tokens"] = (
                 _OBJECTIVE_EVIDENCE_SELECTION_MAX_COMPLETION_TOKENS
             )
+            request_kwargs["response_format"] = {"type": "json_object"}
         elif response_model is StructuredEvidenceExtractions:
             request_kwargs["max_completion_tokens"] = (
                 _OBJECTIVE_EVIDENCE_MAX_COMPLETION_TOKENS
             )
+            request_kwargs["response_format"] = {"type": "json_object"}
         elif response_model is StructuredFindingSynthesis:
             request_kwargs["max_completion_tokens"] = (
                 _FINDING_SYNTHESIS_MAX_COMPLETION_TOKENS
             )
+            request_kwargs["response_format"] = {"type": "json_object"}
         last_error: Exception | None = None
         for attempt in range(2):
             attempt_kwargs = dict(request_kwargs)
@@ -448,12 +538,41 @@ class CoreLLMStructuredExtractor:
                         "Do not output analysis, markdown, copied input, or extra "
                         "fields."
                     )
+                elif response_model is StructuredEvidenceSelections:
+                    retry_instruction = (
+                        "Previous evidence routing output failed validation: "
+                        f"{_trace_text(last_error, 400)}. Return one compact JSON "
+                        "object with exactly one top-level key: selections. Each "
+                        "selection may contain only role, extractable, and "
+                        "confidence. Use {\"selections\":[]} when the current "
+                        "source is not useful. Do not output analysis, markdown, "
+                        "source fields, or copied input."
+                    )
+                elif response_model is StructuredEvidenceExtractions:
+                    retry_instruction = (
+                        "Previous evidence extraction output failed validation: "
+                        f"{_trace_text(last_error, 400)}. Return one compact JSON "
+                        "object with exactly one top-level key: extractions. "
+                        "Return at most one schema-valid extraction or use "
+                        "{\"extractions\":[]}. Do not output analysis, markdown, "
+                        "source refs, evidence ids, source text, or copied input."
+                    )
+                elif response_model is StructuredFindingSynthesis:
+                    retry_instruction = (
+                        "Previous Finding synthesis output failed validation: "
+                        f"{_trace_text(last_error, 400)}. Return one compact JSON "
+                        "object with exactly one top-level key: findings. Return "
+                        "at most one schema-valid Finding or use "
+                        "{\"findings\":[]}. For one directly supporting paper, "
+                        "use insufficient_confirmation and say it is directly "
+                        "supported by one paper. Do not output analysis, markdown, "
+                        "or copied input."
+                    )
                 else:
                     retry_instruction = (
                         "Previous output was invalid. Return only the smallest valid "
                         "JSON object matching the schema. Do not explain, repeat the "
-                        "prompt, or include markdown. For finding synthesis, return "
-                        "at most one finding."
+                        "prompt, or include markdown."
                     )
                 attempt_messages = [
                     *messages,
@@ -554,6 +673,18 @@ class CoreLLMStructuredExtractor:
         elif response_model is StructuredResearchObjectives:
             request_kwargs["max_completion_tokens"] = (
                 _RESEARCH_OBJECTIVE_DISCOVERY_MAX_COMPLETION_TOKENS
+            )
+        elif response_model is StructuredAxisCanonicalizationPlan:
+            request_kwargs["max_completion_tokens"] = (
+                _RESEARCH_AXIS_CANONICALIZATION_MAX_COMPLETION_TOKENS
+            )
+        elif response_model is StructuredObjectiveMergePlan:
+            request_kwargs["max_completion_tokens"] = (
+                _RESEARCH_OBJECTIVE_MERGE_MAX_COMPLETION_TOKENS
+            )
+        elif response_model is StructuredPaperContributionDraft:
+            request_kwargs["max_completion_tokens"] = (
+                _OBJECTIVE_PAPER_FRAME_MAX_COMPLETION_TOKENS
             )
         elif response_model is StructuredEvidenceSelections:
             request_kwargs["max_completion_tokens"] = (

--- a/backend/application/core/semantic_build/llm/prompts.py
+++ b/backend/application/core/semantic_build/llm/prompts.py
@@ -4,7 +4,7 @@ import json
 from typing import Any
 
 
-FINDING_SYNTHESIS_PROMPT_VERSION = "finding_synthesis.v1"
+FINDING_SYNTHESIS_PROMPT_VERSION = "finding_synthesis.v2"
 
 
 _COMMON_SYSTEM_PROMPT = """
@@ -262,6 +262,66 @@ only reject form. The response ends immediately after the JSON object.
 """.strip()
 
 
+_RESEARCH_AXIS_CANONICALIZATION_SYSTEM_PROMPT = """
+TASK MODEL
+You normalize labels already attached to discovered research objectives. Group
+only equivalent material, process, or property labels. This is label
+canonicalization, not objective discovery, merge, extraction, or synthesis.
+
+INPUT SCHEMA
+- `axis_candidates.material`, `.process`, and `.property` contain the complete
+  allowed labels for each axis type.
+- `paper_skims` supplies collection context only. It cannot supply new labels.
+
+DECISION PROCESS
+1. Process each axis type independently.
+2. Group only spelling, acronym, singular/plural, or wording variants that name
+   the same scientific axis.
+3. Copy one alias as `canonical`; never invent a normalized label.
+4. Keep uncertain or scientifically distinct labels in separate groups.
+5. Ensure every input label appears exactly once in its own axis type.
+
+HARD RULES
+- Return exactly one JSON object with one top-level key: `axis_groups`.
+- Never mix axis types or return labels absent from `axis_candidates`.
+- Return no analysis, markdown, copied input, or extra fields.
+
+OUTPUT CONTRACT
+Use `{"axis_groups":[]}` when there are no labels. Each group contains exactly
+`axis_type`, `canonical`, `aliases`, `confidence`, and `reason`.
+""".strip()
+
+
+_RESEARCH_OBJECTIVE_MERGE_SYSTEM_PROMPT = """
+TASK MODEL
+You decide whether already-discovered research objectives represent the same
+material-process-property comparison. This is objective merge, not discovery,
+axis canonicalization, evidence extraction, or synthesis.
+
+INPUT SCHEMA
+- `candidate_objectives` contains the only objectives and ids that may be
+  returned.
+- `paper_skims` provides paper-level context for merge decisions only.
+
+DECISION PROCESS
+1. Compare material scope, changed process variables, measured properties, and
+   comparison intent.
+2. Merge only candidates expressing the same relationship. Keep different
+   research directions separate.
+3. Preserve a singleton group when no merge is justified.
+4. Assign every candidate id to exactly one output group.
+
+HARD RULES
+- Return exactly one JSON object with one top-level key: `merged_objectives`.
+- Copy every `source_objective_id` from the input and never invent axes.
+- Return no analysis, markdown, copied input, or extra fields.
+
+OUTPUT CONTRACT
+Use `{"merged_objectives":[]}` only for an empty candidate list. Every group
+contains exactly the fields required by the supplied JSON schema.
+""".strip()
+
+
 _OBJECTIVE_PAPER_FRAME_SYSTEM_PROMPT = """
 You are framing one paper against one research objective for an evidence-backed literature comparison backend.
 
@@ -277,44 +337,110 @@ Non-negotiable rules:
 
 
 _OBJECTIVE_EVIDENCE_ROUTE_SYSTEM_PROMPT = """
-You are routing source units for one research objective in an evidence-backed literature comparison backend.
+TASK MODEL
+You classify one `current_source` unit for later objective-scoped evidence
+extraction. This is source routing, not extraction, summarization, or synthesis.
 
-Non-negotiable rules:
-- This is routing only, not final fact extraction.
-- Return exactly one JSON object and nothing else.
-- Decide only the `current_source` unit and return at most one route.
-- Do not return source identity fields; the backend binds the route to the
-  current source unit.
-- Do not emit measurement results, sample variants, evidence anchors, or backend persistence ids.
-- Do not output table schemas, column roles, join keys, join plans, source text, sample rows, explanations, or copied input JSON.
-- For low-value, review, literature-comparison, composition-only, or unrelated
-  units, return an empty `routes` array instead of writing a low-value route
-  unless the source is explicitly frame-excluded.
-- Prefer fewer, higher-confidence extractable routes over speculative coverage.
+INPUT SCHEMA
+- `objective` is the active research question and requested axes.
+- `objective_context.target_property_axes` are outcomes that answer the goal;
+  `mediator_axes` are explanatory unless explicitly linked to a target outcome.
+- `paper_frame` states the paper's relevance and useful sections/tables.
+- `tree_position` locates the current unit in the paper.
+- `document_state` contains evidence already retained from earlier units.
+- `current_source` is the only unit to classify.
+
+DECISION PROCESS
+1. Reject references, literature summaries, composition-only content, and units
+   unrelated to the active objective.
+2. Use `current_experimental_evidence` for current-paper target results, trends,
+   comparisons, or explicit author interpretations.
+3. Use `process_or_treatment` or `test_condition` for source units needed to
+   bind variables, samples, methods, or environments.
+4. Use `characterization` for objective-relevant microstructure, defect, phase,
+   morphology, or grain observations.
+5. Return one selection only when later extraction is useful; otherwise reject.
+
+HARD RULES
+- Return exactly one JSON object with one top-level key: `selections`.
+- A selection contains only `role`, `extractable`, and `confidence`.
+- Do not return source ids, source text, explanations, schemas, results, or
+  copied input.
+
+BOUNDARY EXAMPLES
+- A Results paragraph comparing elongation before and after preheating returns
+  `current_experimental_evidence` with `extractable: true`.
+- A Methods paragraph giving build-platform temperature returns
+  `process_or_treatment` with `extractable: true`.
+- A bibliography entry or unrelated composition paragraph returns
+  `{"selections":[]}`.
+
+OUTPUT CONTRACT
+Return either `{"selections":[]}` or one compact selection. The response ends
+immediately after the JSON object.
 """.strip()
 
 
 _OBJECTIVE_EVIDENCE_SYSTEM_PROMPT = """
-You are extracting objective-scoped evidence for an evidence-backed literature comparison backend.
+TASK MODEL
+You extract at most one objective-relevant fact from one selected source unit.
+This is evidence extraction, not routing, paper summarization, or Finding
+synthesis.
 
-Non-negotiable rules:
-- This is final evidence extraction for one research objective and one selected source.
-- Return exactly one JSON object and nothing else.
-- Extract only facts directly supported by `source`; do not use outside knowledge.
-- Use the `objective`, `objective_context`, and `evidence_route` as the research lens.
-- Do not emit backend persistence ids.
-- The backend binds `source_refs` from the active route/source.
-- Do not output `source_refs`, `evidence_anchor_ids`, backend ids, copied source text, or copied input JSON.
-- Prefer fewer, traceable extractions over broad speculative coverage.
-- Return at most one extraction for the current source.
+INPUT SCHEMA
+- `objective` and `objective_context` define the target relationship.
+- `paper_frame` supplies bounded paper-level material, variable, and property
+  context.
+- `evidence_route.role` states why this source was selected.
+- `tree_position` and `document_state` provide local continuity but cannot
+  override the current source.
+- `source` is the only authority for the returned fact. Table cells are the
+  authoritative table structure when present.
+- The objective and paper frame are not factual evidence. Earlier retained
+  evidence in `document_state` may bind context only when it contains the exact
+  reported value or label.
+
+DECISION PROCESS
+1. Verify that `source` supports the active objective and route role.
+2. Select the single strongest target measurement, comparison, condition,
+   process context, characterization, or interpretation.
+3. Bind the property, value or trend, material/sample/process context, test
+   condition, and comparison keys only when explicitly supported.
+4. Use `resolved` only when the source binds the fact sufficiently; otherwise
+   use `partial` or reject with an empty array.
+5. Prefer an empty result over a speculative or literature-derived fact.
+
+HARD RULES
+- Return exactly one JSON object with one top-level key: `extractions`.
+- Return at most one extraction and no hidden reasoning.
+- Do not return source refs, evidence ids, copied source text, or copied input.
+- A measurement must include a numeric or qualitative result in
+  `value_payload`.
+- Every non-empty context value must appear in `source` or exact retained
+  evidence. Never infer sample ids, standards, orientations, temperatures,
+  process names, or baseline labels from domain conventions.
+
+BOUNDARY EXAMPLES
+- A row reporting non-preheated/preheated elongation of 72/82% may return one
+  `measurement` with `property_normalized: "elongation"` and both comparison
+  values in `value_payload`; unrelated context dictionaries remain empty.
+- A paragraph reporting only a build-platform temperature may return one
+  `process_context` extraction.
+- A bibliography entry, unsupported inference, or unrelated result returns
+  `{"extractions":[]}`.
+
+OUTPUT CONTRACT
+Return `{"extractions":[]}` or one compact schema-valid extraction. Omit
+unsupported optional content and end immediately after the JSON object.
 """.strip()
 
 
 _FINDING_SYNTHESIS_SYSTEM_PROMPT = """
 TASK MODEL
-You are the cross-paper evidence judge for one materials-literature goal. Run
-one goal-level synthesis pass over evidence already extracted while traversing
-the candidate papers. Produce final Findings for materials experts. This is
+You are the cross-paper evidence judge for one relationship within a
+materials-literature goal. Evaluate the supplied result set using evidence
+already extracted from the candidate papers. Produce one final Finding for
+materials experts. This is
 evidence synthesis, not source extraction, routing, paper-by-paper generation,
 field clustering, or a general literature summary.
 
@@ -335,7 +461,7 @@ INPUT SCHEMA
 
 DECISION PROCESS
 1. Read the objective and ignore relationships that do not answer it.
-2. Treat each `result_set` independently. If it answers the objective, emit at
+2. Evaluate the supplied `result_set`. If it answers the objective, emit at
    most one Finding and copy its `result_set_id`. Keep its linked measured
    outcomes together; never emit one Finding per result unit.
 3. Build `source_concept` from `source_axes` only. Put fixed values in
@@ -358,7 +484,7 @@ DECISION PROCESS
    before performance outcomes. Preserve decisive values and explicit regime
    limits without strengthening association into causation.
 8. Count only papers whose direct-result ids are assigned to an outcome. Return
-   the smallest set of goal-answering Findings.
+   one Finding or an empty array.
 
 HARD RULES
 - Return exactly one JSON object and nothing else.
@@ -391,6 +517,10 @@ HARD RULES
   qualification instead of foregrounding a small endpoint delta.
 - A single-paper composite statement must say that it is directly supported by
   one paper and use `insufficient_confirmation`.
+- Do not use `significant`, `significantly`, `statistically significant`, or
+  `no significant effect` unless a supporting source explicitly reports that
+  statistical conclusion. A small numeric difference alone is not a
+  significance test; report the measured values instead.
 - Do not convert association into control or causation.
 - If no goal-relevant direct result exists, return an empty `findings` array.
 
@@ -871,7 +1001,7 @@ def build_research_axis_canonicalization_prompt(
         "For each group, provide a short reason grounded in the labels and paper "
         "skim context.\n"
     )
-    return _RESEARCH_OBJECTIVE_SYSTEM_PROMPT, user_prompt
+    return _RESEARCH_AXIS_CANONICALIZATION_SYSTEM_PROMPT, user_prompt
 
 
 def build_research_objective_merge_prompt(
@@ -906,7 +1036,7 @@ def build_research_objective_merge_prompt(
         "`comparison_intent`, and a short `reason` explaining why the sources "
         "were merged or kept separate.\n"
     )
-    return _RESEARCH_OBJECTIVE_SYSTEM_PROMPT, user_prompt
+    return _RESEARCH_OBJECTIVE_MERGE_SYSTEM_PROMPT, user_prompt
 
 
 def build_objective_paper_frame_prompt(
@@ -942,9 +1072,9 @@ def build_objective_evidence_route_prompt(
     user_prompt = (
         "Route the current source unit for this one research objective.\n\n"
         f"Input JSON:\n{json.dumps(payload, ensure_ascii=False, indent=2)}\n\n"
-        "Return only schema-valid structured data with a `routes` array.\n"
+        "Return only schema-valid structured data with a `selections` array.\n"
         "Return at most one route for `current_source`. If it is not useful "
-        "for later objective-scoped extraction, return `{\"routes\": []}`.\n"
+        "for later objective-scoped extraction, return `{\"selections\": []}`.\n"
         "Each route may contain only `role`, `extractable`, and `confidence`. "
         "Do not return `source_kind`, `source_ref`, ids, copied source text, "
         "explanations, or any nested input object.\n"
@@ -1037,8 +1167,8 @@ def build_finding_synthesis_prompt(
         "result sets.\n\n"
         f"Input JSON:\n{input_json}\n\n"
         "Return only schema-valid structured data with a `findings` array.\n"
-        "Return at most 6 Findings, ordered by relevance to the goal.\n"
-        "For each candidate result set, compare the cited direct "
+        "Return at most one Finding for the supplied result set.\n"
+        "Compare its cited direct "
         "evidence by document and condition before choosing `synthesis_status`:\n"
         "- `agreement`: at least two independent papers provide comparable direct "
         "results with the same scientific direction.\n"

--- a/backend/application/core/semantic_build/research_objective_service.py
+++ b/backend/application/core/semantic_build/research_objective_service.py
@@ -3278,6 +3278,14 @@ class ResearchObjectiveService:
     ) -> tuple[Any, str, dict[str, Any]] | None:
         best: tuple[int, int, Any, str, dict[str, Any]] | None = None
         for position, block in enumerate(blocks):
+            heading_key = self._objective_column_key(
+                getattr(block, "heading_path", "")
+            )
+            if any(
+                section in {"references", "bibliography"}
+                for section in heading_key.split("_")
+            ):
+                continue
             text = str(getattr(block, "text", "") or "").strip()
             if not text:
                 continue
@@ -5955,6 +5963,22 @@ class ResearchObjectiveService:
                     route=route,
                     document_tree=document_tree,
                 )
+            node = (
+                self._tree_node_for_route_source(
+                    document_tree=document_tree,
+                    source_ref_kind="block",
+                    source_ref_id=source_block_id,
+                )
+                if document_tree is not None
+                else None
+            )
+            if (
+                node is not None
+                and self._tree_node_in_reference_branch(document_tree, node)
+            ) or "references" in self._objective_column_key(
+                getattr(block, "heading_path", "")
+            ):
+                return {}
             text = str(getattr(block, "text", "") or "").strip()
             return {
                 "source_kind": "text_window",

--- a/backend/tests/unit/services/test_core_llm_extractor.py
+++ b/backend/tests/unit/services/test_core_llm_extractor.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 
 from application.core.semantic_build.llm.extractor import CoreLLMStructuredExtractor
 from application.core.semantic_build.llm.prompts import (
+    build_objective_evidence_route_prompt,
     build_objective_evidence_prompt,
     build_finding_synthesis_prompt,
     build_paper_skim_prompt,
@@ -210,7 +211,7 @@ def test_core_llm_extractor_defaults_to_provider_parse_mode(monkeypatch):
 
 def test_core_llm_extractor_synthesizes_goal_findings_with_distinct_trace():
     parsed = StructuredFindingSynthesis(findings=[])
-    client = _FakeOpenAIClient("unused", parsed=parsed)
+    client = _FakeOpenAIClient('{"findings": []}', parsed=parsed)
     extractor = CoreLLMStructuredExtractor(client=client, model="fake-model")
     payload = {
         "objective": {"question": "How does energy density affect density?"},
@@ -239,13 +240,15 @@ def test_core_llm_extractor_synthesizes_goal_findings_with_distinct_trace():
     result = extractor.synthesize_findings(payload)
 
     assert result == parsed
-    parse_call = client.beta.chat.completions.calls[0]
-    assert parse_call["response_format"] is StructuredFindingSynthesis
-    assert parse_call["max_completion_tokens"] == 2048
+    assert client.beta.chat.completions.calls == []
+    text_call = client.chat.completions.calls[0]
+    assert text_call["response_format"] == {"type": "json_object"}
+    assert text_call["max_completion_tokens"] == 2048
     trace = extractor.consume_last_trace()
     assert trace is not None
     assert trace["task_type"] == "finding_synthesis"
-    assert trace["prompt_version"] == "finding_synthesis.v1"
+    assert trace["prompt_version"] == "finding_synthesis.v2"
+    assert trace["extraction_mode"] == "json_text"
     assert trace["parsed_output"] == {"findings": []}
 
 
@@ -262,9 +265,12 @@ def test_core_llm_extractor_bounds_json_text_finding_synthesis_output():
 
     assert result == StructuredFindingSynthesis(findings=[])
     assert client.chat.completions.calls[0]["max_completion_tokens"] == 2048
+    assert client.chat.completions.calls[0]["response_format"] == {
+        "type": "json_object"
+    }
 
 
-def test_finding_synthesis_prompt_uses_goal_level_contract():
+def test_finding_synthesis_prompt_uses_relationship_level_contract():
     payload = {
         "objective": {"question": "How does energy density affect density?"},
         "result_sets": [],
@@ -276,7 +282,8 @@ def test_finding_synthesis_prompt_uses_goal_level_contract():
 
     assert "INPUT SCHEMA" in system_prompt
     assert "DECISION PROCESS" in system_prompt
-    assert "one goal-level synthesis pass" in system_prompt
+    assert "one relationship within" in system_prompt
+    assert "Produce one final Finding" in system_prompt
     normalized_system_prompt = " ".join(system_prompt.split())
     assert "paper_contributions" in normalized_system_prompt
     assert "cannot replace direct evidence" in normalized_system_prompt
@@ -315,12 +322,18 @@ def test_finding_synthesis_prompt_uses_goal_level_contract():
         normalized_system_prompt
     )
     assert "directly supported by one paper" in normalized_system_prompt
+    assert "A small numeric difference alone is not a significance test" in (
+        normalized_system_prompt
+    )
     assert "cannot increase the contributing paper count" in normalized_system_prompt
     outcome_schema = StructuredFindingSynthesisOutcome.model_json_schema()
     assert "supporting_evidence_ids" not in outcome_schema["properties"]
     assert "backend binds all matching direct-result ids" in normalized_system_prompt
     assert "`agreement`: at least two independent papers" in user_prompt
     assert "`insufficient_confirmation`" in user_prompt
+    assert "only one paper provides a direct result" in user_prompt
+    assert "directly supported by one paper" in normalized_system_prompt
+    assert "Return at most one Finding" in user_prompt
     assert json.dumps(payload, ensure_ascii=False, separators=(",", ":")) in user_prompt
 
 
@@ -593,6 +606,9 @@ def test_core_llm_extractor_validates_axis_canonicalization_response():
 
     assert isinstance(canonicalization_plan, StructuredAxisCanonicalizationPlan)
     assert canonicalization_plan.axis_groups[0].canonical == "scanning strategy"
+    text_call = client.chat.completions.calls[0]
+    assert text_call["max_completion_tokens"] == 2048
+    assert text_call["response_format"] == {"type": "json_object"}
 
 
 def test_core_llm_extractor_validates_research_objective_merge_response():
@@ -626,6 +642,9 @@ def test_core_llm_extractor_validates_research_objective_merge_response():
 
     assert isinstance(merge_plan, StructuredObjectiveMergePlan)
     assert merge_plan.merged_objectives[0].source_objective_ids == ["obj-1", "obj-2"]
+    text_call = client.chat.completions.calls[0]
+    assert text_call["max_completion_tokens"] == 2048
+    assert text_call["response_format"] == {"type": "json_object"}
 
 
 def test_core_llm_extractor_validates_objective_paper_frame_response():
@@ -660,6 +679,26 @@ def test_core_llm_extractor_validates_objective_paper_frame_response():
     assert isinstance(frame, StructuredPaperContributionDraft)
     assert frame.relevance == "high"
     assert frame.relevant_tables == ["table-1"]
+    text_call = client.chat.completions.calls[0]
+    assert text_call["max_completion_tokens"] == 1024
+    assert text_call["response_format"] == {"type": "json_object"}
+
+
+def test_objective_evidence_route_prompt_matches_selection_schema():
+    system_prompt, user_prompt = build_objective_evidence_route_prompt(
+        {
+            "collection_id": "col-1",
+            "objective": {"question": "How does heat treatment affect corrosion?"},
+            "paper_frame": {"relevance": "high"},
+            "current_source": {"source_kind": "text_window", "text": "Result."},
+        }
+    )
+    prompt = f"{system_prompt}\n{user_prompt}"
+
+    assert "`selections`" in prompt
+    assert '{"selections":[]}' in prompt.replace(" ", "")
+    assert "`routes`" not in prompt
+    assert '{"routes":[]}' not in prompt.replace(" ", "")
 
 
 def test_core_llm_extractor_validates_objective_evidence_routes_response():
@@ -690,6 +729,8 @@ def test_core_llm_extractor_validates_objective_evidence_routes_response():
     assert isinstance(routes, StructuredEvidenceSelections)
     assert routes.selections[0].role == "current_experimental_evidence"
     assert "reason" not in routes.selections[0].model_dump()
+    text_call = client.chat.completions.calls[0]
+    assert text_call["response_format"] == {"type": "json_object"}
 
 
 def test_core_llm_extractor_rejects_legacy_objective_route_batches():
@@ -816,11 +857,14 @@ def test_core_llm_extractor_validates_objective_evidence_response():
     assert isinstance(extractions, StructuredEvidenceExtractions)
     assert extractions.extractions[0].evidence_kind == "measurement"
     assert extractions.extractions[0].resolution_status == "resolved"
-    assert client.chat.completions.calls[0]["max_completion_tokens"] == 1024
+    assert client.chat.completions.calls[0]["max_completion_tokens"] == 2048
+    assert client.chat.completions.calls[0]["response_format"] == {
+        "type": "json_object"
+    }
 
 
 def test_objective_evidence_prompt_limits_text_routes_to_one_extraction():
-    _, prompt = build_objective_evidence_prompt(
+    system_prompt, prompt = build_objective_evidence_prompt(
         {
             "collection_id": "col-1",
             "objective": {"question": "How does preheating affect 316L?"},
@@ -848,6 +892,9 @@ def test_objective_evidence_prompt_limits_text_routes_to_one_extraction():
     assert "1.43x10^6 C/s for P150" in prompt
     assert "1.65x10^6 C/s for NP" in prompt
     assert "Bad text example" in prompt
+    normalized_system_prompt = " ".join(system_prompt.split())
+    assert "objective and paper frame are not factual evidence" in normalized_system_prompt
+    assert "Never infer sample ids, standards, orientations" in normalized_system_prompt
 
 
 def test_core_llm_extractor_rejects_backend_bound_objective_evidence_fields():
@@ -1182,6 +1229,61 @@ def test_research_objective_retry_uses_task_specific_validation_contract():
     assert "For finding synthesis" not in retry_instruction
 
 
+@pytest.mark.parametrize(
+    ("method_name", "payload", "invalid_content", "response_label", "top_level_key"),
+    [
+        (
+            "select_objective_evidence",
+            {
+                "objective": {"question": "How does preheating affect elongation?"},
+                "current_source": {"source_kind": "table", "source_ref": "table-1"},
+            },
+            '{"objective":{"question":"copied input"}}',
+            "evidence routing",
+            "selections",
+        ),
+        (
+            "extract_objective_evidence",
+            {
+                "objective": {"question": "How does preheating affect elongation?"},
+                "evidence_route": {"role": "current_experimental_evidence"},
+                "source": {"source_kind": "table", "source_ref": "table-1"},
+            },
+            '{"source":{"source_kind":"table"}}',
+            "evidence extraction",
+            "extractions",
+        ),
+        (
+            "synthesize_findings",
+            {
+                "objective": {"question": "How does preheating affect elongation?"},
+                "result_sets": [{"result_set_id": "result_set_1"}],
+            },
+            '{"result_sets":[{"result_set_id":"result_set_1"}]}',
+            "Finding synthesis",
+            "findings",
+        ),
+    ],
+)
+def test_objective_pipeline_retries_use_task_specific_top_level_contract(
+    method_name,
+    payload,
+    invalid_content,
+    response_label,
+    top_level_key,
+):
+    client = _FakeOpenAIClient(invalid_content)
+    extractor = _json_text_extractor(client)
+
+    with pytest.raises(ValidationError):
+        getattr(extractor, method_name)(payload)
+
+    retry_instruction = client.chat.completions.calls[1]["messages"][-1]["content"]
+    assert f"Previous {response_label} output failed validation" in retry_instruction
+    assert f"exactly one top-level key: {top_level_key}" in retry_instruction
+    assert "copied input" in retry_instruction
+
+
 def test_core_llm_extractor_can_opt_in_to_provider_thinking(monkeypatch):
     monkeypatch.setenv("CORE_LLM_EXTRACTION_MODE", "provider_parse")
     monkeypatch.setenv("LLM_ENABLE_THINKING", "true")
@@ -1200,11 +1302,12 @@ def test_core_llm_extractor_can_opt_in_to_provider_thinking(monkeypatch):
     assert "extra_body" not in client.beta.chat.completions.calls[0]
 
 
-def test_core_llm_extractor_routes_objective_selections_directly_to_bounded_json_text(
+def test_core_llm_extractor_routes_objective_selections_with_provider_schema(
     monkeypatch,
 ):
     monkeypatch.setenv("CORE_LLM_EXTRACTION_MODE", "provider_parse")
-    client = _FakeOpenAIClient('{"selections":[]}')
+    parsed = StructuredEvidenceSelections()
+    client = _FakeOpenAIClient("unused", parsed=parsed)
     extractor = CoreLLMStructuredExtractor(client=client, model="fake-model")
 
     routes = extractor.select_objective_evidence(
@@ -1216,22 +1319,24 @@ def test_core_llm_extractor_routes_objective_selections_directly_to_bounded_json
         }
     )
 
-    assert routes == StructuredEvidenceSelections()
-    assert client.beta.chat.completions.calls == []
-    text_call = client.chat.completions.calls[0]
-    assert text_call["max_completion_tokens"] == 512
-    assert "JSON schema:" in text_call["messages"][1]["content"]
-    assert text_call["extra_body"] == {
+    assert routes == parsed
+    assert client.chat.completions.calls == []
+    parse_call = client.beta.chat.completions.calls[0]
+    assert parse_call["max_completion_tokens"] == 512
+    assert parse_call["response_format"] is StructuredEvidenceSelections
+    assert "JSON schema:" not in parse_call["messages"][1]["content"]
+    assert parse_call["extra_body"] == {
         "chat_template_kwargs": {"enable_thinking": False}
     }
-    assert extractor.consume_last_trace()["extraction_mode"] == "json_text"
+    assert extractor.consume_last_trace()["extraction_mode"] == "provider_parse"
 
 
-def test_core_llm_extractor_caps_provider_parse_completion_tokens_for_objective_units(
+def test_core_llm_extractor_extracts_objective_evidence_with_provider_schema(
     monkeypatch,
 ):
     monkeypatch.setenv("CORE_LLM_EXTRACTION_MODE", "provider_parse")
-    client = _FakeOpenAIClient('{"extractions": []}')
+    parsed = StructuredEvidenceExtractions()
+    client = _FakeOpenAIClient("unused", parsed=parsed)
     extractor = CoreLLMStructuredExtractor(client=client, model="fake-model")
 
     units = extractor.extract_objective_evidence(
@@ -1243,12 +1348,76 @@ def test_core_llm_extractor_caps_provider_parse_completion_tokens_for_objective_
         }
     )
 
-    assert units == StructuredEvidenceExtractions()
-    assert client.beta.chat.completions.calls == []
-    text_call = client.chat.completions.calls[0]
-    assert text_call["max_completion_tokens"] == 1024
-    assert "JSON schema:" in text_call["messages"][1]["content"]
-    assert extractor.consume_last_trace()["extraction_mode"] == "json_text"
+    assert units == parsed
+    assert client.chat.completions.calls == []
+    parse_call = client.beta.chat.completions.calls[0]
+    assert parse_call["max_completion_tokens"] == 2048
+    assert parse_call["response_format"] is StructuredEvidenceExtractions
+    assert "JSON schema:" not in parse_call["messages"][1]["content"]
+    assert extractor.consume_last_trace()["extraction_mode"] == "provider_parse"
+
+
+def test_core_llm_extractor_removes_unsupported_evidence_context(monkeypatch):
+    monkeypatch.setenv("CORE_LLM_EXTRACTION_MODE", "provider_parse")
+    parsed = StructuredEvidenceExtractions(
+        extractions=[
+            {
+                "evidence_kind": "measurement",
+                "property_normalized": "elongation",
+                "material_system": {"material": "316L stainless steel"},
+                "sample_context": {
+                    "condition": "non-preheated",
+                    "sample_id": "NP",
+                    "orientation": "XY",
+                },
+                "process_context": {"process": "LPBF", "power": "200 W"},
+                "test_condition": {"standard": "ASTM E8/E8M"},
+                "resolved_condition": {"temperature": "room temperature"},
+                "value_payload": {
+                    "non_preheated": 72,
+                    "preheated": 82,
+                    "cooling_rate": "1.43x10^6 C/s",
+                },
+                "baseline_context": {"condition": "non-preheated", "value": 72},
+                "join_keys": {"row_index": 1, "col_index": 1},
+                "resolution_status": "resolved",
+                "confidence": 0.95,
+            }
+        ]
+    )
+    client = _FakeOpenAIClient("unused", parsed=parsed)
+    extractor = CoreLLMStructuredExtractor(client=client, model="fake-model")
+
+    result = extractor.extract_objective_evidence(
+        {
+            "objective": {
+                "question": "How does preheating affect 316L elongation?"
+            },
+            "document_state": {"retained_evidence": []},
+            "evidence_route": {"role": "current_experimental_evidence"},
+            "source": {
+                "source_kind": "table",
+                "table_matrix": [
+                    ["Condition", "Elongation (%)"],
+                    ["Non-preheated", "72"],
+                    ["Preheated", "82"],
+                ],
+            },
+        }
+    )
+
+    extraction = result.extractions[0]
+    assert extraction.material_system == {}
+    assert extraction.sample_context == {"condition": "non-preheated"}
+    assert extraction.process_context == {}
+    assert extraction.test_condition == {}
+    assert extraction.resolved_condition == {}
+    assert extraction.baseline_context == {
+        "condition": "non-preheated",
+        "value": 72,
+    }
+    assert extraction.value_payload == {"non_preheated": 72, "preheated": 82}
+    assert extraction.join_keys == {"row_index": 1, "col_index": 1}
 
 
 def test_core_llm_extractor_validates_lightweight_table_batch_mentions():

--- a/backend/tests/unit/services/test_objective_finding_synthesis.py
+++ b/backend/tests/unit/services/test_objective_finding_synthesis.py
@@ -185,7 +185,8 @@ def test_synthesis_keeps_single_paper_finding_at_paper_level() -> None:
     assert finding.direction == "changes"
     assert finding.statement == (
         "In the reported comparison, the coupled condition defined by laser power, "
-        "scan speed was associated with changes in relative density."
+        "scan speed was associated with changes in relative density. This "
+        "relationship is directly supported by one paper."
     )
     assert finding.derivation.supporting_evidence_ids == ("ev-1",)
     assert finding.relations[0].assertion_strength == "associative"
@@ -218,6 +219,222 @@ def test_synthesis_builds_cross_paper_finding_from_two_direct_papers() -> None:
     assert finding.generalization_status == "cross_paper_agreement"
     assert finding.paper_count == 2
     assert finding.derivation.contributing_document_ids == ("paper-1", "paper-2")
+
+
+def test_synthesis_excludes_unsourced_and_non_result_direct_evidence() -> None:
+    extractor = _Extractor([_candidate()])
+    service = FindingSynthesisService(structured_extractor=extractor)
+
+    findings = service.synthesize(
+        collection_id="col-1",
+        objective=_objective(),
+        analysis=_analysis(),
+        contributions=(_contribution("paper-1"),),
+        evidence_records=(
+            _evidence(
+                "valid-table-result",
+                "paper-1",
+                source_excerpt=(
+                    "Laser power and scan speed changed together; relative "
+                    "density increased from 96.1% to 99.2%."
+                ),
+                value_payload={"baseline_value": 96.1, "current_value": 99.2},
+            ),
+            _evidence(
+                "unsourced-value",
+                "paper-1",
+                source_excerpt="420",
+                value_payload={"value": "1.43x10^6 C/s"},
+                confidence=0.99,
+            ),
+            _evidence(
+                "study-aim",
+                "paper-1",
+                source_excerpt=(
+                    "This study aims to understand the effect of processing on "
+                    "relative density."
+                ),
+                value_payload={
+                    "value": "processing",
+                    "value_role": "control_value",
+                },
+                confidence=0.98,
+            ),
+            _evidence(
+                "study-goal",
+                "paper-1",
+                source_excerpt=(
+                    "The goal of this study is to determine whether preheating "
+                    "changes relative density."
+                ),
+                value_payload={"value": "relative density"},
+                confidence=0.98,
+            ),
+            _evidence(
+                "future-work",
+                "paper-1",
+                source_excerpt=(
+                    "Fatigue performance is assumed to improve and will be "
+                    "investigated in the next step."
+                ),
+                value_payload={"value": "improve"},
+                confidence=0.97,
+            ),
+        ),
+    )
+
+    assert len(findings) == 1
+    assert findings[0].derivation.supporting_evidence_ids == (
+        "valid-table-result",
+    )
+    assert [
+        item["evidence_id"]
+        for item in extractor.payloads[0]["result_sets"][0]["direct_evidence"]
+    ] == ["valid-table-result"]
+
+
+def test_synthesis_excludes_prior_literature_from_direct_evidence() -> None:
+    extractor = _Extractor([_candidate()])
+    service = FindingSynthesisService(structured_extractor=extractor)
+
+    findings = service.synthesize(
+        collection_id="col-1",
+        objective=_objective(),
+        analysis=_analysis(),
+        contributions=(_contribution("paper-1"),),
+        evidence_records=(
+            _evidence(
+                "measured-result",
+                "paper-1",
+                source_excerpt=(
+                    "Elongation increased from 72% without preheating to 82% "
+                    "with build-platform preheating."
+                ),
+                value_payload={"baseline_value": 72, "current_value": 82},
+            ),
+            _evidence(
+                "prior-literature",
+                "paper-1",
+                source_excerpt=(
+                    "Thermal history is controlled by the employed process "
+                    "parameters. These have been reported as the controlling "
+                    "parameters for microstructure development."
+                ),
+                value_payload={"value": "microstructure development"},
+                confidence=0.99,
+            ),
+        ),
+    )
+
+    assert len(findings) == 1
+    assert findings[0].derivation.supporting_evidence_ids == ("measured-result",)
+    assert [
+        item["evidence_id"]
+        for item in extractor.payloads[0]["result_sets"][0]["direct_evidence"]
+    ] == ["measured-result"]
+
+
+def test_synthesis_omits_mechanism_without_valid_mechanism_evidence() -> None:
+    extractor = _Extractor(
+        [
+            _candidate(
+                source_concept="laser power",
+                outcomes=[
+                    {
+                        "concept": "relative density",
+                        "direction": "increases",
+                        "statement": "Relative density increased from 96.1% to 99.2%.",
+                        "conflicting_evidence_ids": [],
+                    }
+                ],
+                mediator_concepts=["melt-pool stabilization"],
+                statement=(
+                    "Laser power increased relative density through melt-pool "
+                    "stabilization."
+                ),
+                mechanism_evidence_ids=["condition-1"],
+            )
+        ]
+    )
+    service = FindingSynthesisService(structured_extractor=extractor)
+
+    findings = service.synthesize(
+        collection_id="col-1",
+        objective=_objective(process_axes=["laser power"]),
+        analysis=_analysis(),
+        contributions=(
+            _contribution("paper-1", changed_variables=["laser power"]),
+        ),
+        evidence_records=(
+            _evidence(
+                "ev-1",
+                "paper-1",
+                join_keys={"variable_process_axes": ["laser power"]},
+            ),
+            _evidence(
+                "condition-1",
+                "paper-1",
+                role="condition_context",
+                property_name=None,
+                evidence_kind="process_context",
+            ),
+        ),
+    )
+
+    assert len(findings) == 1
+    assert findings[0].mediators == ()
+    assert findings[0].statement == (
+        "Relative density increased from 96.1% to 99.2%. This relationship is "
+        "directly supported by one paper."
+    )
+    assert "melt-pool stabilization" not in findings[0].statement
+
+
+def test_synthesis_replaces_unsupported_significance_with_measured_values() -> None:
+    extractor = _Extractor(
+        [
+            _candidate(
+                source_concept="laser power",
+                outcomes=[
+                    {
+                        "concept": "relative density",
+                        "direction": "changes",
+                        "statement": (
+                            "Laser power had no significant effect on relative "
+                            "density."
+                        ),
+                        "conflicting_evidence_ids": [],
+                    }
+                ],
+                statement=(
+                    "Laser power had no significant effect on relative density."
+                ),
+            )
+        ]
+    )
+    service = FindingSynthesisService(structured_extractor=extractor)
+
+    findings = service.synthesize(
+        collection_id="col-1",
+        objective=_objective(process_axes=["laser power"]),
+        analysis=_analysis(),
+        contributions=(
+            _contribution("paper-1", changed_variables=["laser power"]),
+        ),
+        evidence_records=(
+            _evidence(
+                "ev-1",
+                "paper-1",
+                join_keys={"variable_process_axes": ["laser power"]},
+            ),
+        ),
+    )
+
+    assert findings[0].statement == (
+        "The reported laser power comparison measured relative density values of "
+        "96.1 and 99.2%. This relationship is directly supported by one paper."
+    )
+    assert "significant" not in findings[0].statement
 
 
 def test_synthesis_prefers_comparison_evidence_over_component_measurements() -> None:

--- a/backend/tests/unit/services/test_research_objective_service.py
+++ b/backend/tests/unit/services/test_research_objective_service.py
@@ -1693,6 +1693,40 @@ def test_research_objective_text_source_payload_uses_document_tree(tmp_path):
     }
 
 
+def test_research_objective_text_source_payload_rejects_reference_block(tmp_path):
+    service = _build_research_objective_service(
+        collection_service=build_test_collection_service(tmp_path / "collections"),
+    )
+    route = EvidenceCandidate.from_mapping(
+        {
+            "objective_id": "obj-heat",
+            "document_id": "paper-1",
+            "source_kind": "text_window",
+            "source_ref": "reference-1",
+            "role": "process_or_treatment",
+            "extractable": True,
+        }
+    )
+    block = SimpleNamespace(
+        block_id="reference-1",
+        page=10,
+        block_type="list_item",
+        heading_path="References",
+        text=(
+            "W. Li et al., Effect of substrate preheating on nanohardness, "
+            "Scr. Mater. 118 (2016) 13-18. doi:10.1016/example."
+        ),
+    )
+
+    payload = service._build_objective_route_source_payload(
+        route=route,
+        blocks=[block],
+        tables=[],
+    )
+
+    assert payload == {}
+
+
 def test_objective_paper_frame_payload_prioritizes_relevant_tree_sections(tmp_path):
     service = _build_research_objective_service(
         collection_service=build_test_collection_service(tmp_path / "collections"),
@@ -4017,6 +4051,58 @@ def test_research_objective_service_builds_method_conditions_and_binds_measureme
         resolved_measurements[1].resolved_condition["test_condition_unit_id"]
         == method_units[1].evidence_id
     )
+
+
+def test_research_objective_service_method_conditions_skip_reference_blocks(
+    tmp_path,
+):
+    service = _build_research_objective_service(
+        collection_service=build_test_collection_service(tmp_path / "collections"),
+    )
+    objective_context = ObjectiveAnalysisLens.from_mapping(
+        {
+            "objective_id": "obj-mechanical",
+            "target_property_axes": ["yield strength"],
+        }
+    )
+    frame = PaperAnalysisFrame.from_mapping(
+        {
+            "objective_id": "obj-mechanical",
+            "document_id": "paper-1",
+            "relevance": "high",
+            "paper_role": "primary_experiment",
+        }
+    )
+    blocks = [
+        SimpleNamespace(
+            block_id="reference-entry",
+            page=10,
+            heading_path="References",
+            text=(
+                "Tensile stress-strain and yield strength testing using ASTM E8 "
+                "and an INSTRON machine at a controlled strain rate."
+            ),
+        ),
+        SimpleNamespace(
+            block_id="tensile-method",
+            page=5,
+            heading_path="2.2. Mechanical Testing",
+            text=(
+                "Tensile tests were performed with an INSTRON machine using "
+                "ASTM E8M specimens."
+            ),
+        ),
+    ]
+
+    method_units = service._build_objective_method_family_test_condition_units(
+        objective_contexts=(objective_context,),
+        objective_paper_frames=(frame,),
+        blocks_by_document_id={"paper-1": blocks},
+    )
+
+    assert len(method_units) == 1
+    assert method_units[0].source_refs[0]["source_ref"] == "tensile-method"
+    assert method_units[0].test_condition["standard"] == "ASTM E8M"
 
 
 def test_research_objective_service_derives_table_characterization_units(


### PR DESCRIPTION
## 概要

- 收紧研究目标路由、证据抽取和 Finding 合成的结构化输出契约
- 为不同任务配置有限重试和输出预算，避免 evidence JSON 被截断
- 过滤研究目的、既有文献、未来工作和无原文支持的值
- 阻止 References/Bibliography 进入证据与测试条件
- 保持单篇 Finding 的证据强度和机制/显著性表述边界

## 验证

- `227 passed`：研究目标、Finding、LLM extractor、API、domain 与 analysis service 相关测试
- 使用真实 316L PDF 与 `qwen3-vl-cpt-sft` 完成 Objective analysis v3
- Finding 正确引用当前论文 tensile result 与表 2（448→465 MPa、72→82%、617→618 MPa）
- page 1 既有文献、page 10 References 和无依据显著性结论未进入支持链

## 影响

不改变 HTTP API、持久化合同或前端状态模型。

Refs: #265, #268