### PR TITLE
bugfix(core): improve expert finding synthesis

### DIFF
--- a/backend/application/core/finding_synthesis_service.py
+++ b/backend/application/core/finding_synthesis_service.py
@@ -31,6 +31,10 @@ logger = logging.getLogger(__name__)
 _NUMBER_RE = re.compile(
     r"(?<![\w.])[-+]?(?:\d+(?:[.,]\d*)?|\.\d+)(?:[eE][-+]?\d+)?(?![\w.])"
 )
+_J_PER_CUBIC_MM_RE = re.compile(
+    r"\bj\s*/\s*mm\s*(?:\^\s*)?(?:3|\u00b3)\b",
+    re.IGNORECASE,
+)
 
 
 class FindingSynthesisService:
@@ -57,6 +61,32 @@ class FindingSynthesisService:
         )
         result_sets = self._result_sets(objective, evidence_records)
         if not result_sets:
+            eligible_evidence = tuple(
+                evidence
+                for evidence in evidence_records
+                if self._eligible_result_evidence(evidence)
+            )
+            logger.warning(
+                "Finding synthesis found no in-scope result sets "
+                "objective_variables=%s objective_outcomes=%s "
+                "eligible_result_count=%s eligible_axes=%s",
+                objective.variables,
+                objective.outcomes,
+                len(eligible_evidence),
+                sorted(
+                    {
+                        (
+                            tuple(
+                                variable.name
+                                for variable in evidence.changed_variables
+                            ),
+                            evidence.reported_result.outcome,
+                        )
+                        for evidence in eligible_evidence
+                        if evidence.reported_result is not None
+                    }
+                )[:12],
+            )
             return ()
         evidence_by_id = {
             evidence.evidence_id: evidence for evidence in evidence_records
@@ -89,7 +119,7 @@ class FindingSynthesisService:
             synthesis_payload = {
                 "objective": objective_payload,
                 "paper_contributions": contribution_payloads,
-                "result_set": result_set,
+                "result_set": self._result_set_prompt_payload(result_set),
                 "context_evidence": [
                     self._evidence_payload(evidence) for evidence in context_evidence
                 ],
@@ -230,10 +260,9 @@ class FindingSynthesisService:
         objective: ResearchObjective,
         evidence_records: tuple[ObjectiveEvidence, ...],
     ) -> tuple[dict[str, Any], ...]:
-        grouped: dict[
-            tuple[tuple[str, ...], str, tuple[Any, ...]],
-            list[ObjectiveEvidence],
-        ] = defaultdict(list)
+        grouped: dict[tuple[tuple[str, ...], str], list[ObjectiveEvidence]] = (
+            defaultdict(list)
+        )
         factor_labels: dict[tuple[str, ...], tuple[str, ...]] = {}
         outcome_labels: dict[str, str] = {}
         for evidence in evidence_records:
@@ -254,16 +283,18 @@ class FindingSynthesisService:
                 objective=objective,
             ):
                 continue
-            interval_key = self._comparison_interval_key(evidence)
-            grouped[(factor_key, outcome_key, interval_key)].append(evidence)
-            factor_labels.setdefault(factor_key, factors)
+            grouped[(factor_key, outcome_key)].append(evidence)
+            factor_labels.setdefault(
+                factor_key,
+                tuple(_normalize_scientific_typography(value) for value in factors),
+            )
             outcome_labels.setdefault(outcome_key, outcome)
 
         result_sets: list[dict[str, Any]] = []
-        for factor_key, outcome_key, interval_key in sorted(grouped):
+        for factor_key, outcome_key in sorted(grouped):
             evidence_items = tuple(
                 sorted(
-                    grouped[(factor_key, outcome_key, interval_key)],
+                    grouped[(factor_key, outcome_key)],
                     key=lambda item: (
                         -item.confidence,
                         item.document_id,
@@ -275,9 +306,7 @@ class FindingSynthesisService:
             outcome = outcome_labels[outcome_key]
             result_sets.append(
                 {
-                    "result_set_id": self._result_set_id(
-                        factors, outcome, interval_key
-                    ),
+                    "result_set_id": self._result_set_id(factors, outcome),
                     "factors": list(factors),
                     "outcome": outcome,
                     "result_evidence": [
@@ -288,20 +317,58 @@ class FindingSynthesisService:
         return tuple(result_sets)
 
     @staticmethod
-    def _comparison_interval_key(
-        evidence: ObjectiveEvidence,
-    ) -> tuple[tuple[str, str, str, str], ...]:
-        return tuple(
-            sorted(
-                (
-                    _normalize_term(variable.name),
-                    _scalar_key(variable.baseline_value),
-                    _scalar_key(variable.target_value),
-                    _normalize_term(variable.unit),
-                )
-                for variable in evidence.changed_variables
+    def _result_set_prompt_payload(
+        result_set: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        result_evidence = _mapping_list(result_set.get("result_evidence"))
+        if not FindingSynthesisService._result_set_is_condition_series(result_set):
+            return dict(result_set)
+
+        compact_evidence: list[dict[str, Any]] = []
+        for item in result_evidence:
+            reported_result = (
+                item.get("reported_result")
+                if isinstance(item.get("reported_result"), Mapping)
+                else {}
             )
-        )
+            compact_evidence.append(
+                {
+                    "evidence_id": item.get("evidence_id"),
+                    "document_id": item.get("document_id"),
+                    "changed_variables": item.get("changed_variables") or [],
+                    "reported_result": {
+                        "outcome": reported_result.get("outcome"),
+                        "value": reported_result.get("value"),
+                        "unit": reported_result.get("unit"),
+                        "direction": reported_result.get("direction"),
+                    },
+                    "attribution_scope": item.get("attribution_scope"),
+                }
+            )
+        return {
+            "result_set_id": result_set.get("result_set_id"),
+            "factors": result_set.get("factors") or [],
+            "outcome": result_set.get("outcome"),
+            "result_evidence": compact_evidence,
+        }
+
+    @staticmethod
+    def _result_set_is_condition_series(result_set: Mapping[str, Any]) -> bool:
+        interval_signatures = {
+            tuple(
+                sorted(
+                    (
+                        _normalize_term(variable.get("name")),
+                        _scalar_key(variable.get("baseline_value")),
+                        _scalar_key(variable.get("target_value")),
+                        _normalize_term(variable.get("unit")),
+                    )
+                    for variable in _mapping_list(item.get("changed_variables"))
+                )
+            )
+            for item in _mapping_list(result_set.get("result_evidence"))
+        }
+        return len(interval_signatures) > 1
 
     @staticmethod
     def _eligible_result_evidence(evidence: ObjectiveEvidence) -> bool:
@@ -449,6 +516,12 @@ class FindingSynthesisService:
                 "candidate statement does not contain the complete factor tuple "
                 "and outcome"
             )
+        if self._result_set_is_condition_series(
+            result_set
+        ) and _statement_contains_numeric_endpoint(statement, factors, outcome):
+            raise ValueError(
+                "condition-series statement contains a numeric endpoint"
+            )
         if self._statement_mentions_unbound_objective_factor(
             statement,
             factors,
@@ -472,6 +545,13 @@ class FindingSynthesisService:
         contradicting_evidence = tuple(
             evidence_by_id[evidence_id] for evidence_id in contradicting_ids
         )
+        if contradicting_evidence and not _statement_acknowledges_heterogeneity(
+            statement
+        ):
+            raise ValueError(
+                "candidate statement does not foreground opposing directions "
+                "across the reported conditions"
+            )
         boundary_ids = self._condition_boundary_evidence_ids(
             supporting_evidence,
             contradicting_evidence,
@@ -533,6 +613,8 @@ class FindingSynthesisService:
             factors=factors,
             synthesis_status=synthesis_status,
             attribution_scope=attribution_scope,
+            supporting_evidence=supporting_evidence,
+            contradicting_evidence=contradicting_evidence,
         )
         finding_id = self._finding_id(
             objective_id=objective.objective_id,
@@ -753,6 +835,8 @@ class FindingSynthesisService:
         factors: tuple[str, ...],
         synthesis_status: str,
         attribution_scope: str,
+        supporting_evidence: tuple[ObjectiveEvidence, ...],
+        contradicting_evidence: tuple[ObjectiveEvidence, ...],
     ) -> tuple[str, ...]:
         deterministic: list[str] = []
         if len(factors) > 1:
@@ -771,6 +855,13 @@ class FindingSynthesisService:
         if synthesis_status == "condition_dependent":
             deterministic.append(
                 "The reported relationship changes across an explicit condition boundary."
+            )
+        if contradicting_evidence and (
+            {item.document_id for item in supporting_evidence}
+            & {item.document_id for item in contradicting_evidence}
+        ):
+            deterministic.append(
+                "Within-paper condition comparisons report opposing directions."
             )
         if attribution_scope == "association_only":
             deterministic.append(
@@ -795,14 +886,19 @@ class FindingSynthesisService:
 
     @staticmethod
     def _evidence_payload(evidence: ObjectiveEvidence) -> dict[str, Any]:
+        changed_variables = []
+        for variable in evidence.changed_variables:
+            record = variable.to_record()
+            record["name"] = _normalize_scientific_typography(record["name"])
+            if record["unit"]:
+                record["unit"] = _normalize_scientific_typography(record["unit"])
+            changed_variables.append(record)
         return {
             "evidence_id": evidence.evidence_id,
             "document_id": evidence.document_id,
             "evidence_role": evidence.evidence_role,
             "source_excerpt": evidence.source_excerpt[:_MAX_EXCERPT_CHARS],
-            "changed_variables": [
-                variable.to_record() for variable in evidence.changed_variables
-            ],
+            "changed_variables": changed_variables,
             "comparison": (
                 evidence.comparison.to_record() if evidence.comparison else None
             ),
@@ -820,10 +916,9 @@ class FindingSynthesisService:
     def _result_set_id(
         factors: tuple[str, ...],
         outcome: str,
-        interval_key: tuple[Any, ...],
     ) -> str:
         identity = json.dumps(
-            [factors, outcome, interval_key],
+            [factors, outcome],
             ensure_ascii=True,
             separators=(",", ":"),
         )
@@ -884,12 +979,52 @@ def _mapping_list(value: Any) -> list[dict[str, Any]]:
 
 
 def _normalize_term(value: Any) -> str:
+    value = _normalize_scientific_typography(value)
     return " ".join(
         part
         for part in "".join(
             character.lower() if character.isalnum() else " "
             for character in (_text(value) or "")
         ).split()
+    )
+
+
+def _normalize_scientific_typography(value: Any) -> str:
+    text = _text(value) or ""
+    text = _J_PER_CUBIC_MM_RE.sub("J/mm3", text)
+    return re.sub(r"\s+([)\]])", r"\1", text)
+
+
+def _statement_acknowledges_heterogeneity(statement: str) -> bool:
+    normalized = _normalize_term(statement)
+    return any(
+        marker in normalized
+        for marker in (
+            "heterogeneous",
+            "opposing",
+            "mixed",
+            "varied by condition",
+            "varies by condition",
+            "not uniform",
+            "inconsistent",
+            "condition dependent",
+        )
+    )
+
+
+def _statement_contains_numeric_endpoint(
+    statement: str,
+    factors: tuple[str, ...],
+    outcome: str,
+) -> bool:
+    label_numbers = {
+        number
+        for label in (*factors, outcome)
+        for number in _numbers(_normalize_scientific_typography(label))
+    }
+    return any(
+        number not in label_numbers
+        for number in _numbers(_normalize_scientific_typography(statement))
     )
 
 
@@ -932,6 +1067,8 @@ def _axis_matches(left: Any, right: Any) -> bool:
     if not left_term or not right_term:
         return False
     if left_term == right_term:
+        return True
+    if {left_term, right_term} == {"densification", "relative density"}:
         return True
     if _axis_acronym(left_term) == right_term or _axis_acronym(right_term) == left_term:
         return True

--- a/backend/application/core/semantic_build/README.md
+++ b/backend/application/core/semantic_build/README.md
@@ -50,6 +50,14 @@ scientific attribution contract:
 - `scientific_context` stores fixed material, sample, process, and test
   attributes as typed name/value/unit entries.
 
+When an extracted Evidence record omits material or process context, the
+service may fill the missing material category or missing process-identity
+attribute from already persisted scope data. It uses the same document's
+`PaperSkim.candidate_materials` and `PaperSkim.candidate_processes`; Objective
+`material_scope` is the material fallback when the document skim has no
+candidate material. It preserves extracted process attributes, does not replace
+extracted context, and does not infer new scientific attributes.
+
 Transient extraction state is scoped to one Objective, analysis version, and
 document. It carries only prior role/outcome coverage and Source positions
 between blocks, never prior scientific values or context. It is reset before
@@ -61,12 +69,20 @@ material differences, reject sparse comparison axes as non-attributable, and
 are bounded per Objective/document.
 
 Finding synthesis groups Evidence only by an exact normalized changed-factor
-tuple and one exact outcome. Each group can produce at most one Finding. The
-backend binds the result-set identity, assigns every direct result as supporting
-or contradicting, and derives condition boundaries, attribution scope, synthesis
-status, certainty, common scientific context, and one Finding-local binding for
-every PaperContribution in the analysis. The provider may identify only
-subordinate mechanisms backed by supplied context Evidence.
+tuple and one exact outcome. Multiple baseline-to-target intervals in that
+group form one condition series rather than separate Findings, and their exact
+endpoints remain on the individual Evidence records. For a condition series,
+the model-facing view retains every Evidence and paper id, factor endpoint,
+structured result, and attribution scope while omitting repeated excerpts and
+context; its Finding statement cannot publish numeric endpoints because they
+belong to individual comparisons. The backend keeps the complete persisted
+Evidence for validation and traceback. Each group can produce at most one Finding. The backend binds the
+result-set identity, assigns every direct result as supporting or
+contradicting, requires the statement to foreground heterogeneous responses
+when directions oppose, and derives condition boundaries, attribution scope,
+synthesis status, certainty, common scientific context, and one Finding-local
+binding for every PaperContribution in the analysis. The provider may identify
+only subordinate mechanisms backed by supplied context Evidence.
 
 When a schema-valid candidate fails a backend semantic guard, synthesis records
 the concrete rejection reason and permits one bounded provider repair against

--- a/backend/application/core/semantic_build/README.md
+++ b/backend/application/core/semantic_build/README.md
@@ -53,10 +53,10 @@ scientific attribution contract:
 When an extracted Evidence record omits material or process context, the
 service may fill the missing material category or missing process-identity
 attribute from already persisted scope data. It uses the same document's
-`PaperSkim.candidate_materials` and `PaperSkim.candidate_processes`; Objective
-`material_scope` is the material fallback when the document skim has no
-candidate material. It preserves extracted process attributes, does not replace
-extracted context, and does not infer new scientific attributes.
+`PaperSkim.candidate_materials` and `PaperSkim.candidate_processes`. Objective
+scope alone never supplies document Evidence context. The service preserves
+extracted process attributes, does not replace extracted context, and does not
+infer new scientific attributes.
 
 Transient extraction state is scoped to one Objective, analysis version, and
 document. It carries only prior role/outcome coverage and Source positions

--- a/backend/application/core/semantic_build/llm/prompts.py
+++ b/backend/application/core/semantic_build/llm/prompts.py
@@ -4,7 +4,7 @@ import json
 from typing import Any
 
 
-FINDING_SYNTHESIS_PROMPT_VERSION = "finding_synthesis.v5"
+FINDING_SYNTHESIS_PROMPT_VERSION = "finding_synthesis.v7"
 
 
 _COMMON_SYSTEM_PROMPT = """
@@ -155,9 +155,13 @@ This is not extraction, paper-by-paper generation, clustering, or summary.
 INPUT SCHEMA
 - `objective`: the user question and requested scientific scope.
 - `result_set`: one backend-owned `result_set_id`, complete `factors`, one
-  `outcome`, and `result_evidence`. Every result Evidence has the exact source
+  `outcome`, and `result_evidence`. A single comparison carries its source
   excerpt, explicit changed variables, comparison, reported result,
-  attribution scope, scientific context, and paper id.
+  attribution scope, scientific context, and paper id. A multi-interval
+  condition series carries every Evidence id and paper id, every factor
+  endpoint, structured result value/direction, and attribution scope while
+  omitting repeated excerpts and context. The backend retains the complete
+  persisted Evidence for final validation and traceback.
 - `paper_contributions`: every paper considered in this Objective analysis,
   including analyzed papers without a direct result and excluded or failed
   papers. Paper metadata can qualify judgment but cannot become Evidence.
@@ -190,6 +194,9 @@ DECISION PROCESS
    and do not strengthen association into single-variable causation. Every
    numeric endpoint in the statement must come from one complete supporting
    Evidence comparison; never combine endpoints from different Evidence rows.
+   When result Evidence contains opposing directions, explicitly foreground
+   heterogeneous or opposing responses across the reported conditions instead
+   of presenting the selected direction as uniform.
 7. When `candidate_rejection` is present, correct that exact failure and then
    re-check every rule against the original result Evidence. Do not repeat the
    rejected candidate or weaken its scientific claim to evade validation.
@@ -902,6 +909,46 @@ def build_finding_synthesis_prompt(
         if isinstance(item, dict)
     ]
     representative_evidence = result_evidence[0] if result_evidence else {}
+    interval_signatures = {
+        tuple(
+            sorted(
+                (
+                    str(variable.get("name") or "").strip().casefold(),
+                    str(
+                        variable.get("baseline_value")
+                        if variable.get("baseline_value") is not None
+                        else ""
+                    ).strip(),
+                    str(
+                        variable.get("target_value")
+                        if variable.get("target_value") is not None
+                        else ""
+                    ).strip(),
+                    str(variable.get("unit") or "").strip().casefold(),
+                )
+                for variable in item.get("changed_variables", ())
+                if isinstance(variable, dict)
+            )
+        )
+        for item in result_evidence
+    }
+    is_condition_series = len(interval_signatures) > 1
+    reported_directions = {
+        str(reported_result.get("direction") or "").strip()
+        for item in result_evidence
+        if isinstance(item.get("reported_result"), dict)
+        and (reported_result := item["reported_result"])
+    }
+    has_opposing_directions = len(reported_directions) > 1
+    factor_phrase = (
+        ""
+        if not factors
+        else factors[0]
+        if len(factors) == 1
+        else f"{factors[0]} and {factors[1]}"
+        if len(factors) == 2
+        else f"{', '.join(factors[:-1])}, and {factors[-1]}"
+    )
     comparison_details = [
         (
             f"`{str(item.get('name') or '').strip()}: "
@@ -950,25 +997,42 @@ def build_finding_synthesis_prompt(
             "tuple, one outcome, comparison values, and attribution scope.\n\n"
         )
     comparison_contract = ""
-    if comparison_details:
+    if is_condition_series:
         comparison_contract += (
-            "- The statement must identify this complete source comparison: "
-            f"{', '.join(comparison_details)}.\n"
+            "- Treat the supplied comparisons as one reported condition series, "
+            "not as independent Findings.\n"
+            "- Start the statement with `Across the reported condition series, "
+            f"{factor_phrase} showed heterogeneous or opposing responses in "
+            f"{outcome}` and then summarize the response pattern.\n"
+            "- Do not include numeric values in the statement; keep every endpoint "
+            "bound to its individual Evidence record.\n"
         )
-    if result_value:
+    else:
+        if comparison_details:
+            comparison_contract += (
+                "- The statement must identify this complete source comparison: "
+                f"{', '.join(comparison_details)}.\n"
+            )
+        if result_value:
+            comparison_contract += (
+                "- The statement must state the source-reported result detail "
+                f"`{result_value}`.\n"
+            )
         comparison_contract += (
-            "- The statement must state the source-reported result detail "
-            f"`{result_value}`.\n"
+            "- Never return a generic restatement such as `factor affects outcome`; "
+            "state what differed between the compared groups.\n"
         )
-    comparison_contract += (
-        "- Never return a generic restatement such as `factor affects outcome`; "
-        "state what differed between the compared groups.\n"
-    )
+    if has_opposing_directions:
+        comparison_contract += (
+            "- The statement must explicitly describe the responses as heterogeneous "
+            "or opposing across conditions; the selected direction is not uniform.\n"
+        )
     if len(factors) > 1:
-        factor_phrase = (
-            f"{factors[0]} and {factors[1]}"
-            if len(factors) == 2
-            else f"{', '.join(factors[:-1])}, and {factors[-1]}"
+        joint_statement_contract = (
+            ""
+            if is_condition_series
+            else f"- Start the statement with `Joint changes in {factor_phrase} "
+            "were associated with` and then state the direction and outcome.\n"
         )
         exact_contract = (
             "Exact contract for this result set:\n"
@@ -976,8 +1040,7 @@ def build_finding_synthesis_prompt(
             f"- The statement must contain the outcome verbatim: `{outcome}`.\n"
             "- `assertion_strength` must be `associative`; this is a joint-factor "
             "comparison, never a single-factor causal effect.\n"
-            f"- Start the statement with `Joint changes in {factor_phrase} were "
-            "associated with` and then state the direction and outcome.\n"
+            f"{joint_statement_contract}"
             "- Omit numbers unless all numeric endpoints come from one complete "
             "supporting Evidence comparison.\n"
             f"{comparison_contract}\n"

--- a/backend/application/core/semantic_build/research_objective_service.py
+++ b/backend/application/core/semantic_build/research_objective_service.py
@@ -404,6 +404,7 @@ _OBJECTIVE_EXTRACTABLE_ROUTE_ROLES = {
 }
 _NUMBER_PATTERN = re.compile(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?")
 _BROAD_PROPERTY_AXIS_EXPANSIONS = {
+    "densification": ("relative density",),
     "mechanical properties": (
         "yield strength",
         "ultimate tensile strength",
@@ -752,6 +753,7 @@ class ResearchObjectiveService:
             collection_id=collection_id,
             extractor=objective_inputs["extractor"],
             objectives=(objective,),
+            paper_skims=objective_inputs["paper_skims"],
             objective_paper_frames=paper_frames,
             objective_evidence_routes=evidence_candidates,
             blocks_by_document_id=objective_inputs["blocks_by_document_id"],
@@ -2438,6 +2440,7 @@ class ResearchObjectiveService:
         collection_id: str,
         extractor: CoreLLMStructuredExtractor,
         objectives: tuple[ResearchObjective, ...],
+        paper_skims: tuple[PaperSkim, ...],
         objective_paper_frames: tuple[PaperAnalysisFrame, ...],
         objective_evidence_routes: tuple[EvidenceCandidate, ...],
         blocks_by_document_id: dict[str, list[Any]],
@@ -2656,7 +2659,12 @@ class ResearchObjectiveService:
             collection_id,
             len(units),
         )
-        bound_units = self._bind_objective_result_process_context(tuple(units))
+        enriched_units = self._enrich_objective_scope_context(
+            tuple(units),
+            objectives=objectives,
+            paper_skims=paper_skims,
+        )
+        bound_units = self._bind_objective_result_process_context(enriched_units)
         comparison_units = self._build_objective_pairwise_comparison_units(
             bound_units,
             objectives=objectives,
@@ -2668,6 +2676,70 @@ class ResearchObjectiveService:
                 len(comparison_units),
             )
         return (*bound_units, *comparison_units)
+
+    @staticmethod
+    def _enrich_objective_scope_context(
+        units: tuple[ExtractedEvidenceDraft, ...],
+        *,
+        objectives: tuple[ResearchObjective, ...],
+        paper_skims: tuple[PaperSkim, ...],
+    ) -> tuple[ExtractedEvidenceDraft, ...]:
+        objective_by_id = {item.objective_id: item for item in objectives}
+        skim_by_document_id = {item.document_id: item for item in paper_skims}
+        enriched: list[ExtractedEvidenceDraft] = []
+        for unit in units:
+            objective = objective_by_id.get(unit.objective_id)
+            paper_skim = skim_by_document_id.get(unit.document_id)
+            context = unit.scientific_context.to_record()
+            if not context["material"]:
+                material_values = (
+                    paper_skim.candidate_materials
+                    if paper_skim and paper_skim.candidate_materials
+                    else objective.material_scope
+                    if objective
+                    else ()
+                )
+                context["material"] = [
+                    {"name": "material", "value": value, "unit": None}
+                    for value in material_values
+                ]
+            if paper_skim and paper_skim.candidate_processes:
+                process_identity_names = {
+                    "fabrication process",
+                    "manufacturing process",
+                    "process",
+                    "processing method",
+                    "production process",
+                }
+                has_process_identity = any(
+                    " ".join(
+                        str(item.get("name") or "")
+                        .casefold()
+                        .replace("_", " ")
+                        .split()
+                    )
+                    in process_identity_names
+                    for item in context["process"]
+                )
+                if not has_process_identity:
+                    context["process"] = [
+                        *context["process"],
+                        *(
+                            {
+                                "name": "process",
+                                "value": value,
+                                "unit": None,
+                            }
+                            for value in paper_skim.candidate_processes
+                        ),
+                    ]
+            if context == unit.scientific_context.to_record():
+                enriched.append(unit)
+                continue
+            record = unit.to_record()
+            record["scientific_context"] = context
+            enriched.append(ExtractedEvidenceDraft.from_mapping(record))
+        return tuple(enriched)
 
     def _objective_table_route_should_skip_llm_fallback(
         self,

--- a/backend/application/core/semantic_build/research_objective_service.py
+++ b/backend/application/core/semantic_build/research_objective_service.py
@@ -2661,7 +2661,6 @@ class ResearchObjectiveService:
         )
         enriched_units = self._enrich_objective_scope_context(
             tuple(units),
-            objectives=objectives,
             paper_skims=paper_skims,
         )
         bound_units = self._bind_objective_result_process_context(enriched_units)
@@ -2681,22 +2680,17 @@ class ResearchObjectiveService:
     def _enrich_objective_scope_context(
         units: tuple[ExtractedEvidenceDraft, ...],
         *,
-        objectives: tuple[ResearchObjective, ...],
         paper_skims: tuple[PaperSkim, ...],
     ) -> tuple[ExtractedEvidenceDraft, ...]:
-        objective_by_id = {item.objective_id: item for item in objectives}
         skim_by_document_id = {item.document_id: item for item in paper_skims}
         enriched: list[ExtractedEvidenceDraft] = []
         for unit in units:
-            objective = objective_by_id.get(unit.objective_id)
             paper_skim = skim_by_document_id.get(unit.document_id)
             context = unit.scientific_context.to_record()
             if not context["material"]:
                 material_values = (
                     paper_skim.candidate_materials
                     if paper_skim and paper_skim.candidate_materials
-                    else objective.material_scope
-                    if objective
                     else ()
                 )
                 context["material"] = [

--- a/backend/domain/core/finding.py
+++ b/backend/domain/core/finding.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from hashlib import sha1
 import math
+import re
 from typing import Any, Final, Mapping
 
 from domain.core.research_objective import (
@@ -37,6 +38,10 @@ _CONTRADICTING_DIRECTIONS: Final[dict[str, frozenset[str]]] = {
     "worsen": frozenset({"improve", "no_change"}),
     "no_change": frozenset({"increase", "decrease", "improve", "worsen"}),
 }
+_J_PER_CUBIC_MM_RE = re.compile(
+    r"\bj\s*/\s*mm\s*(?:\^\s*)?(?:3|\u00b3)\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -688,10 +693,11 @@ def _strings(value: Any) -> tuple[str, ...]:
 
 
 def _normalize_term(value: Any) -> str:
+    text = _J_PER_CUBIC_MM_RE.sub("J/mm3", _text(value) or "")
     return " ".join(
         part
         for part in "".join(
             character.lower() if character.isalnum() else " "
-            for character in (_text(value) or "")
+            for character in text
         ).split()
     )

--- a/backend/tests/unit/services/test_core_llm_extractor.py
+++ b/backend/tests/unit/services/test_core_llm_extractor.py
@@ -694,7 +694,7 @@ def test_core_llm_extractor_synthesizes_goal_findings_with_distinct_trace():
     trace = extractor.consume_last_trace()
     assert trace is not None
     assert trace["task_type"] == "finding_synthesis"
-    assert trace["prompt_version"] == "finding_synthesis.v5"
+    assert trace["prompt_version"] == "finding_synthesis.v7"
     assert trace["parsed_output"] == {"findings": []}
 
 
@@ -821,6 +821,68 @@ def test_finding_synthesis_prompt_requires_specific_single_factor_result():
         "difference in microstructure:" in user_prompt
     )
     assert "Never return a generic restatement" in user_prompt
+
+
+def test_finding_synthesis_prompt_treats_multiple_intervals_as_condition_series():
+    payload = {
+        "objective": {
+            "question": "How does scan rotation affect yield strength?"
+        },
+        "result_set": {
+            "result_set_id": "result-set-rotation",
+            "factors": ["scan rotation"],
+            "outcome": "yield strength",
+            "result_evidence": [
+                {
+                    "evidence_id": "rotation-0-30",
+                    "changed_variables": [
+                        {
+                            "name": "scan rotation",
+                            "baseline_value": 0,
+                            "target_value": 30,
+                            "unit": "degree",
+                        }
+                    ],
+                    "reported_result": {
+                        "outcome": "yield strength",
+                        "value": 515,
+                        "unit": "MPa",
+                        "direction": "decrease",
+                    },
+                },
+                {
+                    "evidence_id": "rotation-30-45",
+                    "changed_variables": [
+                        {
+                            "name": "scan rotation",
+                            "baseline_value": 30,
+                            "target_value": 45,
+                            "unit": "degree",
+                        }
+                    ],
+                    "reported_result": {
+                        "outcome": "yield strength",
+                        "value": 545,
+                        "unit": "MPa",
+                        "direction": "increase",
+                    },
+                },
+            ],
+        },
+        "paper_contributions": [],
+        "context_evidence": [],
+    }
+
+    _system_prompt, user_prompt = build_finding_synthesis_prompt(payload)
+
+    assert "one reported condition series" in user_prompt
+    assert (
+        "Across the reported condition series, scan rotation showed "
+        "heterogeneous or opposing responses in yield strength"
+    ) in user_prompt
+    assert "Do not include numeric values in the statement" in user_prompt
+    assert "heterogeneous or opposing across conditions" in user_prompt
+    assert "source-reported result detail `515`" not in user_prompt
 
 
 def test_finding_synthesis_prompt_carries_backend_semantic_rejection():

--- a/backend/tests/unit/services/test_objective_finding_synthesis.py
+++ b/backend/tests/unit/services/test_objective_finding_synthesis.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -191,6 +192,18 @@ def _candidate(**overrides) -> dict:
     return payload
 
 
+def _heterogeneous_candidate(**overrides) -> dict:
+    overrides.setdefault(
+        "statement",
+        (
+            "Laser power and scan speed showed heterogeneous relative density "
+            "responses across the reported conditions, with an increase and an "
+            "opposing decrease."
+        ),
+    )
+    return _candidate(**overrides)
+
+
 def test_synthesis_builds_one_atomic_single_paper_finding() -> None:
     extractor = _Extractor([_candidate()])
     service = FindingSynthesisService(structured_extractor=extractor)
@@ -288,6 +301,28 @@ def test_synthesis_keeps_relative_density_out_of_defect_structure() -> None:
     assert result_sets == ()
 
 
+def test_synthesis_accepts_relative_density_for_densification_outcome() -> None:
+    service = FindingSynthesisService(structured_extractor=_Extractor([]))
+
+    result_sets = service._result_sets(
+        _objective(
+            variables=["energy density"],
+            outcomes=["densification"],
+        ),
+        (
+            _evidence(
+                "ev-relative-density",
+                "paper-1",
+                outcome="relative density",
+                factors=("energy density",),
+            ),
+        ),
+    )
+
+    assert len(result_sets) == 1
+    assert result_sets[0]["outcome"] == "relative density"
+
+
 def test_synthesis_derives_cross_paper_agreement() -> None:
     extractor = _Extractor([_candidate()])
     service = FindingSynthesisService(structured_extractor=extractor)
@@ -308,7 +343,7 @@ def test_synthesis_derives_cross_paper_agreement() -> None:
     assert finding.support_scope == "cross_paper"
 
 
-def test_synthesis_keeps_comparison_intervals_in_result_set_identity() -> None:
+def test_synthesis_groups_comparison_intervals_as_one_condition_series() -> None:
     service = FindingSynthesisService(structured_extractor=_Extractor([]))
     evidence = tuple(
         _evidence(
@@ -341,8 +376,41 @@ def test_synthesis_keeps_comparison_intervals_in_result_set_identity() -> None:
         evidence,
     )
 
-    assert len(result_sets) == 3
-    assert [len(item["result_evidence"]) for item in result_sets] == [1, 1, 1]
+    assert len(result_sets) == 1
+    assert [len(item["result_evidence"]) for item in result_sets] == [3]
+
+
+def test_synthesis_normalizes_scientific_unit_typography_for_display() -> None:
+    service = FindingSynthesisService(structured_extractor=_Extractor([]))
+
+    result_set = service._result_sets(
+        _objective(variables=["energy density"]),
+        (
+            _evidence(
+                "density-result",
+                "paper-1",
+                factors=("Energy density (J/mm 3 )",),
+                changed_variables=[
+                    {
+                        "name": "Energy density (J/mm 3 )",
+                        "baseline_value": 70,
+                        "target_value": 150,
+                        "unit": "J/ mm 3",
+                    }
+                ],
+            ),
+        ),
+    )[0]
+
+    assert result_set["factors"] == ["Energy density (J/mm3)"]
+    assert result_set["result_evidence"][0]["changed_variables"] == [
+        {
+            "name": "Energy density (J/mm3)",
+            "baseline_value": 70,
+            "target_value": 150,
+            "unit": "J/mm3",
+        }
+    ]
 
 
 def test_synthesis_does_not_use_complete_context_as_a_grouping_key() -> None:
@@ -385,18 +453,12 @@ def test_synthesis_does_not_use_complete_context_as_a_grouping_key() -> None:
 def test_synthesis_keeps_context_inside_one_comparison_interval() -> None:
     extractor = _Extractor(
         [
-            _candidate(
+            _heterogeneous_candidate(
                 statement=(
-                    "Scan strategy rotation angle was associated with increased "
-                    "yield strength."
+                    "Scan strategy rotation angle showed heterogeneous yield strength "
+                    "responses across the reported conditions, with an increase and "
+                    "an opposing decrease."
                 ),
-            ),
-            _candidate(
-                statement=(
-                    "Scan strategy rotation angle was associated with decreased "
-                    "yield strength."
-                ),
-                direction="decrease",
             ),
         ]
     )
@@ -676,6 +738,54 @@ def test_synthesis_rejects_statement_mixing_numeric_evidence_endpoints() -> None
     assert findings == ()
 
 
+def test_synthesis_rejects_numeric_endpoint_for_multi_interval_series() -> None:
+    extractor = _Extractor(
+        [
+            _heterogeneous_candidate(
+                statement=(
+                    "Across the reported condition series, laser power and scan "
+                    "speed from 70 to 150 showed heterogeneous relative density "
+                    "responses, with an increase and an opposing decrease."
+                ),
+            ),
+            None,
+        ]
+    )
+    service = FindingSynthesisService(structured_extractor=extractor)
+
+    findings = service.synthesize(
+        collection_id="col-1",
+        objective=_objective(),
+        analysis=_analysis(),
+        contributions=(_contribution("paper-1"),),
+        evidence_records=(
+            _evidence("series-70-100", "paper-1"),
+            _evidence(
+                "series-100-150",
+                "paper-1",
+                direction="decrease",
+                changed_variables=[
+                    {
+                        "name": "laser power",
+                        "baseline_value": 100,
+                        "target_value": 150,
+                    },
+                    {
+                        "name": "scan speed",
+                        "baseline_value": 900,
+                        "target_value": 800,
+                    },
+                ],
+            ),
+        ),
+    )
+
+    assert findings == ()
+    assert extractor.payloads[1]["candidate_rejection"]["reason"] == (
+        "condition-series statement contains a numeric endpoint"
+    )
+
+
 def test_synthesis_rejects_statement_number_absent_from_bound_evidence() -> None:
     service = FindingSynthesisService(
         structured_extractor=_Extractor(
@@ -779,7 +889,7 @@ def test_synthesis_derives_all_same_direction_results_as_support() -> None:
 
 def test_synthesis_derives_opposing_result_as_contradiction() -> None:
     service = FindingSynthesisService(
-        structured_extractor=_Extractor([_candidate()])
+        structured_extractor=_Extractor([_heterogeneous_candidate()])
     )
     evidence = (
         _evidence("ev-1", "paper-1"),
@@ -800,6 +910,45 @@ def test_synthesis_derives_opposing_result_as_contradiction() -> None:
     assert finding.supporting_evidence_ids == ("ev-1",)
     assert finding.contradicting_evidence_ids == ("conflict-1",)
     assert finding.synthesis_status == "conflict"
+
+
+def test_synthesis_requires_within_paper_heterogeneity_in_statement_and_limitations(
+) -> None:
+    extractor = _Extractor(
+        [
+            _candidate(),
+            _candidate(
+                statement=(
+                    "Across the reported conditions, joint changes in laser power "
+                    "and scan speed showed heterogeneous relative density responses: "
+                    "increases were accompanied by an opposing decrease."
+                )
+            ),
+        ]
+    )
+    service = FindingSynthesisService(structured_extractor=extractor)
+
+    finding = service.synthesize(
+        collection_id="col-1",
+        objective=_objective(),
+        analysis=_analysis(),
+        contributions=(_contribution("paper-1"),),
+        evidence_records=(
+            _evidence("increase-1", "paper-1"),
+            _evidence("increase-2", "paper-1"),
+            _evidence("decrease-1", "paper-1", direction="decrease"),
+        ),
+    )[0]
+
+    assert len(extractor.payloads) == 2
+    assert "opposing directions" in extractor.payloads[1]["candidate_rejection"][
+        "reason"
+    ]
+    assert "heterogeneous" in finding.statement
+    assert (
+        "Within-paper condition comparisons report opposing directions."
+        in finding.limitations
+    )
 
 
 def test_synthesis_rejects_result_direction_that_is_not_an_explicit_opposition() -> None:
@@ -826,8 +975,9 @@ def test_synthesis_assigns_support_and_contradiction_by_direction_not_role() -> 
                 _candidate(
                     direction="decrease",
                     statement=(
-                        "Laser power and scan speed were jointly associated with a "
-                        "decrease in relative density."
+                        "Laser power and scan speed showed heterogeneous relative "
+                        "density responses across the reported conditions, with a "
+                        "decrease and an opposing increase."
                     ),
                 )
             ]
@@ -876,6 +1026,69 @@ def test_synthesis_does_not_drop_results_after_the_first_48() -> None:
     )[0]
 
     assert len(extractor.payloads[0]["result_set"]["result_evidence"]) == 49
+    assert finding.direct_document_count == 49
+
+
+def test_synthesis_compacts_large_condition_series_without_dropping_results() -> None:
+    evidence_ids = [f"condition-series-{index}" for index in range(49)]
+    extractor = _Extractor([_candidate()])
+    service = FindingSynthesisService(structured_extractor=extractor)
+    contributions = tuple(
+        _contribution(f"paper-{'x' * 96}-{index}") for index in range(49)
+    )
+    long_result_text = "relative density changed across this comparison " * 30
+    evidence = tuple(
+        _evidence(
+            evidence_id,
+            contributions[index].document_id,
+            source_excerpt="source evidence " * 200,
+            changed_variables=[
+                {
+                    "name": "laser power",
+                    "baseline_value": index,
+                    "target_value": index + 1,
+                },
+                {
+                    "name": "scan speed",
+                    "baseline_value": 1000 - index,
+                    "target_value": 999 - index,
+                },
+            ],
+            reported_result={
+                "outcome": "relative density",
+                "value": 95 + index / 100,
+                "unit": "%",
+                "direction": "increase",
+                "result_text": long_result_text,
+            },
+        )
+        for index, evidence_id in enumerate(evidence_ids)
+    )
+
+    finding = service.synthesize(
+        collection_id="col-1",
+        objective=_objective(),
+        analysis=_analysis(),
+        contributions=contributions,
+        evidence_records=evidence,
+    )[0]
+
+    payload = extractor.payloads[0]
+    result_evidence = payload["result_set"]["result_evidence"]
+    assert len(result_evidence) == len(evidence_ids)
+    assert {item["evidence_id"] for item in result_evidence} == set(evidence_ids)
+    assert all(
+        set(item)
+        == {
+            "evidence_id",
+            "document_id",
+            "changed_variables",
+            "reported_result",
+            "attribution_scope",
+        }
+        for item in result_evidence
+    )
+    assert len(json.dumps(payload, ensure_ascii=False, separators=(",", ":"))) < 45_000
     assert finding.direct_document_count == 49
 
 
@@ -946,7 +1159,7 @@ def test_synthesis_bounds_prompt_excerpts_and_context_without_dropping_results()
 
 def test_synthesis_derives_conflict_and_preserves_both_papers() -> None:
     extractor = _Extractor(
-        [_candidate()]
+        [_heterogeneous_candidate()]
     )
     service = FindingSynthesisService(structured_extractor=extractor)
 
@@ -981,7 +1194,7 @@ def test_synthesis_does_not_treat_cited_context_as_a_condition_boundary() -> Non
     )
     extractor = _Extractor(
         [
-            _candidate(
+            _heterogeneous_candidate(
                 context_evidence_ids=["condition-2"],
                 condition_boundary_evidence_ids=["conflict-1", "condition-2"],
             )
@@ -1013,7 +1226,11 @@ def test_synthesis_does_not_treat_cited_context_as_a_condition_boundary() -> Non
 def test_synthesis_direct_result_cannot_be_a_condition_boundary() -> None:
     service = FindingSynthesisService(
         structured_extractor=_Extractor(
-            [_candidate(condition_boundary_evidence_ids=["conflict-1"])]
+            [
+                _heterogeneous_candidate(
+                    condition_boundary_evidence_ids=["conflict-1"]
+                )
+            ]
         )
     )
 
@@ -1039,7 +1256,9 @@ def test_synthesis_direct_result_cannot_be_a_condition_boundary() -> None:
 
 def test_synthesis_derives_condition_boundary_from_opposing_papers_with_disjoint_context(
 ) -> None:
-    service = FindingSynthesisService(structured_extractor=_Extractor([_candidate()]))
+    service = FindingSynthesisService(
+        structured_extractor=_Extractor([_heterogeneous_candidate()])
+    )
     shared = {"material": [], "sample": [], "test": []}
 
     finding = service.synthesize(
@@ -1086,7 +1305,7 @@ def test_synthesis_does_not_link_model_boundary_context_implicitly() -> None:
     )
     extractor = _Extractor(
         [
-            _candidate(
+            _heterogeneous_candidate(
                 condition_boundary_evidence_ids=["condition-2"],
             )
         ]
@@ -1118,7 +1337,7 @@ def test_synthesis_does_not_link_model_boundary_context_implicitly() -> None:
 def test_synthesis_drops_boundary_labels_that_are_not_evidence_ids() -> None:
     extractor = _Extractor(
         [
-            _candidate(
+            _heterogeneous_candidate(
                 condition_boundary_evidence_ids=["Fixed scan speed"],
             )
         ]

--- a/backend/tests/unit/services/test_research_objective_service.py
+++ b/backend/tests/unit/services/test_research_objective_service.py
@@ -4515,7 +4515,6 @@ def test_research_objective_service_enriches_missing_source_backed_scope_context
 
     enriched = service._enrich_objective_scope_context(
         (evidence,),
-        objectives=(objective,),
         paper_skims=(paper_skim,),
     )[0]
 
@@ -4534,6 +4533,42 @@ def test_research_objective_service_enriches_missing_source_backed_scope_context
         ],
         "test": [],
     }
+
+
+def test_research_objective_service_does_not_invent_material_without_document_skim(
+    tmp_path,
+):
+    service = _build_research_objective_service(
+        collection_service=build_test_collection_service(tmp_path / "collections"),
+    )
+    evidence = ExtractedEvidenceDraft.from_mapping(
+        {
+            "evidence_id": "density-result",
+            "objective_id": "obj-density",
+            "document_id": "paper-1",
+            "source_kind": "table",
+            "source_ref": "table-1",
+            "evidence_role": "direct_result",
+            "changed_variables": [
+                {"name": "energy density", "target_value": 150}
+            ],
+            "reported_result": {
+                "outcome": "relative density",
+                "direction": "increase",
+                "result_text": "Relative density increased.",
+            },
+            "attribution_scope": "association_only",
+            "resolution_status": "resolved",
+            "confidence": 0.9,
+        }
+    )
+
+    enriched = service._enrich_objective_scope_context(
+        (evidence,),
+        paper_skims=(),
+    )[0]
+
+    assert enriched.scientific_context.material == ()
 
 
 def test_research_objective_service_routes_matching_tables_beyond_seed_documents(

--- a/backend/tests/unit/services/test_research_objective_service.py
+++ b/backend/tests/unit/services/test_research_objective_service.py
@@ -315,6 +315,7 @@ def test_objective_evidence_document_state_is_typed_and_document_scoped(tmp_path
         collection_id="col-test",
         extractor=extractor,
         objectives=(objective,),
+        paper_skims=(),
         objective_paper_frames=(),
         objective_evidence_routes=routes,
         blocks_by_document_id=blocks,
@@ -409,6 +410,7 @@ def test_objective_evidence_continues_after_one_route_format_failure(tmp_path):
         collection_id="col-test",
         extractor=extractor,
         objectives=(objective,),
+        paper_skims=(),
         objective_paper_frames=(),
         objective_evidence_routes=routes,
         blocks_by_document_id={"paper-1": blocks},
@@ -483,6 +485,7 @@ def test_objective_context_drops_model_changed_variable_without_values(tmp_path)
         collection_id="col-test",
         extractor=ContextExtractor(),
         objectives=(objective,),
+        paper_skims=(),
         objective_paper_frames=(),
         objective_evidence_routes=(route,),
         blocks_by_document_id={"paper-1": [block]},
@@ -4206,6 +4209,7 @@ def test_research_objective_evidence_prompt_compacts_long_text_source(
         collection_id="col-test",
         extractor=extractor,
         objectives=(objective,),
+        paper_skims=(),
         objective_paper_frames=(frame,),
         objective_evidence_routes=(route,),
         blocks_by_document_id={"paper-1": [block]},
@@ -4435,6 +4439,103 @@ def test_research_objective_service_uses_objective_scientific_intent_directly(
     }
 
 
+def test_research_objective_service_enriches_missing_source_backed_scope_context(
+    tmp_path,
+):
+    service = _build_research_objective_service(
+        collection_service=build_test_collection_service(tmp_path / "collections"),
+    )
+    objective = _research_objective(
+        {
+            "objective_id": "obj-density",
+            "question": "How does energy density affect relative density?",
+            "material_scope": ["316L stainless steel"],
+            "variables": ["energy density"],
+            "outcomes": ["relative density"],
+        }
+    )
+    paper_skim = PaperSkim.from_mapping(
+        {
+            "document_id": "paper-1",
+            "doc_role": "experimental",
+            "candidate_materials": ["316L stainless steel"],
+            "candidate_processes": ["selective laser melting"],
+            "candidate_properties": ["relative density"],
+            "changed_variables": ["energy density"],
+            "possible_objectives": [objective.question],
+            "evidence_density": "high",
+            "confidence": 0.9,
+        }
+    )
+    evidence = ExtractedEvidenceDraft.from_mapping(
+        {
+            "evidence_id": "density-result",
+            "objective_id": objective.objective_id,
+            "document_id": "paper-1",
+            "source_kind": "table",
+            "source_ref": "table-1",
+            "evidence_role": "direct_result",
+            "changed_variables": [
+                {
+                    "name": "energy density",
+                    "baseline_value": 70,
+                    "target_value": 150,
+                    "unit": "J/mm3",
+                }
+            ],
+            "comparison": {
+                "baseline_label": "condition 1",
+                "target_label": "condition 2",
+                "axis_names": ["energy density"],
+                "comparable": True,
+            },
+            "reported_result": {
+                "outcome": "relative density",
+                "value": 99.2,
+                "unit": "%",
+                "direction": "increase",
+                "result_text": "Relative density increased to 99.2%.",
+            },
+            "attribution_scope": "isolated_effect",
+            "scientific_context": {
+                "material": [],
+                "sample": [],
+                "process": [
+                    {"name": "hatch space", "value": 0.1, "unit": "mm"}
+                ],
+                "test": [],
+            },
+            "source_refs": [
+                {"source_kind": "table", "source_ref": "table-1"}
+            ],
+            "resolution_status": "resolved",
+            "confidence": 0.9,
+        }
+    )
+
+    enriched = service._enrich_objective_scope_context(
+        (evidence,),
+        objectives=(objective,),
+        paper_skims=(paper_skim,),
+    )[0]
+
+    assert enriched.scientific_context.to_record() == {
+        "material": [
+            {"name": "material", "value": "316L stainless steel", "unit": None}
+        ],
+        "sample": [],
+        "process": [
+            {"name": "hatch space", "value": 0.1, "unit": "mm"},
+            {
+                "name": "process",
+                "value": "selective laser melting",
+                "unit": None,
+            }
+        ],
+        "test": [],
+    }
+
+
 def test_research_objective_service_routes_matching_tables_beyond_seed_documents(
     tmp_path,
 ):
@@ -4632,6 +4733,30 @@ def test_real_ved_process_and_defect_tables_form_joint_comparison(tmp_path):
         "table-2",
         "table-5",
     }
+
+
+def test_objective_densification_outcome_includes_relative_density_evidence(
+    tmp_path,
+):
+    service = _build_research_objective_service(
+        collection_service=build_test_collection_service(tmp_path / "collections"),
+    )
+    objective = _research_objective(
+        {
+            "objective_id": "obj-density",
+            "question": "How does energy density affect densification?",
+            "variables": ["energy density"],
+            "outcomes": ["densification"],
+        }
+    )
+
+    target_axes = service._objective_outcomes(objective)
+
+    assert target_axes == ("densification", "relative density")
+    assert service._objective_property_matches_target_axes(
+        "relative density",
+        target_axes=target_axes,
+    )
 
 
 def test_real_p001_density_table_retains_complete_changed_factor_tuple(tmp_path):


### PR DESCRIPTION
## Summary

- group exact factor tuples and outcomes into condition-series Findings instead of interval fragments
- preserve all persisted Evidence while compacting large model payloads
- recognize relative density as densification evidence and enrich missing material/process identity only from same-document PaperSkim
- constrain mixed-direction and multi-interval wording so summaries remain faithful to individual Evidence records
- add focused regression coverage and update the owning semantic-build documentation

## Contract impact

- no public API or migration changes
- no dependency, Docker, compose, workflow, or release changes
- source, page, table-row, and column traceback remains intact
- Objective scope is never substituted for document-derived Evidence context

## Verification

- 271 relevant backend tests passed
- `python3 scripts/check_docs_governance.py` passed: 93 governed docs, 144 Markdown files
- `git diff --check` passed
- Python compile check passed for changed backend modules

## Real workflow evidence

A fresh local backend ran the authenticated upload/objective-analysis path against the real PDF fixture:

- analysis task succeeded
- 134 Evidence records persisted
- 4 traceable Findings produced
- four-factor condition series contains 22 Evidence records: 16 support and 6 oppose
- all Findings contain 316L stainless steel and Selective laser melting (SLM) scope from same-document PaperSkim data
- multi-interval statements contain no numeric endpoints

The fixture contains one paper, so this validates within-paper synthesis and traceback, not cross-paper confirmation.