### PR TITLE
bugfix(core): make objective analysis reviewable

### DIFF
--- a/backend/application/core/finding_synthesis_service.py
+++ b/backend/application/core/finding_synthesis_service.py
@@ -85,57 +85,71 @@ class FindingSynthesisService:
                 evidence_records,
                 result_documents,
             )
-            try:
-                parsed = self.structured_extractor.synthesize_findings(
-                    {
-                        "objective": objective_payload,
-                        "paper_contributions": contribution_payloads,
-                        "result_set": result_set,
-                        "context_evidence": [
-                            self._evidence_payload(evidence)
-                            for evidence in context_evidence
-                        ],
-                    }
-                )
-            except Exception:  # noqa: BLE001
-                logger.exception(
-                    "Finding synthesis failed result_set_id=%s",
-                    result_set["result_set_id"],
-                )
-                continue
-            parsed_record = (
-                parsed.model_dump() if hasattr(parsed, "model_dump") else dict(parsed)
-            )
             expected_result_set_id = str(result_set["result_set_id"])
-            candidates = _mapping_list(parsed_record.get("findings"))
-            if not candidates:
-                logger.warning(
-                    "Finding synthesis returned no candidate result_set_id=%s "
-                    "factors=%s outcome=%s result_evidence=%s",
-                    expected_result_set_id,
-                    _strings(result_set.get("factors")),
-                    _text(result_set.get("outcome")),
-                    [
-                        {
-                            "evidence_id": _text(item.get("evidence_id")),
-                            "document_id": _text(item.get("document_id")),
-                            "direction": _text(
-                                (
-                                    item.get("reported_result")
-                                    if isinstance(
-                                        item.get("reported_result"), Mapping
-                                    )
-                                    else {}
-                                ).get("direction")
-                            ),
-                            "attribution_scope": _text(
-                                item.get("attribution_scope")
-                            ),
-                        }
-                        for item in _mapping_list(result_set.get("result_evidence"))
-                    ],
+            synthesis_payload = {
+                "objective": objective_payload,
+                "paper_contributions": contribution_payloads,
+                "result_set": result_set,
+                "context_evidence": [
+                    self._evidence_payload(evidence) for evidence in context_evidence
+                ],
+            }
+            candidate_rejection: dict[str, Any] | None = None
+            for semantic_attempt in range(2):
+                request_payload = dict(synthesis_payload)
+                if candidate_rejection is not None:
+                    request_payload["candidate_rejection"] = candidate_rejection
+                try:
+                    parsed = self.structured_extractor.synthesize_findings(
+                        request_payload
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.exception(
+                        "Finding synthesis failed result_set_id=%s semantic_attempt=%s",
+                        expected_result_set_id,
+                        semantic_attempt + 1,
+                    )
+                    break
+                parsed_record = (
+                    parsed.model_dump()
+                    if hasattr(parsed, "model_dump")
+                    else dict(parsed)
                 )
-            for candidate in candidates:
+                candidates = _mapping_list(parsed_record.get("findings"))
+                if not candidates:
+                    logger.warning(
+                        "Finding synthesis returned no candidate result_set_id=%s "
+                        "factors=%s outcome=%s result_evidence=%s",
+                        expected_result_set_id,
+                        _strings(result_set.get("factors")),
+                        _text(result_set.get("outcome")),
+                        [
+                            {
+                                "evidence_id": _text(item.get("evidence_id")),
+                                "document_id": _text(item.get("document_id")),
+                                "direction": _text(
+                                    (
+                                        item.get("reported_result")
+                                        if isinstance(
+                                            item.get("reported_result"), Mapping
+                                        )
+                                        else {}
+                                    ).get("direction")
+                                ),
+                                "attribution_scope": _text(
+                                    item.get("attribution_scope")
+                                ),
+                            }
+                            for item in _mapping_list(
+                                result_set.get("result_evidence")
+                            )
+                        ],
+                    )
+                    break
+                candidate = {
+                    **candidates[0],
+                    "result_set_id": expected_result_set_id,
+                }
                 logger.debug(
                     "Inspecting Finding synthesis candidate result_set_id=%s "
                     "result_evidence_count=%s direction=%s assertion_strength=%s "
@@ -148,22 +162,36 @@ class FindingSynthesisService:
                     _text(result_set.get("outcome")),
                     _text(candidate.get("statement")),
                 )
-                if _text(candidate.get("result_set_id")) != expected_result_set_id:
-                    continue
-                finding = self._finding_from_candidate(
-                    collection_id=collection_id,
-                    objective=objective,
-                    analysis=analysis,
-                    candidate=candidate,
-                    result_set=result_set,
-                    context_evidence=context_evidence,
-                    contributions=contributions,
-                    evidence_by_id=evidence_by_id,
-                    display_rank=len(findings),
-                )
-                if finding is not None:
-                    findings.append(finding)
+                try:
+                    finding = self._finding_from_candidate(
+                        collection_id=collection_id,
+                        objective=objective,
+                        analysis=analysis,
+                        candidate=candidate,
+                        result_set=result_set,
+                        context_evidence=context_evidence,
+                        contributions=contributions,
+                        evidence_by_id=evidence_by_id,
+                        display_rank=len(findings),
+                    )
+                except ValueError as exc:
+                    rejection_reason = str(exc)
+                    logger.warning(
+                        "Rejected Finding candidate result_set_id=%s reason=%s "
+                        "semantic_repair_attempted=%s",
+                        expected_result_set_id,
+                        rejection_reason,
+                        semantic_attempt > 0,
+                    )
+                    if semantic_attempt == 0:
+                        candidate_rejection = {
+                            "reason": rejection_reason,
+                            "previous_candidate": candidate,
+                        }
+                        continue
                     break
+                findings.append(finding)
+                break
         return tuple(findings)
 
     @staticmethod
@@ -353,7 +381,7 @@ class FindingSynthesisService:
         contributions: tuple[PaperContribution, ...],
         evidence_by_id: Mapping[str, ObjectiveEvidence],
         display_rank: int,
-    ) -> Finding | None:
+    ) -> Finding:
         result_ids = tuple(
             evidence_id
             for item in _mapping_list(result_set.get("result_evidence"))
@@ -364,7 +392,7 @@ class FindingSynthesisService:
             evidence_by_id[evidence_id].reported_result is None
             for evidence_id in result_ids
         ):
-            return None
+            raise ValueError("result set lacks complete reported-result Evidence")
         supporting_ids = tuple(
             evidence_id
             for evidence_id in result_ids
@@ -376,20 +404,22 @@ class FindingSynthesisService:
             if evidence_by_id[evidence_id].reported_result.direction != direction
         )
         if not supporting_ids:
-            return None
+            raise ValueError(
+                f"candidate direction {direction} has no supporting result Evidence"
+            )
         if any(
             evidence_by_id[evidence_id].evidence_role
             not in {"direct_result", "contradictory_result"}
             for evidence_id in (*supporting_ids, *contradicting_ids)
         ):
-            return None
+            raise ValueError("candidate references non-result Evidence as direct support")
 
         allowed_context_ids = {item.evidence_id for item in context_evidence}
         context_ids = self._candidate_evidence_ids(candidate, "context_evidence_ids")
         if context_ids is None:
-            return None
+            raise ValueError("candidate context_evidence_ids are malformed")
         if not set(context_ids) <= allowed_context_ids:
-            return None
+            raise ValueError("candidate references unavailable context Evidence")
         mechanisms: list[dict[str, Any]] = []
         mechanism_ids: list[str] = []
         for mechanism in _mapping_list(candidate.get("mechanisms")):
@@ -413,15 +443,21 @@ class FindingSynthesisService:
         outcome = _text(result_set.get("outcome"))
         statement = _text(candidate.get("statement"))
         if not factors or not outcome or not statement:
-            return None
+            raise ValueError("candidate lacks factors, outcome, or statement")
         if not self._statement_covers_atomic_result(statement, factors, outcome):
-            return None
+            raise ValueError(
+                "candidate statement does not contain the complete factor tuple "
+                "and outcome"
+            )
         if self._statement_mentions_unbound_objective_factor(
             statement,
             factors,
             objective.variables,
         ):
-            return None
+            raise ValueError(
+                "candidate statement introduces an Objective factor absent from "
+                "the result set"
+            )
         supporting_evidence = tuple(
             evidence_by_id[evidence_id] for evidence_id in supporting_ids
         )
@@ -429,7 +465,10 @@ class FindingSynthesisService:
             statement,
             supporting_evidence,
         ):
-            return None
+            raise ValueError(
+                "candidate statement combines numeric values not bound to one "
+                "supporting Evidence record"
+            )
         contradicting_evidence = tuple(
             evidence_by_id[evidence_id] for evidence_id in contradicting_ids
         )
@@ -439,7 +478,10 @@ class FindingSynthesisService:
         )
         expected_direction = self._direction_for(supporting_evidence)
         if expected_direction is None or direction != expected_direction:
-            return None
+            raise ValueError(
+                "candidate direction does not match one consistent supporting "
+                "Evidence direction"
+            )
 
         paper_bindings = self._paper_bindings(
             contributions=contributions,
@@ -457,7 +499,9 @@ class FindingSynthesisService:
             "descriptive"
         )
         if assertion_strength == "causal" and attribution_scope != "isolated_effect":
-            return None
+            raise ValueError(
+                "candidate causal assertion lacks isolated-effect attribution"
+            )
         if assertion_strength == "causal" and any(
             evidence.source_kind != "table"
             or evidence.selection_reason
@@ -479,7 +523,9 @@ class FindingSynthesisService:
         if attribution_scope == "descriptive_only" and assertion_strength != (
             "descriptive"
         ):
-            return None
+            raise ValueError(
+                "candidate assertion strength exceeds descriptive-only attribution"
+            )
         direct_evidence = supporting_evidence + contradicting_evidence
         certainty = Finding.certainty_for(synthesis_status, direct_evidence)
         limitations = self._limitations(
@@ -523,13 +569,8 @@ class FindingSynthesisService:
                 }
             )
             finding.validate_sources(tuple(evidence_by_id.values()), contributions)
-        except ValueError:
-            logger.warning(
-                "Rejected invalid Finding candidate result_set_id=%s",
-                result_set["result_set_id"],
-                exc_info=True,
-            )
-            return None
+        except ValueError as exc:
+            raise ValueError(f"candidate violates the Finding contract: {exc}") from exc
         return finding
 
     @staticmethod

--- a/backend/application/core/semantic_build/README.md
+++ b/backend/application/core/semantic_build/README.md
@@ -62,10 +62,17 @@ are bounded per Objective/document.
 
 Finding synthesis groups Evidence only by an exact normalized changed-factor
 tuple and one exact outcome. Each group can produce at most one Finding. The
-provider assigns every direct result as supporting or contradicting and may
-identify condition boundaries and subordinate mechanisms. The backend derives
-the attribution scope, synthesis status, certainty, common scientific context,
-and one Finding-local binding for every PaperContribution in the analysis.
+backend binds the result-set identity, assigns every direct result as supporting
+or contradicting, and derives condition boundaries, attribution scope, synthesis
+status, certainty, common scientific context, and one Finding-local binding for
+every PaperContribution in the analysis. The provider may identify only
+subordinate mechanisms backed by supplied context Evidence.
+
+When a schema-valid candidate fails a backend semantic guard, synthesis records
+the concrete rejection reason and permits one bounded provider repair against
+the same Evidence. The repaired candidate must pass every original guard; a
+second rejection is terminal for that result set and no invalid Finding is
+published.
 
 `agreement`, `conflict`, `condition_dependent`, and
 `insufficient_confirmation` therefore describe validated Evidence coverage,

--- a/backend/application/core/semantic_build/llm/extractor.py
+++ b/backend/application/core/semantic_build/llm/extractor.py
@@ -19,6 +19,7 @@ from .schemas import (
     StructuredPaperContributionDraft,
     StructuredPaperSkim,
     StructuredFindingSynthesis,
+    StructuredResearchObjective,
     StructuredResearchObjectives,
     StructuredTableBatchMentions,
     StructuredTableMatrixRepair,
@@ -421,21 +422,30 @@ class CoreLLMStructuredExtractor:
                 _FINDING_SYNTHESIS_MAX_COMPLETION_TOKENS
             )
         last_error: Exception | None = None
+        last_raw_content: str | None = None
+        preserved_objectives: list[StructuredResearchObjective] = []
         for attempt in range(2):
             attempt_kwargs = dict(request_kwargs)
-            attempt_messages = messages
+            attempt_messages = [*messages]
+            attempt_kwargs["messages"] = attempt_messages
             if attempt:
                 if isinstance(last_error, ValidationError):
+                    validation_errors = last_error.errors(
+                        include_input=False,
+                        include_url=False,
+                    )
                     repair_detail = "; ".join(
                         f"{'.'.join(str(part) for part in error['loc'])}: "
                         f"{error['msg']}"
-                        for error in last_error.errors(
-                            include_input=False,
-                            include_url=False,
-                        )
+                        for error in validation_errors
                     )
                 else:
+                    validation_errors = []
                     repair_detail = str(last_error or "invalid structured output")
+                objective_role_errors = bool(validation_errors) and all(
+                    "question roles" in str(error["msg"])
+                    for error in validation_errors
+                )
                 if response_model is StructuredEvidenceExtractions:
                     retry_instruction = (
                         "Previous evidence extraction output failed validation: "
@@ -446,19 +456,45 @@ class CoreLLMStructuredExtractor:
                         "changed variable and a comparable comparison; joint_effect "
                         "requires at least two. Return only compact JSON."
                     )
-                elif response_model is StructuredResearchObjectives:
+                elif (
+                    response_model is StructuredResearchObjectives
+                    and objective_role_errors
+                ):
+                    retry_scope = (
+                        "Return corrections only for invalid objectives; do not repeat "
+                        "or rewrite objectives that were already valid. "
+                        if preserved_objectives
+                        else "Return one corrected `objectives` JSON array. "
+                    )
                     retry_instruction = (
-                        "Correct every research-objective role error. Each error below "
-                        "names field labels missing from the question. If that variables "
-                        "or outcomes list has another label already present in the correct "
-                        "question role, delete the missing label from the list. If deleting "
-                        "it would leave that role empty, put the full missing label verbatim "
-                        "in the question. Then use the canonical form 'How does <full "
-                        "variables labels joined with and> affect <full outcomes labels "
-                        "joined with and>?'. Keep material and process scope only in "
-                        "material_scope or constraints. Drop any objective that still "
-                        "cannot satisfy this form. Return only compact JSON. Errors: "
-                        f"{repair_detail[:1000]}"
+                        f"{retry_scope}"
+                        "Correct every research-objective role error. Keep atomic, "
+                        "non-duplicate axes and preserve their variable-to-outcome "
+                        "direction. If an error names a field label missing from the "
+                        "question and another label already occupies that variables or "
+                        "outcomes role, delete the missing label from the list. If "
+                        "deleting it would leave that role empty, put the full missing "
+                        "label verbatim in the question. Then use the canonical form "
+                        "'How does <full variables labels joined with and> affect <full "
+                        "outcomes labels joined with and>?'. Keep material and process "
+                        "scope only in material_scope or constraints. Drop any objective "
+                        "that still cannot satisfy this form. Return only compact JSON. "
+                        f"Errors: {repair_detail[:1000]}"
+                    )
+                elif response_model is StructuredResearchObjectives:
+                    retry_scope = (
+                        "Return corrections only for invalid objectives; do not repeat "
+                        "or rewrite objectives that were already valid. "
+                        if preserved_objectives
+                        else "Return one corrected `objectives` JSON array. "
+                    )
+                    retry_instruction = (
+                        "Previous output was invalid. "
+                        f"{retry_scope}"
+                        "Correct the JSON or schema errors exactly. Keep the top-level "
+                        "object to the single `objectives` field, use only schema fields, "
+                        "and return no more than six objectives. Return only compact JSON "
+                        f"without commentary. Errors: {repair_detail[:1000]}"
                     )
                 elif response_model is StructuredFindingSynthesis:
                     retry_instruction = (
@@ -473,11 +509,18 @@ class CoreLLMStructuredExtractor:
                         "prompt, or include markdown. Correct these validation errors: "
                         f"{repair_detail[:1000]}"
                     )
-                attempt_messages = [
-                    *messages,
-                    {"role": "user", "content": retry_instruction},
-                ]
-                attempt_kwargs["messages"] = attempt_messages
+                if (
+                    response_model is StructuredResearchObjectives
+                    and last_raw_content
+                ):
+                    attempt_messages.append(
+                        {"role": "assistant", "content": last_raw_content}
+                    )
+                attempt_messages.append(
+                    {"role": "user", "content": retry_instruction}
+                )
+                if response_model is StructuredResearchObjectives:
+                    messages[:] = attempt_messages
                 logger.warning(
                     "Retrying structured JSON response model=%s response_model=%s",
                     self.model,
@@ -488,14 +531,98 @@ class CoreLLMStructuredExtractor:
                 raw_content = self._coerce_message_content(
                     completion.choices[0].message.content if completion.choices else None
                 )
+                last_raw_content = raw_content
+                if (
+                    response_model is StructuredResearchObjectives
+                    and attempt
+                    and raw_content
+                ):
+                    messages.append({"role": "assistant", "content": raw_content})
                 if not raw_content:
                     raise RuntimeError(
                         "structured extraction returned empty response content"
                     )
                 payload = self._load_json_payload(self._extract_json_object(raw_content))
                 try:
-                    return response_model.model_validate(payload), raw_content
-                except ValidationError:
+                    parsed = response_model.model_validate(payload)
+                    if (
+                        response_model is StructuredResearchObjectives
+                        and attempt
+                        and preserved_objectives
+                        and isinstance(parsed, StructuredResearchObjectives)
+                    ):
+                        combined: list[StructuredResearchObjective] = []
+                        seen: set[str] = set()
+                        for objective in [*preserved_objectives, *parsed.objectives]:
+                            key = objective.model_dump_json()
+                            if key in seen:
+                                continue
+                            seen.add(key)
+                            combined.append(objective)
+                        parsed = StructuredResearchObjectives(objectives=combined)
+                    return parsed, raw_content
+                except ValidationError as validation_error:
+                    if (
+                        response_model is StructuredResearchObjectives
+                        and isinstance(payload, dict)
+                        and isinstance(payload.get("objectives"), list)
+                    ):
+                        objective_payloads = payload["objectives"]
+                        if len(objective_payloads) > 6:
+                            raise validation_error
+                        validation_paths = {
+                            ".".join(str(part) for part in error["loc"])
+                            for candidate_error in (last_error, validation_error)
+                            if isinstance(candidate_error, ValidationError)
+                            for error in candidate_error.errors(
+                                include_input=False,
+                                include_url=False,
+                            )
+                        }
+                        allowed_echo_keys = {
+                            f"`{path}`" for path in validation_paths if path
+                        }
+                        container_extra_keys = set(payload) - {"objectives"}
+                        if container_extra_keys - allowed_echo_keys:
+                            raise validation_error
+                        valid_objectives: list[StructuredResearchObjective] = []
+                        for objective_payload in objective_payloads:
+                            try:
+                                valid_objectives.append(
+                                    StructuredResearchObjective.model_validate(
+                                        objective_payload
+                                    )
+                                )
+                            except ValidationError:
+                                continue
+                        if attempt == 0:
+                            preserved_objectives = valid_objectives
+                        else:
+                            preserved_keys = {
+                                objective.model_dump_json()
+                                for objective in preserved_objectives
+                            }
+                            corrected_objectives = [
+                                objective
+                                for objective in valid_objectives
+                                if objective.model_dump_json() not in preserved_keys
+                            ]
+                            if corrected_objectives:
+                                combined: list[StructuredResearchObjective] = []
+                                seen: set[str] = set()
+                                for objective in [
+                                    *preserved_objectives,
+                                    *corrected_objectives,
+                                ]:
+                                    key = objective.model_dump_json()
+                                    if key in seen:
+                                        continue
+                                    seen.add(key)
+                                    combined.append(objective)
+                                return (
+                                    StructuredResearchObjectives(objectives=combined),
+                                    raw_content,
+                                )
                     if isinstance(payload, dict):
                         extra_keys = set(payload) - set(response_model.model_fields)
                         if extra_keys - {"confidence"}:
@@ -506,9 +633,17 @@ class CoreLLMStructuredExtractor:
                             if key in response_model.model_fields
                         }
                         if filtered_payload != payload:
-                            return response_model.model_validate(filtered_payload), raw_content
+                            return (
+                                response_model.model_validate(filtered_payload),
+                                raw_content,
+                            )
                     raise
-            except (RuntimeError, ValueError, ValidationError, json.JSONDecodeError) as exc:
+            except (
+                RuntimeError,
+                ValueError,
+                ValidationError,
+                json.JSONDecodeError,
+            ) as exc:
                 last_error = exc
                 if attempt == 0:
                     continue

--- a/backend/application/core/semantic_build/llm/extractor.py
+++ b/backend/application/core/semantic_build/llm/extractor.py
@@ -586,6 +586,7 @@ class CoreLLMStructuredExtractor:
                         if container_extra_keys - allowed_echo_keys:
                             raise validation_error
                         valid_objectives: list[StructuredResearchObjective] = []
+                        invalid_objective_payloads: list[dict[str, Any]] = []
                         for objective_payload in objective_payloads:
                             try:
                                 valid_objectives.append(
@@ -594,7 +595,8 @@ class CoreLLMStructuredExtractor:
                                     )
                                 )
                             except ValidationError:
-                                continue
+                                if isinstance(objective_payload, dict):
+                                    invalid_objective_payloads.append(objective_payload)
                         if attempt == 0:
                             preserved_objectives = valid_objectives
                         else:
@@ -607,6 +609,16 @@ class CoreLLMStructuredExtractor:
                                 for objective in valid_objectives
                                 if objective.model_dump_json() not in preserved_keys
                             ]
+                            corrected_objectives.extend(
+                                objective
+                                for objective_payload in invalid_objective_payloads
+                                if (
+                                    objective := self._repair_trailing_scope_objective(
+                                        objective_payload
+                                    )
+                                )
+                                is not None
+                            )
                             if corrected_objectives:
                                 combined: list[StructuredResearchObjective] = []
                                 seen: set[str] = set()
@@ -623,6 +635,44 @@ class CoreLLMStructuredExtractor:
                                     StructuredResearchObjectives(objectives=combined),
                                     raw_content,
                                 )
+                    if (
+                        response_model is StructuredEvidenceExtractions
+                        and isinstance(payload, dict)
+                        and isinstance(payload.get("extractions"), list)
+                    ):
+                        allowed_echo_keys = {
+                            "OBJECTIVE",
+                            "OBJECTIVE VARIABLES",
+                            "OBJECTIVE OUTCOMES",
+                            "ROUTE HINT ONLY (DO NOT COPY AS EVIDENCE ROLE)",
+                            "SOURCE KIND",
+                            "SOURCE",
+                        }
+                        filtered_payload = {"extractions": payload["extractions"]}
+                        extra_keys = set(payload) - {"extractions"}
+                        if extra_keys and extra_keys <= allowed_echo_keys:
+                            return (
+                                StructuredEvidenceExtractions.model_validate(
+                                    filtered_payload
+                                ),
+                                raw_content,
+                            )
+                    if (
+                        response_model is StructuredEvidenceExtractions
+                        and isinstance(payload, dict)
+                        and "extractions" not in payload
+                        and bool(payload)
+                        and set(payload)
+                        <= {
+                            "OBJECTIVE",
+                            "OBJECTIVE VARIABLES",
+                            "OBJECTIVE OUTCOMES",
+                            "ROUTE HINT ONLY (DO NOT COPY AS EVIDENCE ROLE)",
+                            "SOURCE KIND",
+                            "SOURCE",
+                        }
+                    ):
+                        return StructuredEvidenceExtractions(), raw_content
                     if isinstance(payload, dict):
                         extra_keys = set(payload) - set(response_model.model_fields)
                         if extra_keys - {"confidence"}:
@@ -649,6 +699,49 @@ class CoreLLMStructuredExtractor:
                     continue
                 raise
         raise RuntimeError("structured extraction failed after retry") from last_error
+
+    @staticmethod
+    def _repair_trailing_scope_objective(
+        payload: dict[str, Any],
+    ) -> StructuredResearchObjective | None:
+        filtered = {
+            key: value
+            for key, value in payload.items()
+            if key in StructuredResearchObjective.model_fields
+        }
+        variables = [
+            str(value).strip()
+            for value in filtered.get("variables", [])
+            if str(value).strip()
+        ]
+        outcomes = [
+            str(value).strip()
+            for value in filtered.get("outcomes", [])
+            if str(value).strip()
+        ]
+        question = str(filtered.get("question") or "").strip()
+        if not question or not variables or not outcomes:
+            return None
+
+        probe = dict(filtered)
+        probe["constraints"] = [
+            *list(filtered.get("constraints") or []),
+            *re.findall(r"[^\W_]+", question, flags=re.UNICODE),
+        ]
+        try:
+            StructuredResearchObjective.model_validate(probe)
+        except ValidationError:
+            return None
+
+        subject = " and ".join(variables)
+        result = " and ".join(outcomes)
+        auxiliary = "does" if len(variables) == 1 else "do"
+        repaired = dict(filtered)
+        repaired["question"] = f"How {auxiliary} {subject} affect {result}?"
+        try:
+            return StructuredResearchObjective.model_validate(repaired)
+        except ValidationError:
+            return None
 
     def _parse_provider_structured_response(
         self,

--- a/backend/application/core/semantic_build/llm/prompts.py
+++ b/backend/application/core/semantic_build/llm/prompts.py
@@ -4,7 +4,7 @@ import json
 from typing import Any
 
 
-FINDING_SYNTHESIS_PROMPT_VERSION = "finding_synthesis.v4"
+FINDING_SYNTHESIS_PROMPT_VERSION = "finding_synthesis.v5"
 
 
 _COMMON_SYSTEM_PROMPT = """
@@ -164,6 +164,9 @@ INPUT SCHEMA
 - `context_evidence`: bounded condition, comparison, mechanism, and baseline
   excerpts from papers in this result set. Context cannot create factors,
   outcomes, directions, or supporting papers.
+- `candidate_rejection`: present only for one bounded repair attempt. It contains
+  the backend's concrete semantic rejection reason and the previous candidate.
+  It is correction guidance, not Evidence and not a source of scientific facts.
 
 DECISION PROCESS
 1. Confirm that the factor tuple and outcome answer the Objective. Otherwise
@@ -187,10 +190,15 @@ DECISION PROCESS
    and do not strengthen association into single-variable causation. Every
    numeric endpoint in the statement must come from one complete supporting
    Evidence comparison; never combine endpoints from different Evidence rows.
+7. When `candidate_rejection` is present, correct that exact failure and then
+   re-check every rule against the original result Evidence. Do not repeat the
+   rejected candidate or weaken its scientific claim to evade validation.
 
 HARD RULES
 - Return exactly one JSON object and nothing else.
 - Return at most one Finding and copy `result_set_id` exactly.
+- Treat `result_set_id` as backend-owned identity. Never derive or alter it from
+  `candidate_rejection.previous_candidate`.
 - Do not output factors, outcome, paper count, Finding level, synthesis status,
   attribution scope, certainty, common context, or hidden reasoning. The backend
   owns and derives them from Evidence.
@@ -925,6 +933,22 @@ def build_finding_synthesis_prompt(
         else ""
     ).strip()
     result_direction = str(reported_result.get("direction") or "").strip()
+    candidate_rejection = (
+        payload.get("candidate_rejection")
+        if isinstance(payload.get("candidate_rejection"), dict)
+        else {}
+    )
+    rejection_reason = str(candidate_rejection.get("reason") or "").strip()
+    repair_contract = ""
+    if rejection_reason:
+        repair_contract = (
+            "Semantic repair required:\n"
+            f"- The previous candidate was rejected because: {rejection_reason}\n"
+            "- Return one corrected replacement only if it satisfies every original "
+            "Evidence and Finding rule; otherwise return an empty findings array.\n"
+            "- Re-read result_evidence for its exact direction, complete factor "
+            "tuple, one outcome, comparison values, and attribution scope.\n\n"
+        )
     comparison_contract = ""
     if comparison_details:
         comparison_contract += (
@@ -988,6 +1012,7 @@ def build_finding_synthesis_prompt(
         "Judge one atomic factor-to-outcome result set for this research "
         "objective.\n\n"
         f"Input JSON:\n{input_json}\n\n"
+        f"{repair_contract}"
         f"{exact_contract}"
         "Return only schema-valid structured data with a `findings` array.\n"
         "Return at most one Finding. Choose one direction that accounts for every "

--- a/backend/application/core/semantic_build/llm/schemas.py
+++ b/backend/application/core/semantic_build/llm/schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import unicodedata
 from functools import lru_cache
@@ -304,6 +305,30 @@ def _axis_role_spans(
     return tuple(sorted(spans))
 
 
+def _scope_role_spans(
+    scope: str,
+    question_role: str,
+    role_tokens: tuple[str, ...],
+) -> tuple[tuple[int, int], ...]:
+    spans = set(_axis_role_spans(scope, question_role, role_tokens))
+    normalized_scope = unicodedata.normalize("NFKC", scope)
+    explicit_acronyms = {
+        token.casefold()
+        for token in re.findall(r"[^\W_]+", normalized_scope, flags=re.UNICODE)
+        if 2 <= len(token) <= 8
+        and token.isupper()
+        and any(character.isalpha() for character in token)
+    }
+    if explicit_acronyms:
+        long_form_tokens = tuple(
+            token
+            for token in _normalize_objective_axis_tokens(scope)
+            if token not in explicit_acronyms
+        )
+        spans.update(_token_sequence_spans(role_tokens, long_form_tokens))
+    return tuple(sorted(spans))
+
+
 def _role_matches_declared_axes(
     question_role: str,
     axes: list[str],
@@ -320,7 +345,7 @@ def _role_matches_declared_axes(
     scope_indexes = frozenset(
         index
         for scope in declared_scope or []
-        for start, end in _axis_role_spans(scope, question_role, role_tokens)
+        for start, end in _scope_role_spans(scope, question_role, role_tokens)
         for index in range(start, end)
     )
 
@@ -1342,8 +1367,62 @@ class StructuredEvidenceContext(_StrictModel):
 
     @field_validator("material", "sample", "process", "test", mode="before")
     @classmethod
-    def _normalize_lists(cls, value: object) -> object:
-        return _normalize_list_container(value)
+    def _normalize_lists(cls, value: object, info: ValidationInfo) -> object:
+        items = _normalize_list_container(value)
+        if not isinstance(items, list):
+            return items
+        normalized_items: list[object] = []
+        for item in items:
+            if isinstance(item, StructuredEvidenceAttribute):
+                normalized_items.append(item)
+                continue
+            if isinstance(item, (str, int, float, bool)):
+                normalized_items.append(
+                    {"name": info.field_name, "value": item, "unit": None}
+                )
+                continue
+            if not isinstance(item, dict):
+                normalized_items.append(item)
+                continue
+
+            name = str(item.get("name") or info.field_name).strip()
+            unit = item.get("unit")
+            if "value" in item:
+                attribute_value = item["value"]
+                if isinstance(attribute_value, (dict, list)):
+                    attribute_value = json.dumps(
+                        attribute_value,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    )
+                normalized_items.append(
+                    {"name": name, "value": attribute_value, "unit": unit}
+                )
+                continue
+
+            details = {
+                key: detail
+                for key, detail in item.items()
+                if key not in {"name", "unit"}
+            }
+            normalized_items.append(
+                {
+                    "name": name if details else info.field_name,
+                    "value": (
+                        json.dumps(
+                            details,
+                            ensure_ascii=False,
+                            separators=(",", ":"),
+                            sort_keys=True,
+                        )
+                        if details
+                        else name
+                    ),
+                    "unit": unit,
+                }
+            )
+        return normalized_items
 
 
 class StructuredEvidenceExtraction(_StrictModel):
@@ -1381,6 +1460,40 @@ class StructuredEvidenceExtraction(_StrictModel):
         "unknown",
     ] = "partial"
     confidence: float = 0.0
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_attribution_cardinality(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+        attribution_scope = _normalize_underscored_choice(
+            value.get("attribution_scope"),
+            allowed=_OBJECTIVE_EVIDENCE_ATTRIBUTION_SCOPES,
+            default="not_attributable",
+        )
+        changed_variables = value.get("changed_variables")
+        if (
+            attribution_scope == "joint_effect"
+            and isinstance(changed_variables, list)
+            and len(changed_variables) == 1
+        ):
+            attribution_scope = "isolated_effect"
+        if (
+            attribution_scope in {"isolated_effect", "joint_effect"}
+            and isinstance(changed_variables, list)
+            and any(
+                (
+                    item.get("baseline_value") is None
+                    or item.get("target_value") is None
+                )
+                for item in changed_variables
+                if isinstance(item, dict)
+            )
+        ):
+            attribution_scope = "association_only"
+        if attribution_scope != value.get("attribution_scope"):
+            return {**value, "attribution_scope": attribution_scope}
+        return value
 
     @field_validator("evidence_role", mode="before")
     @classmethod

--- a/backend/application/core/semantic_build/llm/schemas.py
+++ b/backend/application/core/semantic_build/llm/schemas.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import unicodedata
+from functools import lru_cache
 from typing import Any, Literal
 
 from pydantic import (
@@ -45,12 +46,32 @@ _OBJECTIVE_CLAUSE_BOUNDARY_PATTERN = re.compile(
 )
 _OBJECTIVE_ACRONYM_STOP_WORDS = {"a", "an", "and", "for", "of", "the", "to"}
 _OBJECTIVE_ROLE_FILLER_WORDS = {"a", "an", "and", "for", "of", "the", "to"}
-_OBJECTIVE_SCOPE_FILLER_WORDS = {"in", "processed"}
+_OBJECTIVE_SCOPE_CONNECTOR_WORDS = {
+    "after",
+    "at",
+    "by",
+    "during",
+    "for",
+    "in",
+    "of",
+    "through",
+    "under",
+    "using",
+    "via",
+    "with",
+}
+_OBJECTIVE_SCOPE_FILLER_WORDS = {
+    "fabricated",
+    "manufactured",
+    "processed",
+    "produced",
+}
 _OBJECTIVE_TOKEN_NORMALIZATIONS = {
     "analyses": "analysis",
     "axes": "axis",
     "gases": "gas",
 }
+_OBJECTIVE_ROLE_SEARCH_STATE_LIMIT = 4096
 
 _METHOD_FACT_METHOD_ROLES = {"process", "characterization", "test"}
 _TEXT_WINDOW_METHOD_ROLES = _METHOD_FACT_METHOD_ROLES | {"other"}
@@ -290,9 +311,10 @@ def _role_matches_declared_axes(
     declared_scope: list[str] | None = None,
 ) -> bool:
     role_tokens = _normalize_objective_axis_tokens(question_role)
-    spans_by_axis = [
-        _axis_role_spans(axis, question_role, role_tokens) for axis in axes
-    ]
+    spans_by_axis = sorted(
+        [_axis_role_spans(axis, question_role, role_tokens) for axis in axes],
+        key=len,
+    )
     if not role_tokens or any(not spans for spans in spans_by_axis):
         return False
     scope_indexes = frozenset(
@@ -301,23 +323,55 @@ def _role_matches_declared_axes(
         for start, end in _axis_role_spans(scope, question_role, role_tokens)
         for index in range(start, end)
     )
-    scope_filler_indexes = frozenset(
-        index
-        for index, token in enumerate(role_tokens)
-        if token in _OBJECTIVE_SCOPE_FILLER_WORDS
-        and (index - 1 in scope_indexes or index + 1 in scope_indexes)
-    )
 
+    search_state_count = 0
+
+    @lru_cache(maxsize=None)
     def covers_role(axis_index: int, covered_indexes: frozenset[int]) -> bool:
+        nonlocal search_state_count
+        if search_state_count >= _OBJECTIVE_ROLE_SEARCH_STATE_LIMIT:
+            return False
+        search_state_count += 1
         if axis_index == len(spans_by_axis):
-            return all(
-                index in covered_indexes
-                or index in scope_indexes
-                or index in scope_filler_indexes
-                or token in _OBJECTIVE_ROLE_FILLER_WORDS
+            uncovered = tuple(
+                index
                 for index, token in enumerate(role_tokens)
+                if index not in covered_indexes
+                and token not in _OBJECTIVE_ROLE_FILLER_WORDS
+            )
+            if not uncovered:
+                return True
+            if not declared_scope or not covered_indexes:
+                return False
+            last_axis_index = max(covered_indexes)
+            if any(index <= last_axis_index for index in uncovered):
+                return False
+            trailing_scope_indexes = tuple(
+                index for index in scope_indexes if index > last_axis_index
+            )
+            if not trailing_scope_indexes:
+                return False
+            first_scope_index = min(trailing_scope_indexes)
+            connector_indexes = tuple(
+                index
+                for index in range(last_axis_index + 1, first_scope_index + 1)
+                if role_tokens[index] in _OBJECTIVE_SCOPE_CONNECTOR_WORDS
+            )
+            if not connector_indexes:
+                return False
+            return all(
+                index in scope_indexes
+                or token in _OBJECTIVE_ROLE_FILLER_WORDS
+                or token in _OBJECTIVE_SCOPE_CONNECTOR_WORDS
+                or token in _OBJECTIVE_SCOPE_FILLER_WORDS
+                for index, token in enumerate(
+                    role_tokens[last_axis_index + 1 :],
+                    start=last_axis_index + 1,
+                )
             )
         for start, end in spans_by_axis[axis_index]:
+            if search_state_count >= _OBJECTIVE_ROLE_SEARCH_STATE_LIMIT:
+                return False
             span_indexes = frozenset(range(start, end))
             if covered_indexes.isdisjoint(span_indexes) and covers_role(
                 axis_index + 1,
@@ -385,6 +439,24 @@ def _validate_objective_question_roles(
     outcomes: list[str],
     declared_scope: list[str],
 ) -> None:
+    role_keys: dict[str, set[tuple[str, ...]]] = {}
+    for role_name, role_axes in (("variables", variables), ("outcomes", outcomes)):
+        seen_keys: set[tuple[str, ...]] = set()
+        for axis in role_axes:
+            axis_key = _normalize_objective_axis_tokens(axis)
+            if axis_key in seen_keys:
+                raise ValueError(
+                    "question roles do not align; duplicate axis in "
+                    f"{role_name}: {axis}"
+                )
+            seen_keys.add(axis_key)
+        role_keys[role_name] = seen_keys
+    if role_keys["variables"] & role_keys["outcomes"]:
+        raise ValueError(
+            "question roles do not align; the same axis cannot appear in both "
+            "variables and outcomes"
+        )
+
     role_candidates = _objective_question_roles(question)
     if not role_candidates:
         raise ValueError("question roles must use a supported active variable-to-outcome form")

--- a/backend/application/core/semantic_build/research_objective_service.py
+++ b/backend/application/core/semantic_build/research_objective_service.py
@@ -365,7 +365,7 @@ _SKIM_MODEL_TEXT_PREVIEW_CHARS = 400
 _SKIM_HEADING_LIMIT = 16
 _SKIM_CAPTION_LIMIT = 12
 _DISCOVERY_AXIS_VALUE_LIMIT = 2
-_DISCOVERY_OBJECTIVE_LIMIT = 1
+_DISCOVERY_OBJECTIVE_LIMIT = 3
 _DISCOVERY_TEXT_VALUE_CHARS = 80
 _DISCOVERY_OBJECTIVE_TEXT_CHARS = 180
 _FRAME_SECTION_SNIPPET_LIMIT = 12
@@ -1135,22 +1135,59 @@ class ResearchObjectiveService:
         )
         parsed_objectives = extractor.discover_research_objectives(objective_payload)
         discovered_objective_count = len(parsed_objectives.objectives)
-        research_objectives = tuple(
-            objective
-            for objective in (
-                self._canonicalize_objective_document_ids(
-                    ResearchObjective.from_mapping(
-                        {
-                            **item.model_dump(),
-                            "collection_id": collection_id,
-                        }
-                    ),
-                    documents=artifacts.documents,
-                )
-                for item in parsed_objectives.objectives
+        discovery_skims = {
+            str(skim["document_id"]): skim for skim in objective_payload["paper_skims"]
+        }
+        accepted_objectives: list[ResearchObjective] = []
+        for item in parsed_objectives.objectives:
+            objective = self._canonicalize_objective_document_ids(
+                ResearchObjective.from_mapping(
+                    {
+                        **item.model_dump(),
+                        "collection_id": collection_id,
+                    }
+                ),
+                documents=artifacts.documents,
             )
-            if is_question_shaped_objective(objective)
-        )
+            if not is_question_shaped_objective(objective):
+                continue
+            matching_document_ids: set[str] = set()
+            for document_id, skim in discovery_skims.items():
+                for candidate_question in skim["possible_objectives"]:
+                    try:
+                        StructuredResearchObjective.model_validate(
+                            {
+                                "question": candidate_question,
+                                "material_scope": [
+                                    *objective.material_scope,
+                                    *skim["candidate_materials"],
+                                ],
+                                "variables": objective.variables,
+                                "outcomes": objective.outcomes,
+                                "constraints": [
+                                    *objective.constraints,
+                                    *skim["candidate_processes"],
+                                ],
+                            }
+                        )
+                    except ValidationError:
+                        continue
+                    matching_document_ids.add(document_id)
+                    break
+            seed_document_ids = set(objective.seed_document_ids)
+            if not seed_document_ids or not seed_document_ids.issubset(
+                matching_document_ids
+            ):
+                logger.warning(
+                    "Research objective rejected because axes do not come from one "
+                    "seed candidate collection_id=%s question=%s seed_document_ids=%s",
+                    collection_id,
+                    objective.question,
+                    sorted(seed_document_ids),
+                )
+                continue
+            accepted_objectives.append(objective)
+        research_objectives = tuple(accepted_objectives)
         research_objectives = self._canonicalize_research_objective_axes_with_llm(
             collection_id=collection_id,
             extractor=extractor,
@@ -1163,6 +1200,14 @@ class ResearchObjectiveService:
             paper_skims=tuple(paper_skims),
             objectives=research_objectives,
         )
+        for objective in research_objectives:
+            StructuredResearchObjective.model_validate(
+                {
+                    key: value
+                    for key, value in objective.to_record().items()
+                    if key in StructuredResearchObjective.model_fields
+                }
+            )
         research_objectives = self._dedupe_research_objectives(research_objectives)
         logger.info(
             "Research objective discovery finished collection_id=%s paper_skim_count=%s discovered_objective_count=%s accepted_objective_count=%s",
@@ -1184,14 +1229,19 @@ class ResearchObjectiveService:
         def values(
             items: tuple[str, ...],
             limit: int,
-            *,
-            text_chars: int = _DISCOVERY_TEXT_VALUE_CHARS,
         ) -> list[str]:
             return [
-                str(item).strip()[:text_chars]
+                str(item).strip()[:_DISCOVERY_TEXT_VALUE_CHARS]
                 for item in items[:limit]
                 if str(item).strip()
             ]
+
+        possible_objectives = [
+            text
+            for item in skim.possible_objectives
+            if (text := str(item).strip())
+            and len(text) <= _DISCOVERY_OBJECTIVE_TEXT_CHARS
+        ][:_DISCOVERY_OBJECTIVE_LIMIT]
 
         return {
             "document_id": skim.document_id,
@@ -1204,11 +1254,7 @@ class ResearchObjectiveService:
                 skim.candidate_processes,
                 _DISCOVERY_AXIS_VALUE_LIMIT,
             ),
-            "possible_objectives": values(
-                skim.possible_objectives,
-                _DISCOVERY_OBJECTIVE_LIMIT,
-                text_chars=_DISCOVERY_OBJECTIVE_TEXT_CHARS,
-            ),
+            "possible_objectives": possible_objectives,
         }
 
     def _canonicalize_objective_document_ids(
@@ -7478,10 +7524,27 @@ class ResearchObjectiveService:
                 collection_id,
             )
             return objectives
-        return tuple(
+        canonicalized = tuple(
             self._apply_axis_canonicalization(objective, axis_mapping)
             for objective in objectives
         )
+        try:
+            for objective in canonicalized:
+                StructuredResearchObjective.model_validate(
+                    {
+                        key: value
+                        for key, value in objective.to_record().items()
+                        if key in StructuredResearchObjective.model_fields
+                    }
+                )
+        except ValidationError:
+            logger.warning(
+                "Research objective axis canonicalization broke question roles; "
+                "using original axes collection_id=%s",
+                collection_id,
+            )
+            return objectives
+        return canonicalized
 
     def _build_axis_canonicalization_candidates(
         self,

--- a/backend/application/core/semantic_build/research_objective_service.py
+++ b/backend/application/core/semantic_build/research_objective_service.py
@@ -1175,6 +1175,18 @@ class ResearchObjectiveService:
                     matching_document_ids.add(document_id)
                     break
             seed_document_ids = set(objective.seed_document_ids)
+            if not seed_document_ids and len(matching_document_ids) == 1:
+                payload = objective.to_record()
+                payload["seed_document_ids"] = sorted(matching_document_ids)
+                objective = ResearchObjective.from_mapping(payload)
+                seed_document_ids = set(objective.seed_document_ids)
+                logger.info(
+                    "Research objective recovered one missing seed document "
+                    "collection_id=%s question=%s seed_document_id=%s",
+                    collection_id,
+                    objective.question,
+                    next(iter(seed_document_ids)),
+                )
             if not seed_document_ids or not seed_document_ids.issubset(
                 matching_document_ids
             ):
@@ -1294,6 +1306,22 @@ class ResearchObjectiveService:
                     else aliases.get(normalized)
                     or aliases.get(normalized.rsplit("/", 1)[-1])
                 )
+                if (
+                    not document_id
+                    and len(normalized) >= 32
+                    and all(
+                        character in "0123456789abcdefABCDEF"
+                        for character in normalized
+                    )
+                ):
+                    truncated_matches = [
+                        candidate
+                        for candidate in canonical_ids
+                        if len(candidate) == len(normalized) + 1
+                        and candidate.startswith(normalized)
+                    ]
+                    if len(truncated_matches) == 1:
+                        document_id = truncated_matches[0]
                 if document_id and document_id not in seen:
                     seen.add(document_id)
                     result.append(document_id)
@@ -6190,6 +6218,8 @@ class ResearchObjectiveService:
         scored_candidates: list[tuple[int, int, dict[str, Any]]] = []
         for node in self._document_tree_nodes_in_order(document_tree):
             if self._tree_node_in_reference_branch(document_tree, node):
+                continue
+            if str(getattr(node, "source_ref_kind", "") or "").strip() != "block":
                 continue
             block_type = self._route_text_node_block_type(node)
             if block_type not in {"paragraph", "list_item", "figure_caption"}:

--- a/backend/tests/support/fake_core_llm_extractor.py
+++ b/backend/tests/support/fake_core_llm_extractor.py
@@ -258,6 +258,18 @@ class FakeCoreLLMStructuredExtractor:
                 continue
             seen_questions.add(key)
             document_id = str(skim.get("document_id") or "").strip()
+            outcome_match = re.fullmatch(
+                r"How does .+? affect (.+?) of .+\?",
+                candidate_question,
+                flags=re.IGNORECASE,
+            )
+            candidate_outcomes = [
+                str(item)
+                for item in skim.get("candidate_properties", [])
+                if str(item).strip()
+            ]
+            if not candidate_outcomes and outcome_match:
+                candidate_outcomes = [outcome_match.group(1).strip()]
             objectives.append(
                 StructuredResearchObjective(
                     question=candidate_question,
@@ -271,11 +283,7 @@ class FakeCoreLLMStructuredExtractor:
                         for item in skim.get("candidate_processes", [])
                         if str(item).strip()
                     ],
-                    outcomes=[
-                        str(item)
-                        for item in skim.get("candidate_properties", [])
-                        if str(item).strip()
-                    ],
+                    outcomes=candidate_outcomes,
                     requested_comparator="compare process or treatment effects across papers",
                     seed_document_ids=[document_id] if document_id else [],
                     excluded_document_ids=[

--- a/backend/tests/unit/services/test_core_llm_extractor.py
+++ b/backend/tests/unit/services/test_core_llm_extractor.py
@@ -16,6 +16,7 @@ from application.core.semantic_build.llm.schemas import (
     StructuredAxisCanonicalizationPlan,
     StructuredDocumentProfile,
     StructuredExtractionBundle,
+    StructuredEvidenceContext,
     StructuredEvidenceExtraction,
     StructuredEvidenceSelections,
     StructuredEvidenceExtractions,
@@ -268,6 +269,14 @@ def test_structured_research_objective_accepts_aligned_question_roles(
             ["SS316L"],
             ["heat treatment"],
             ["microstructure"],
+            ["Selective laser melting (SLM)"],
+        ),
+        (
+            "How does energy density affect relative density in 316L stainless "
+            "steel processed via selective laser melting?",
+            ["316L stainless steel"],
+            ["energy density"],
+            ["relative density"],
             ["Selective laser melting (SLM)"],
         ),
     ],
@@ -1052,6 +1061,40 @@ def test_core_llm_extractor_preserves_valid_objectives_during_role_repair():
     ]
 
 
+def test_core_llm_extractor_repairs_repeated_trailing_scope_role_errors():
+    invalid = json.dumps(
+        {
+            "objectives": [
+                {
+                    "question": (
+                        "How does energy density affect the relative density of "
+                        "316L stainless steel processed via selective laser melting?"
+                    ),
+                    "variables": ["energy density"],
+                    "outcomes": ["relative density"],
+                    "material_scope": ["316L stainless steel"],
+                    "process_scope": ["Selective laser melting (SLM)"],
+                    "constraints": ["document_id: paper-1"],
+                    "seed_document_ids": ["paper-1"],
+                }
+            ]
+        }
+    )
+    client = _FakeOpenAIClient(invalid)
+    extractor = _json_text_extractor(client)
+
+    objectives = extractor.discover_research_objectives(
+        {"collection_id": "col-1", "paper_skims": []}
+    )
+
+    assert len(client.chat.completions.calls) == 2
+    assert len(objectives.objectives) == 1
+    repaired = objectives.objectives[0]
+    assert repaired.question == "How does energy density affect relative density?"
+    assert repaired.variables == ["energy density"]
+    assert repaired.outcomes == ["relative density"]
+
+
 def test_core_llm_extractor_rejects_repeated_reversed_research_objective_roles():
     invalid = json.dumps(
         {
@@ -1448,6 +1491,231 @@ def test_core_llm_extractor_validates_objective_evidence_response():
     assert extraction.attribution_scope == "association_only"
     assert extractions.extractions[0].resolution_status == "resolved"
     assert client.chat.completions.calls[0]["max_completion_tokens"] == 2048
+
+
+def test_structured_objective_evidence_normalizes_compact_context_attributes():
+    context = StructuredEvidenceContext.model_validate(
+        {
+            "material": ["316L stainless steel"],
+            "sample": [
+                {
+                    "name": "cylindrical specimen",
+                    "shape": "cylindrical",
+                    "size": "10 mm diameter x 10 mm height",
+                }
+            ],
+            "process": [
+                {
+                    "name": "hatch spacing",
+                    "value": [0.12, 0.111],
+                    "unit": "mm",
+                }
+            ],
+            "test": [
+                {
+                    "name": "density measurement",
+                    "method": "Archimedes",
+                }
+            ],
+        }
+    )
+
+    assert context.material[0].model_dump() == {
+        "name": "material",
+        "value": "316L stainless steel",
+        "unit": None,
+    }
+    assert json.loads(str(context.sample[0].value)) == {
+        "shape": "cylindrical",
+        "size": "10 mm diameter x 10 mm height",
+    }
+    assert json.loads(str(context.process[0].value)) == [0.12, 0.111]
+    assert json.loads(str(context.test[0].value)) == {"method": "Archimedes"}
+
+
+def test_structured_objective_evidence_repairs_single_variable_joint_effect():
+    extraction = StructuredEvidenceExtraction.model_validate(
+        {
+            "evidence_role": "direct_result",
+            "changed_variables": [
+                {
+                    "name": "energy density",
+                    "baseline_value": 70,
+                    "target_value": 150,
+                    "unit": "J/mm3",
+                }
+            ],
+            "comparison": {
+                "baseline_label": "70 J/mm3",
+                "target_label": "150 J/mm3",
+                "axis_names": ["energy density"],
+                "comparable": True,
+            },
+            "reported_result": {
+                "outcome": "relative density",
+                "value": 99.5,
+                "unit": "%",
+                "direction": "increase",
+                "result_text": "Relative density increased to 99.5%.",
+            },
+            "attribution_scope": "joint_effect",
+            "scientific_context": {},
+            "resolution_status": "resolved",
+            "confidence": 0.9,
+        }
+    )
+
+    assert extraction.attribution_scope == "isolated_effect"
+
+
+def test_structured_objective_evidence_downgrades_unbound_experimental_attribution():
+    extraction = StructuredEvidenceExtraction.model_validate(
+        {
+            "evidence_role": "direct_result",
+            "changed_variables": [
+                {
+                    "name": "energy density",
+                    "baseline_value": None,
+                    "target_value": 150,
+                    "unit": "J/mm3",
+                }
+            ],
+            "comparison": {
+                "baseline_label": "lower energy density",
+                "target_label": "150 J/mm3",
+                "axis_names": ["energy density"],
+                "comparable": True,
+            },
+            "reported_result": {
+                "outcome": "relative density",
+                "value": 99.5,
+                "unit": "%",
+                "direction": "increase",
+                "result_text": "Relative density increased to 99.5%.",
+            },
+            "attribution_scope": "isolated_effect",
+            "scientific_context": {},
+            "resolution_status": "partial",
+            "confidence": 0.8,
+        }
+    )
+
+    assert extraction.attribution_scope == "association_only"
+
+
+def test_core_llm_extractor_ignores_top_level_prompt_echo_for_evidence():
+    response = json.dumps(
+        {
+            "extractions": [
+                {
+                    "evidence_role": "direct_result",
+                    "changed_variables": [],
+                    "comparison": None,
+                    "reported_result": {
+                        "outcome": "relative density",
+                        "value": 99.5,
+                        "unit": "%",
+                        "direction": "unknown",
+                        "result_text": "Relative density reached 99.5%.",
+                    },
+                    "attribution_scope": "descriptive_only",
+                    "scientific_context": {},
+                    "resolution_status": "resolved",
+                    "confidence": 0.9,
+                }
+            ],
+            "OBJECTIVE": "How does energy density affect relative density?",
+            "SOURCE KIND": "text_window",
+            "SOURCE": "Relative density reached 99.5%.",
+        }
+    )
+    extractor = _json_text_extractor(_FakeOpenAIClient(response))
+
+    parsed = extractor.extract_objective_evidence(
+        {
+            "objective": {
+                "question": "How does energy density affect relative density?"
+            },
+            "evidence_route": {
+                "source_kind": "text_window",
+                "source_ref": "block-1",
+            },
+            "source": {
+                "source_kind": "text_window",
+                "source_ref": "block-1",
+                "text": "Relative density reached 99.5%.",
+            },
+        }
+    )
+
+    assert len(parsed.extractions) == 1
+    assert parsed.extractions[0].reported_result is not None
+
+
+def test_core_llm_extractor_rejects_unknown_top_level_evidence_fields():
+    response = json.dumps(
+        {
+            "extractions": [],
+            "unexpected_model_field": "must not be silently discarded",
+        }
+    )
+    client = _FakeOpenAIClient(response)
+    extractor = _json_text_extractor(client)
+
+    with pytest.raises(ValidationError):
+        extractor.extract_objective_evidence(
+            {
+                "objective": {
+                    "question": "How does energy density affect relative density?"
+                },
+                "evidence_route": {
+                    "source_kind": "text_window",
+                    "source_ref": "block-1",
+                },
+                "source": {
+                    "source_kind": "text_window",
+                    "source_ref": "block-1",
+                    "text": "Relative density reached 99.5%.",
+                },
+            }
+        )
+
+    assert len(client.chat.completions.calls) == 2
+
+
+def test_core_llm_extractor_treats_prompt_only_evidence_echo_as_empty():
+    response = json.dumps(
+        {
+            "OBJECTIVE": "How does energy density affect relative density?",
+            "OBJECTIVE VARIABLES": ["energy density"],
+            "OBJECTIVE OUTCOMES": ["relative density"],
+            "ROUTE HINT ONLY (DO NOT COPY AS EVIDENCE ROLE)": (
+                "process_or_treatment"
+            ),
+            "SOURCE KIND": "text_window",
+            "SOURCE": "Relative density reached 99.5%.",
+        }
+    )
+    extractor = _json_text_extractor(_FakeOpenAIClient(response))
+
+    parsed = extractor.extract_objective_evidence(
+        {
+            "objective": {
+                "question": "How does energy density affect relative density?"
+            },
+            "evidence_route": {
+                "source_kind": "text_window",
+                "source_ref": "block-1",
+            },
+            "source": {
+                "source_kind": "text_window",
+                "source_ref": "block-1",
+                "text": "Relative density reached 99.5%.",
+            },
+        }
+    )
+
+    assert parsed.extractions == []
 
 
 def test_structured_objective_evidence_rejects_effect_without_variable_change():

--- a/backend/tests/unit/services/test_core_llm_extractor.py
+++ b/backend/tests/unit/services/test_core_llm_extractor.py
@@ -685,7 +685,7 @@ def test_core_llm_extractor_synthesizes_goal_findings_with_distinct_trace():
     trace = extractor.consume_last_trace()
     assert trace is not None
     assert trace["task_type"] == "finding_synthesis"
-    assert trace["prompt_version"] == "finding_synthesis.v4"
+    assert trace["prompt_version"] == "finding_synthesis.v5"
     assert trace["parsed_output"] == {"findings": []}
 
 
@@ -812,6 +812,34 @@ def test_finding_synthesis_prompt_requires_specific_single_factor_result():
         "difference in microstructure:" in user_prompt
     )
     assert "Never return a generic restatement" in user_prompt
+
+
+def test_finding_synthesis_prompt_carries_backend_semantic_rejection():
+    payload = {
+        "objective": {"question": "How does energy density affect density?"},
+        "result_set": {
+            "result_set_id": "result-set-1",
+            "factors": ["energy density"],
+            "outcome": "density",
+            "result_evidence": [],
+        },
+        "candidate_rejection": {
+            "reason": "candidate direction decrease has no supporting result Evidence",
+            "previous_candidate": {
+                "result_set_id": "result-set-1",
+                "statement": "Energy density decreased density.",
+                "direction": "decrease",
+            },
+        },
+    }
+
+    system_prompt, user_prompt = build_finding_synthesis_prompt(payload)
+
+    assert "present only for one bounded repair attempt" in system_prompt
+    assert "correction guidance, not Evidence" in system_prompt
+    assert "Semantic repair required:" in user_prompt
+    assert payload["candidate_rejection"]["reason"] in user_prompt
+    assert "Re-read result_evidence for its exact direction" in user_prompt
 
 
 def test_core_llm_extractor_allows_explicit_json_text_mode(monkeypatch):

--- a/backend/tests/unit/services/test_core_llm_extractor.py
+++ b/backend/tests/unit/services/test_core_llm_extractor.py
@@ -305,6 +305,106 @@ def test_structured_research_objective_does_not_hide_source_axis_as_scope():
         )
 
 
+def test_structured_research_objective_does_not_hide_result_axis_as_scope():
+    with pytest.raises(ValidationError, match="result side"):
+        StructuredResearchObjective.model_validate(
+            {
+                "question": (
+                    "How does heat treatment affect yield strength and elongation?"
+                ),
+                "variables": ["heat treatment"],
+                "outcomes": ["yield strength"],
+                "constraints": ["elongation"],
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("question", "constraint"),
+    [
+        (
+            "How does aging affect yield strength at room temperature?",
+            "room temperature",
+        ),
+        (
+            "How does aging affect yield strength under tensile testing?",
+            "tensile testing",
+        ),
+        (
+            "How does aging affect yield strength after solution treatment?",
+            "solution treatment",
+        ),
+        (
+            "How does aging affect yield strength during tensile testing?",
+            "tensile testing",
+        ),
+        (
+            "How does aging affect yield strength with argon shielding?",
+            "argon shielding",
+        ),
+        (
+            "How does aging affect yield strength using ASTM E8 testing?",
+            "ASTM E8 testing",
+        ),
+        (
+            "How does aging affect yield strength for room temperature testing?",
+            "room temperature testing",
+        ),
+        (
+            "How does aging affect yield strength via tensile testing?",
+            "tensile testing",
+        ),
+        (
+            "How does aging affect yield strength by tensile testing?",
+            "tensile testing",
+        ),
+        (
+            "How does aging affect yield strength through tensile testing?",
+            "tensile testing",
+        ),
+    ],
+)
+def test_structured_research_objective_allows_trailing_declared_test_scope(
+    question,
+    constraint,
+):
+    objective = StructuredResearchObjective.model_validate(
+        {
+            "question": question,
+            "variables": ["aging"],
+            "outcomes": ["yield strength"],
+            "constraints": [constraint],
+        }
+    )
+
+    assert objective.constraints == [constraint]
+
+
+def test_structured_research_objective_rejects_axis_in_both_roles():
+    with pytest.raises(ValidationError, match="both variables and outcomes"):
+        StructuredResearchObjective.model_validate(
+            {
+                "question": (
+                    "How do porosity and density affect density and roughness "
+                    "and porosity?"
+                ),
+                "variables": ["porosity", "density"],
+                "outcomes": ["density", "roughness", "porosity"],
+            }
+        )
+
+
+def test_structured_research_objective_rejects_duplicate_axes_before_assignment():
+    with pytest.raises(ValidationError, match="duplicate axis"):
+        StructuredResearchObjective.model_validate(
+            {
+                "question": "How do porosity and porosity affect density?",
+                "variables": ["porosity", "porosity"],
+                "outcomes": ["density"],
+            }
+        )
+
+
 def test_research_objective_discovery_contract_bounds_model_output():
     objective = {
         "question": "How does heat treatment affect yield strength?",
@@ -714,7 +814,6 @@ def test_finding_synthesis_prompt_requires_specific_single_factor_result():
     assert "Never return a generic restatement" in user_prompt
 
 
-
 def test_core_llm_extractor_allows_explicit_json_text_mode(monkeypatch):
     monkeypatch.setenv("CORE_LLM_EXTRACTION_MODE", "json_text")
     client = _FakeOpenAIClient(
@@ -865,6 +964,64 @@ def test_core_llm_extractor_retries_reversed_research_objective_roles():
     assert "question roles" in repair_prompt
     assert "delete the missing label from the list" in repair_prompt
     assert "put the full missing label verbatim" in repair_prompt
+
+
+def test_core_llm_extractor_preserves_valid_objectives_during_role_repair():
+    valid_objective = {
+        "question": "How does heat treatment affect yield strength?",
+        "variables": ["heat treatment"],
+        "outcomes": ["yield strength"],
+    }
+    invalid_objective = {
+        "question": "How does porosity affect mechanical properties?",
+        "variables": ["laser power"],
+        "outcomes": ["porosity"],
+    }
+    repaired_objective = {
+        "question": "How does porosity affect mechanical properties?",
+        "variables": ["porosity"],
+        "outcomes": ["mechanical properties"],
+    }
+    first_response = json.dumps(
+        {"objectives": [valid_objective, invalid_objective]}
+    )
+    second_response = json.dumps(
+        {
+            "objectives": [
+                valid_objective,
+                invalid_objective,
+                repaired_objective,
+            ],
+            "`objectives.1`": "still invalid",
+        }
+    )
+    client = _FakeOpenAIClient(first_response)
+    responses = iter((first_response, second_response))
+
+    def create(**kwargs):  # noqa: ANN003
+        client.chat.completions.calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(message=SimpleNamespace(content=next(responses)))
+            ]
+        )
+
+    client.chat.completions.create = create
+    extractor = _json_text_extractor(client)
+
+    objectives = extractor.discover_research_objectives(
+        {"collection_id": "col-1", "paper_skims": []}
+    )
+
+    assert [objective.model_dump() for objective in objectives.objectives] == [
+        StructuredResearchObjective.model_validate(valid_objective).model_dump(),
+        StructuredResearchObjective.model_validate(repaired_objective).model_dump(),
+    ]
+    retry_messages = client.chat.completions.calls[1]["messages"]
+    assert retry_messages[-2] == {"role": "assistant", "content": first_response}
+    assert "Return corrections only for invalid objectives" in retry_messages[-1][
+        "content"
+    ]
 
 
 def test_core_llm_extractor_rejects_repeated_reversed_research_objective_roles():

--- a/backend/tests/unit/services/test_objective_finding_synthesis.py
+++ b/backend/tests/unit/services/test_objective_finding_synthesis.py
@@ -20,7 +20,7 @@ class _Extractor:
 
     def synthesize_findings(self, payload: dict) -> SimpleNamespace:
         self.payloads.append(payload)
-        response = self.responses.pop(0)
+        response = self.responses.pop(0) if self.responses else None
         if isinstance(response, Exception):
             raise response
         if response is None:
@@ -1592,6 +1592,89 @@ def test_synthesis_continues_after_one_result_set_provider_failure() -> None:
 
     assert len(extractor.payloads) == 2
     assert [finding.outcome for finding in findings] == ["relative density"]
+
+
+def test_synthesis_repairs_semantically_rejected_production_candidate_once() -> None:
+    extractor = _Extractor(
+        [
+            _candidate(
+                result_set_id="model-invented-result-set",
+                statement=(
+                    "energy density: low -> high results in low densification "
+                    "levels, higher porosity"
+                ),
+                direction="decrease",
+                assertion_strength="descriptive",
+            ),
+            _candidate(
+                statement=(
+                    "Energy density showed an increase in densification under "
+                    "the reported comparison."
+                ),
+                direction="increase",
+                assertion_strength="descriptive",
+            ),
+        ]
+    )
+    service = FindingSynthesisService(structured_extractor=extractor)
+
+    findings = service.synthesize(
+        collection_id="col-1",
+        objective=_objective(
+            question="How does energy density affect densification?",
+            variables=["energy density"],
+            outcomes=["densification"],
+        ),
+        analysis=_analysis(),
+        contributions=(
+            _contribution(
+                "paper-1",
+                changed_variables=["energy density"],
+                measured_property_scope=["densification"],
+            ),
+        ),
+        evidence_records=(
+            _evidence(
+                "ev-density",
+                "paper-1",
+                factors=("energy density",),
+                outcome="densification",
+                direction="increase",
+            ),
+        ),
+    )
+
+    assert len(findings) == 1
+    assert findings[0].direction == "increase"
+    assert len(extractor.payloads) == 2
+    repair = extractor.payloads[1]["candidate_rejection"]
+    assert repair["reason"] == (
+        "candidate direction decrease has no supporting result Evidence"
+    )
+    assert repair["previous_candidate"]["result_set_id"].startswith("result_set_")
+    assert repair["previous_candidate"]["result_set_id"] != (
+        "model-invented-result-set"
+    )
+
+
+def test_synthesis_stops_after_one_semantic_repair(caplog) -> None:
+    rejected = _candidate(
+        statement="Laser power was associated with relative density.",
+    )
+    extractor = _Extractor([rejected, rejected])
+    service = FindingSynthesisService(structured_extractor=extractor)
+
+    findings = service.synthesize(
+        collection_id="col-1",
+        objective=_objective(),
+        analysis=_analysis(),
+        contributions=(_contribution("paper-1"),),
+        evidence_records=(_evidence("ev-1", "paper-1"),),
+    )
+
+    assert findings == ()
+    assert len(extractor.payloads) == 2
+    assert "semantic_repair_attempted=True" in caplog.text
 
 
 def test_synthesis_rejects_cross_version_children_and_orphan_evidence() -> None:

--- a/backend/tests/unit/services/test_research_objective_service.py
+++ b/backend/tests/unit/services/test_research_objective_service.py
@@ -2390,6 +2390,28 @@ class _UnmatchedSeedObjectiveExtractor(_DuplicateMechanicalObjectiveExtractor):
         )
 
 
+class _MissingSeedObjectiveExtractor(_ObjectiveExtractor):
+    def discover_research_objectives(
+        self,
+        payload: dict[str, Any],
+    ) -> StructuredResearchObjectives:
+        self.discovery_payloads.append(payload)
+        return StructuredResearchObjectives(
+            objectives=[
+                StructuredResearchObjective(
+                    question="How does heat treatment affect corrosion resistance?",
+                    material_scope=["316L stainless steel"],
+                    variables=["heat treatment"],
+                    outcomes=["corrosion resistance"],
+                    constraints=["LPBF"],
+                    seed_document_ids=[],
+                    confidence=0.88,
+                    reason="model omitted the source document binding",
+                )
+            ]
+        )
+
+
 class _OverbroadPersistedObjectiveExtractor(_DuplicateMechanicalObjectiveExtractor):
     def discover_research_objectives(
         self,
@@ -2701,6 +2723,55 @@ def test_research_objective_service_canonicalizes_model_document_references(
 
     assert normalized.seed_document_ids == ("canonical-1",)
     assert normalized.excluded_document_ids == ("canonical-2",)
+
+
+def test_research_objective_service_repairs_one_character_truncated_document_id(
+    tmp_path,
+):
+    service = _build_research_objective_service(
+        collection_service=build_test_collection_service(tmp_path / "collections"),
+    )
+    canonical_id = "a" * 127 + "0"
+    objective = _research_objective(
+        {
+            "objective_id": "obj-density",
+            "question": "How does laser power affect relative density?",
+            "seed_document_ids": [canonical_id[:-1]],
+        }
+    )
+
+    normalized = service._canonicalize_objective_document_ids(
+        objective,
+        documents=[SimpleNamespace(document_id=canonical_id, metadata={})],
+    )
+
+    assert normalized.seed_document_ids == (canonical_id,)
+
+
+def test_research_objective_service_rejects_ambiguous_or_overtruncated_document_id(
+    tmp_path,
+):
+    service = _build_research_objective_service(
+        collection_service=build_test_collection_service(tmp_path / "collections"),
+    )
+    common_prefix = "a" * 127
+    objective = _research_objective(
+        {
+            "objective_id": "obj-density",
+            "question": "How does laser power affect relative density?",
+            "seed_document_ids": [common_prefix, common_prefix[:-1]],
+        }
+    )
+
+    normalized = service._canonicalize_objective_document_ids(
+        objective,
+        documents=[
+            SimpleNamespace(document_id=common_prefix + "0", metadata={}),
+            SimpleNamespace(document_id=common_prefix + "1", metadata={}),
+        ],
+    )
+
+    assert normalized.seed_document_ids == ()
 
 
 def test_research_objective_service_forces_extractable_objective_route_roles(
@@ -6248,6 +6319,59 @@ def test_research_objective_tree_routing_keeps_direct_result_among_scope_text(
     }
 
 
+def test_research_objective_tree_routing_excludes_non_block_caption_refs(tmp_path):
+    service = _build_research_objective_service(
+        collection_service=build_test_collection_service(tmp_path / "collections"),
+    )
+    frame = PaperAnalysisFrame.from_mapping(
+        {
+            "objective_id": "obj-density",
+            "document_id": "paper-1",
+            "relevance": "high",
+            "paper_role": "primary_experiment",
+            "changed_variables": ["energy density"],
+            "measured_property_scope": ["relative density"],
+        }
+    )
+    document_tree = SourceDocumentTree(
+        document_id="paper-1",
+        collection_id="col-test",
+        root_node_id="root",
+        nodes={
+            "root": SourceDocumentNode(
+                node_id="root",
+                document_id="paper-1",
+                parent_id=None,
+                child_ids=("figure-caption",),
+                node_type="document",
+                order=0,
+            ),
+            "figure-caption": SourceDocumentNode(
+                node_id="figure-caption",
+                document_id="paper-1",
+                parent_id="root",
+                child_ids=(),
+                node_type="caption",
+                order=100,
+                text=(
+                    "Relative density increased when energy density changed from "
+                    "70 to 150 J/mm3."
+                ),
+                source_ref_kind="figure",
+                source_ref_id="figure-1",
+            ),
+        },
+    )
+
+    candidates = service._build_tree_route_text_candidates(
+        frame=frame,
+        blocks=[],
+        document_tree=document_tree,
+    )
+
+    assert candidates == []
+
+
 def test_research_objective_tree_routing_keeps_multiple_comparative_results(
     tmp_path,
 ):
@@ -6964,6 +7088,63 @@ def test_research_objective_service_does_not_global_fill_unmatched_seed_axes(
     objectives = _build_duplicate_paper_objectives(
         tmp_path,
         _UnmatchedSeedObjectiveExtractor(),
+    )
+
+    assert objectives == ()
+
+
+def test_research_objective_service_recovers_unique_missing_seed_document_id(
+    tmp_path,
+):
+    objectives = _build_duplicate_paper_objectives(
+        tmp_path,
+        _MissingSeedObjectiveExtractor(),
+    )
+
+    assert len(objectives) == 1
+    assert objectives[0].seed_document_ids == ("paper-1",)
+
+
+def test_research_objective_service_rejects_ambiguous_missing_seed_document_id(
+    tmp_path,
+):
+    collection_service = build_test_collection_service(tmp_path / "collections")
+    collection_id = collection_service.create_collection("Ambiguous seeds")[
+        "collection_id"
+    ]
+    service = _build_research_objective_service(
+        collection_service=collection_service,
+        structured_extractor=_MissingSeedObjectiveExtractor(),
+    )
+    service.source_artifact_repository.replace_collection_artifacts(
+        collection_id,
+        "build_test",
+        SourceArtifactSet.from_records(
+            documents=[
+                {
+                    "id": document_id,
+                    "title": "LPBF 316L corrosion experiment",
+                    "text": "Heat treatment changed corrosion resistance.",
+                }
+                for document_id in ("paper-1", "paper-2")
+            ],
+            blocks=[
+                {
+                    "block_id": f"{document_id}-abstract",
+                    "document_id": document_id,
+                    "block_type": "paragraph",
+                    "text": "Heat treatment changed corrosion resistance.",
+                    "block_order": 1,
+                }
+                for document_id in ("paper-1", "paper-2")
+            ],
+        ),
+    )
+    _seed_document_profiles(service, collection_id)
+
+    objectives = service.build_objective_candidates(
+        collection_id,
+        build_id="build_test",
     )
 
     assert objectives == ()

--- a/backend/tests/unit/services/test_research_objective_service.py
+++ b/backend/tests/unit/services/test_research_objective_service.py
@@ -1357,7 +1357,8 @@ class _ObjectiveExtractor:
             candidate_properties=["corrosion"],
             changed_variables=["heat treatment temperature"],
             possible_objectives=[
-                "How does heat treatment affect corrosion resistance of LPBF 316L stainless steel?"
+                "How does heat treatment affect corrosion resistance of LPBF 316L "
+                "stainless steel?"
             ],
             evidence_density="high",
             confidence=0.91,
@@ -1372,10 +1373,10 @@ class _ObjectiveExtractor:
         return StructuredResearchObjectives(
             objectives=[
                 StructuredResearchObjective(
-                    question="How does heat treatment affect corrosion?",
+                    question="How does heat treatment affect corrosion resistance?",
                     material_scope=["316L stainless steel"],
                     variables=["heat treatment"],
-                    outcomes=["corrosion"],
+                    outcomes=["corrosion resistance"],
                     constraints=["LPBF"],
                     requested_comparator="compare as-built and heat-treated corrosion behavior",
                     seed_document_ids=["paper-1"],
@@ -1740,8 +1741,8 @@ class _BroadObjectiveExtractor(_ObjectiveExtractor):
                 "scanning speed",
             ],
             possible_objectives=[
-                "What is the relationship between SLM processing parameters "
-                "and mechanical properties of 316L stainless steel?"
+                "What is the relationship between processing parameters "
+                "and mechanical properties?"
             ],
             evidence_density="high",
             confidence=0.91,
@@ -1775,6 +1776,25 @@ class _BroadObjectiveExtractor(_ObjectiveExtractor):
 
 
 class _DuplicateMechanicalObjectiveExtractor(_BroadObjectiveExtractor):
+    def extract_paper_skim(self, payload: dict[str, Any]) -> StructuredPaperSkim:
+        self.skim_payloads.append(payload)
+        return StructuredPaperSkim(
+            doc_role="experimental",
+            candidate_materials=["316L stainless steel"],
+            candidate_processes=["Selective Laser Melting"],
+            possible_objectives=[
+                "How do energy density, scanning strategy, and scanning speed "
+                "affect densification and microstructure?",
+                "What are the effects of energy density and scanning speed on "
+                "yield strength, ultimate tensile strength, elongation, and "
+                "microhardness?",
+                "How does scanning strategy influence yield strength and "
+                "microhardness?",
+            ],
+            evidence_density="high",
+            confidence=0.91,
+        )
+
     def discover_research_objectives(
         self,
         payload: dict[str, Any],
@@ -1958,7 +1978,13 @@ class _CanonicalizingAxisExtractor(_DuplicateMechanicalObjectiveExtractor):
                 "scanning speed",
             ],
             possible_objectives=[
-                "How do SLM processing parameters affect 316L stainless steel?"
+                "How do energy density, scanning strategy, and scanning speed "
+                "affect densification and microstructure?",
+                "What are the effects of energy density and scanning speed on "
+                "yield strength, ultimate tensile strength, elongation, and "
+                "microhardness?",
+                "How does scanning strategy influence yield strength and "
+                "microhardness?",
             ],
             evidence_density="high",
             confidence=0.91,
@@ -2109,6 +2135,21 @@ class _InventedAxisMergeExtractor(_DuplicateMechanicalObjectiveExtractor):
 
 
 class _CrossObjectiveAxisMergeExtractor(_DuplicateMechanicalObjectiveExtractor):
+    def extract_paper_skim(self, payload: dict[str, Any]) -> StructuredPaperSkim:
+        self.skim_payloads.append(payload)
+        return StructuredPaperSkim(
+            doc_role="experimental",
+            candidate_materials=["316L stainless steel"],
+            candidate_processes=["Selective Laser Melting"],
+            possible_objectives=[
+                "How do laser power and scanning speed affect yield strength and "
+                "elongation?",
+                "How does porosity influence corrosion potential and "
+                "pitting potential?",
+            ],
+            evidence_density="high",
+        )
+
     def discover_research_objectives(
         self,
         payload: dict[str, Any],
@@ -2182,6 +2223,17 @@ class _CrossObjectiveAxisMergeExtractor(_DuplicateMechanicalObjectiveExtractor):
 
 
 class _OppositeDirectionMergeExtractor(_DuplicateMechanicalObjectiveExtractor):
+    def extract_paper_skim(self, payload: dict[str, Any]) -> StructuredPaperSkim:
+        self.skim_payloads.append(payload)
+        return StructuredPaperSkim(
+            doc_role="experimental",
+            possible_objectives=[
+                "How does porosity affect density and roughness?",
+                "How does density affect porosity and roughness?",
+            ],
+            evidence_density="high",
+        )
+
     def discover_research_objectives(
         self,
         payload: dict[str, Any],
@@ -2223,6 +2275,91 @@ class _OppositeDirectionMergeExtractor(_DuplicateMechanicalObjectiveExtractor):
                     outcomes=["porosity"],
                     reason="invalid opposite-direction merge",
                 )
+            ]
+        )
+
+
+class _CrossCandidateAxisExtractor(_ObjectiveExtractor):
+    def extract_paper_skim(self, payload: dict[str, Any]) -> StructuredPaperSkim:
+        self.skim_payloads.append(payload)
+        return StructuredPaperSkim(
+            doc_role="experimental",
+            possible_objectives=[
+                "How does laser power affect porosity?",
+                "How does heat treatment affect corrosion resistance?",
+            ],
+            evidence_density="high",
+        )
+
+    def discover_research_objectives(
+        self,
+        payload: dict[str, Any],
+    ) -> StructuredResearchObjectives:
+        self.discovery_payloads.append(payload)
+        return StructuredResearchObjectives(
+            objectives=[
+                StructuredResearchObjective(
+                    question="How does laser power affect corrosion resistance?",
+                    variables=["laser power"],
+                    outcomes=["corrosion resistance"],
+                    seed_document_ids=["paper-1"],
+                )
+            ]
+        )
+
+
+class _AxisQuestionMismatchExtractor(_ObjectiveExtractor):
+    def extract_paper_skim(self, payload: dict[str, Any]) -> StructuredPaperSkim:
+        self.skim_payloads.append(payload)
+        return StructuredPaperSkim(
+            doc_role="experimental",
+            candidate_materials=["316L stainless steel"],
+            possible_objectives=["How does scan strategy affect porosity?"],
+            evidence_density="high",
+        )
+
+    def discover_research_objectives(
+        self,
+        payload: dict[str, Any],
+    ) -> StructuredResearchObjectives:
+        self.discovery_payloads.append(payload)
+        return StructuredResearchObjectives(
+            objectives=[
+                StructuredResearchObjective(
+                    question="How does scan strategy affect porosity?",
+                    material_scope=["316L stainless steel"],
+                    variables=["scan strategy"],
+                    outcomes=["porosity"],
+                    seed_document_ids=["paper-1"],
+                )
+            ]
+        )
+
+    def canonicalize_research_objective_axes(
+        self,
+        payload: dict[str, Any],
+    ) -> StructuredAxisCanonicalizationPlan:
+        self.canonicalization_payloads.append(payload)
+        return StructuredAxisCanonicalizationPlan(
+            axis_groups=[
+                StructuredAxisCanonicalizationGroup(
+                    axis_type="material",
+                    canonical="316L stainless steel",
+                    aliases=["316L stainless steel"],
+                    reason="unchanged",
+                ),
+                StructuredAxisCanonicalizationGroup(
+                    axis_type="variable",
+                    canonical="scanning strategy",
+                    aliases=["scan strategy"],
+                    reason="canonicalized spelling",
+                ),
+                StructuredAxisCanonicalizationGroup(
+                    axis_type="outcome",
+                    canonical="porosity",
+                    aliases=["porosity"],
+                    reason="unchanged",
+                ),
             ]
         )
 
@@ -2501,10 +2638,10 @@ class _DuplicateObjectiveIdExtractor(_ObjectiveExtractor):
     ) -> StructuredResearchObjectives:
         self.discovery_payloads.append(payload)
         objective = StructuredResearchObjective(
-            question="How does heat treatment affect corrosion?",
+            question="How does heat treatment affect corrosion resistance?",
             material_scope=["316L stainless steel"],
             variables=["heat treatment"],
-            outcomes=["corrosion"],
+            outcomes=["corrosion resistance"],
             constraints=["LPBF"],
             requested_comparator="compare heat treatment effects on corrosion",
             seed_document_ids=["paper-1"],
@@ -4426,6 +4563,109 @@ def test_real_ved_process_and_defect_tables_form_joint_comparison(tmp_path):
     }
 
 
+def test_real_p001_density_table_retains_complete_changed_factor_tuple(tmp_path):
+    service = _build_research_objective_service(
+        collection_service=build_test_collection_service(tmp_path / "collections"),
+    )
+    objective = _research_objective(
+        {
+            "objective_id": "obj-p001-density",
+            "question": "How does energy density affect densification?",
+            "variables": ["energy density"],
+            "outcomes": ["densification"],
+        }
+    )
+    table = SimpleNamespace(
+        table_id="table-p001-1",
+        document_id="paper-p001",
+        caption_text="SLM processing parameters along with relative densities.",
+        heading_path="Materials and methods",
+        page=2,
+        column_headers=(
+            "Condition number",
+            "Sample number",
+            "Hatch space (mm)",
+            "Scan strategy",
+            "Scanning speed (mm/s)",
+            "Energy density (J/mm 3 )",
+            "Relative density",
+        ),
+        table_matrix=(
+            (
+                "Condition number",
+                "Sample number",
+                "Hatch space (mm)",
+                "Scan strategy",
+                "Scanning speed (mm/s)",
+                "Energy density (J/mm 3 )",
+                "Relative density",
+            ),
+            ("1", "1", "0.114", "A", "0.25", "70", "95.4"),
+            ("3", "6", "0.111", "B", "0.12", "150", "95.7"),
+        ),
+        row_count=3,
+        col_count=7,
+    )
+    hints = service._build_objective_table_routing_hints(
+        objective,
+        tables=(table,),
+    )
+    routes: list[EvidenceCandidate] = []
+    service._append_objective_context_hint_routes(
+        routes=routes,
+        seen=set(),
+        frame=PaperAnalysisFrame.from_mapping(
+            {
+                "objective_id": objective.objective_id,
+                "document_id": "paper-p001",
+                "relevance": "high",
+                "paper_role": "primary_experiment",
+                "relevant_tables": [table.table_id],
+            }
+        ),
+        objective_context=objective,
+        routing_hints=hints,
+        candidate_by_key={
+            ("table", table.table_id): {
+                "source_kind": "table",
+                "source_ref": table.table_id,
+                "frame_status": "relevant",
+                "table_schema": service._build_route_table_schema(table),
+            }
+        },
+    )
+    units = tuple(
+        ExtractedEvidenceDraft.from_mapping(record)
+        for route in routes
+        for record in service._objective_table_matrix_evidence_records(
+            route=route,
+            source=service._build_objective_route_source_payload(
+                route=route,
+                blocks=[],
+                tables=[table],
+            ),
+            objective_context=objective,
+        )
+    )
+    comparisons = service._build_objective_pairwise_comparison_units(
+        service._bind_objective_result_process_context(units),
+        objectives=(objective,),
+    )
+
+    assert len(comparisons) == 1
+    comparison = comparisons[0]
+    assert comparison.attribution_scope == "joint_effect"
+    assert {
+        service._normalize_property_label(item.name)
+        for item in comparison.changed_variables
+    } == {
+        "hatch space",
+        "scan strategy",
+        "scanning speed",
+        "energy density",
+    }
+
+
 def test_research_objective_service_does_not_route_single_letter_acronym_tables(
     tmp_path,
 ):
@@ -4463,6 +4703,30 @@ def test_research_objective_service_does_not_route_single_letter_acronym_tables(
     )
 
     assert hints == ()
+
+
+def test_objective_discovery_skim_keeps_three_complete_candidate_questions():
+    candidates = (
+        "How does " + "very long processing condition " * 8 + "affect porosity?",
+        "How does laser power affect porosity?",
+        "How does heat treatment affect corrosion resistance?",
+        "How does aging affect yield strength?",
+        "How does scanning speed affect density?",
+    )
+    skim = PaperSkim.from_mapping(
+        {
+            "document_id": "paper-1",
+            "possible_objectives": candidates,
+        }
+    )
+
+    discovery_skim = _ResearchObjectiveService._build_objective_discovery_skim(skim)
+
+    assert discovery_skim["possible_objectives"] == list(candidates[1:4])
+    assert all(
+        candidate.endswith("?")
+        for candidate in discovery_skim["possible_objectives"]
+    )
 
 
 def test_research_objective_service_treats_energy_density_only_table_as_condition(
@@ -6560,6 +6824,19 @@ def test_research_objective_service_canonicalizes_axis_aliases_with_llm(
     assert "scan strategy" not in all_variables
 
 
+def test_research_objective_service_rejects_axis_canonicalization_that_breaks_question(
+    tmp_path,
+):
+    objectives = _build_duplicate_paper_objectives(
+        tmp_path,
+        _AxisQuestionMismatchExtractor(),
+    )
+
+    assert len(objectives) == 1
+    assert objectives[0].variables == ("scan strategy",)
+    assert objectives[0].question == "How does scan strategy affect porosity?"
+
+
 def test_research_objective_service_falls_back_when_axis_plan_drops_axes(
     tmp_path,
 ):
@@ -6670,6 +6947,17 @@ def test_research_objective_service_rejects_completed_opposite_direction_merge(
     }
 
 
+def test_research_objective_service_rejects_axes_combined_across_skim_candidates(
+    tmp_path,
+):
+    objectives = _build_duplicate_paper_objectives(
+        tmp_path,
+        _CrossCandidateAxisExtractor(),
+    )
+
+    assert objectives == ()
+
+
 def test_research_objective_service_does_not_global_fill_unmatched_seed_axes(
     tmp_path,
 ):
@@ -6678,14 +6966,10 @@ def test_research_objective_service_does_not_global_fill_unmatched_seed_axes(
         _UnmatchedSeedObjectiveExtractor(),
     )
 
-    assert len(objectives) == 1
-    objective = objectives[0]
-    assert objective.variables == ("heat treatment",)
-    assert objective.outcomes == ("mechanical properties",)
-    assert objective.constraints == ("Selective Laser Melting",)
+    assert objectives == ()
 
 
-def test_research_objective_service_keeps_candidate_definition_as_source_of_truth(
+def test_research_objective_service_rejects_overbroad_candidate_definition(
     tmp_path,
 ):
     collection_service = build_test_collection_service(tmp_path / "collections")
@@ -6730,9 +7014,7 @@ def test_research_objective_service_keeps_candidate_definition_as_source_of_trut
     )
 
     assert service.objective_repository.list_objectives(collection_id) == objectives
-    assert objectives[0].confirmation_status == "candidate"
-    assert objectives[0].active_analysis_version is None
-    assert objectives[0].published_analysis_version is None
+    assert objectives == ()
 
 
 def test_research_objective_service_rejects_merge_with_disjoint_outcomes(
@@ -6767,7 +7049,7 @@ def test_research_objective_service_rejects_merge_that_drops_variable_intent(
     )
 
 
-def test_research_objective_service_preserves_single_mixed_property_objective(
+def test_research_objective_service_rejects_single_cross_candidate_objective(
     tmp_path,
 ):
     objectives = _build_duplicate_paper_objectives(
@@ -6775,15 +7057,7 @@ def test_research_objective_service_preserves_single_mixed_property_objective(
         _SingleMixedObjectiveExtractor(),
     )
 
-    assert len(objectives) == 1
-    assert objectives[0].outcomes == (
-        "densification",
-        "microstructure",
-        "yield strength",
-        "ultimate tensile strength",
-        "elongation",
-        "microhardness",
-    )
+    assert objectives == ()
 
 
 def test_research_objective_service_dedupes_repeated_objective_ids_before_persist(


### PR DESCRIPTION
## Summary

- enforce atomic, seed-backed ResearchObjective axes and preserve valid sibling objectives during model repair
- expose precise Finding semantic rejections and allow one bounded repair against unchanged Evidence
- normalize the real provider variants observed during PDF ingestion while keeping ambiguous bindings and unknown fields rejected
- prevent non-block figure references from entering text-window evidence routing

## Why

The v0.11.9 contract fixes were still insufficient for the live provider output. A real uploaded paper could produce omitted or one-character-truncated document IDs, prompt echo fields, compact evidence context, or attribution shapes that passed through individual stages but left the analysis without publishable reviewable Findings.

This change keeps the scientific and source-traceability guards strict, but repairs only cases that are unambiguous and evidenced by the current collection.

## Verification

- `752 passed, 2 warnings` in the full backend unit suite
- `206 passed` in the focused LLM extractor and ResearchObjective service suite
- `5 passed` in `tests/integration/services/test_task_runner.py`
- docs governance passed for 93 governed docs and 144 markdown files
- `git diff --check upstream/main...HEAD`
- live API flow with a fresh 3,525,279-byte PDF upload:
  - collection build completed and produced three source-bound Objective candidates
  - confirmed Objective analysis version 2 succeeded and was published from the final restarted worktree process
  - 9 Findings and 67 Evidence records returned
  - 9/9 Finding detail endpoints and Finding-filtered Evidence queries passed
  - all Evidence excerpts were non-empty
  - all 67 primary and 115 related Source references resolved through document content/Markdown source maps

## Review Notes

- no browser API or persistence schema changes
- no dependency, deployment, compose, workflow, or release changes
- no compatibility layer or new architectural abstraction
- ambiguous missing document bindings remain rejected

Refs #268 and #272.
