### PR TITLE
chore(release): 准备 v0.11.9

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -297,7 +297,7 @@ def create_app(
 
     app = FastAPI(
         title="TsingAI-Lens API",
-        version="0.11.8",
+        version="0.11.9",
         docs_url=f"{PUBLIC_API_PREFIX}/docs",
         redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
         openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsingai-lens"
-version = "0.11.8"
+version = "0.11.9"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.11.8",
+	"version": "0.11.9",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## 发布内容

- 统一 ResearchObjective、ObjectiveEvidence 和原子 Finding 科学合同。
- 修复 Evidence 提示词负载、非 JSON 输出和 schema repair 失败问题。
- 统一专家反馈、训练导出、研究工作区、AI Chat 与实验方案对同一 Finding/Evidence 版本的消费。
- 将前后端版本统一更新为 0.11.9。

## 升级说明

本版本包含不可逆迁移 20260802_0020 至 0023。升级后保留 Source 文档与解析数据，但已有 Objective 分析需要重新运行；无法无损转换的旧 curation 需要重新复核。

## 验证

- Backend targeted suites: 283 passed
- Migration lifecycle: 5 passed, 2 skipped（未配置真实 PostgreSQL）
- Frontend svelte-check: 0 errors, 0 warnings
- Frontend unit/component: 129 passed
- Docs governance: passed
- Version surfaces: backend package、FastAPI、frontend 均为 0.11.9

Release source: #291