### PR TITLE
bugfix(objectives): 稳定目标发现和证据提取

### DIFF
--- a/backend/application/core/objectives/extraction.py
+++ b/backend/application/core/objectives/extraction.py
@@ -23,6 +23,7 @@ from application.core.objectives.prompts import (
     build_research_objective_merge_prompt,
 )
 from application.core.objectives.schemas import (
+    PAPER_SKIM_OUTPUT_LIMITS,
     StructuredAxisCanonicalizationPlan,
     StructuredEvidenceExtractions,
     StructuredEvidenceSelections,
@@ -93,6 +94,7 @@ class ObjectiveExtractor:
             user_prompt=user_prompt,
             response_model=StructuredPaperSkim,
             max_completion_tokens=_PAPER_SKIM_MAX_COMPLETION_TOKENS,
+            json_text_parser=self._parse_paper_skim_json_response,
         )
         if not isinstance(response, StructuredPaperSkim):
             raise TypeError("unexpected paper skim response type")
@@ -364,6 +366,7 @@ class ObjectiveExtractor:
         response_model: type[BaseModel],
         max_completion_tokens: int | None,
         repair_instruction_builder: Callable[[str], str] | None = None,
+        payload_normalizer: Callable[[Any], Any] | None = None,
     ) -> tuple[BaseModel, str | None]:
         request_kwargs = {
             "model": self.model,
@@ -418,6 +421,8 @@ class ObjectiveExtractor:
                         "structured extraction returned empty response content"
                     )
                 payload = load_json_payload(extract_json_object(raw_content))
+                if payload_normalizer is not None:
+                    payload = payload_normalizer(payload)
                 try:
                     return response_model.model_validate(payload), raw_content
                 except ValidationError:
@@ -447,6 +452,68 @@ class ObjectiveExtractor:
                     continue
                 raise
         raise RuntimeError("structured extraction failed after retry") from last_error
+
+    def _parse_paper_skim_json_response(
+        self,
+        *,
+        messages: list[dict[str, str]],
+        response_model: type[BaseModel],
+        max_completion_tokens: int | None,
+    ) -> tuple[BaseModel, str | None]:
+        return self._parse_json_text_response(
+            messages=messages,
+            response_model=response_model,
+            max_completion_tokens=max_completion_tokens,
+            payload_normalizer=self._normalize_paper_skim_payload,
+        )
+
+    @staticmethod
+    def _normalize_paper_skim_payload(payload: Any) -> Any:
+        if not isinstance(payload, dict):
+            return payload
+        normalized = dict(payload)
+        normalized_fields: list[str] = []
+        for field_name, (max_items, max_characters) in PAPER_SKIM_OUTPUT_LIMITS.items():
+            values = payload.get(field_name)
+            if not isinstance(values, list):
+                continue
+            bounded_values = [
+                ObjectiveExtractor._bound_paper_skim_text(
+                    value,
+                    max_characters=max_characters,
+                    preserve_question_mark=field_name == "possible_objectives",
+                )
+                if isinstance(value, str)
+                else value
+                for value in values[:max_items]
+            ]
+            if bounded_values != values:
+                normalized[field_name] = bounded_values
+                normalized_fields.append(field_name)
+        if normalized_fields:
+            logger.warning(
+                "Normalized PaperSkim model output to schema bounds fields=%s",
+                ",".join(normalized_fields),
+            )
+        return normalized
+
+    @staticmethod
+    def _bound_paper_skim_text(
+        value: str,
+        *,
+        max_characters: int,
+        preserve_question_mark: bool,
+    ) -> str:
+        compact = " ".join(value.split())
+        if len(compact) <= max_characters:
+            return compact
+        suffix = "?" if preserve_question_mark and compact.endswith("?") else ""
+        prefix_limit = max_characters - len(suffix)
+        prefix = compact[:prefix_limit].rstrip()
+        if " " in prefix:
+            prefix = prefix.rsplit(" ", 1)[0]
+        prefix = prefix.rstrip(" ,;:")
+        return f"{prefix}{suffix}"
 
     def _parse_finding_synthesis_json_response(
         self,
@@ -682,7 +749,14 @@ class ObjectiveExtractor:
             "model": self.model,
             "temperature": 0,
             "messages": messages,
-            "response_format": {"type": "json_object"},
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "structured_evidence_extractions",
+                    "schema": StructuredEvidenceExtractions.model_json_schema(),
+                    "strict": True,
+                },
+            },
             **self._provider_request_options(),
         }
         if max_completion_tokens is not None:
@@ -712,23 +786,32 @@ class ObjectiveExtractor:
                     )
                 else:
                     repair_detail = str(last_error or "invalid structured output")
+                if "echoed input fields" in repair_detail:
+                    retry_instruction = (
+                        "Your previous response only echoed the input fields and did "
+                        "not perform evidence extraction. Do not repeat OBJECTIVE, "
+                        "OBJECTIVE VARIABLES, OBJECTIVE OUTCOMES, ROUTE HINT, SOURCE "
+                        "KIND, or SOURCE. Re-read SOURCE and return exactly one compact "
+                        "JSON object with the single top-level key `extractions`. Use "
+                        "{\"extractions\":[]} only when SOURCE contains no comparison "
+                        "that answers the objective."
+                    )
+                else:
+                    retry_instruction = (
+                        "Previous evidence extraction output failed validation: "
+                        f"{repair_detail[:1000]}. Return at most one schema-valid "
+                        "extraction or {\"extractions\":[]}. Context evidence must "
+                        "use reported_result null, no changed variables, no "
+                        "comparison, and not_attributable. One extraction represents "
+                        "one comparison interval. isolated_effect requires exactly one "
+                        "distinct changed-variable name and a comparable comparison; "
+                        "joint_effect requires at least two distinct changed-variable "
+                        "names. Never repeat a changed-variable name; for a condition "
+                        "series choose one complete source-supported pair. Return only "
+                        "compact JSON."
+                    )
                 attempt_messages.append(
-                    {
-                        "role": "user",
-                        "content": (
-                            "Previous evidence extraction output failed validation: "
-                            f"{repair_detail[:1000]}. Return at most one schema-valid "
-                            "extraction or {\"extractions\":[]}. Context evidence must "
-                            "use reported_result null, no changed variables, no "
-                            "comparison, and not_attributable. One extraction represents "
-                            "one comparison interval. isolated_effect requires exactly one "
-                            "distinct changed-variable name and a comparable comparison; "
-                            "joint_effect requires at least two distinct changed-variable "
-                            "names. Never repeat a changed-variable name; for a condition "
-                            "series choose one complete source-supported pair. Return only "
-                            "compact JSON."
-                        ),
-                    }
+                    {"role": "user", "content": retry_instruction}
                 )
                 logger.warning(
                     "Retrying objective evidence JSON response model=%s",
@@ -768,7 +851,10 @@ class ObjectiveExtractor:
                         and bool(payload)
                         and set(payload) <= echoed_prompt_keys
                     ):
-                        return StructuredEvidenceExtractions(), raw_content
+                        raise ValueError(
+                            "objective evidence response echoed input fields instead "
+                            "of returning extractions"
+                        )
                     if isinstance(payload, dict):
                         extra_keys = set(payload) - set(response_model.model_fields)
                         if extra_keys - {"confidence"}:

--- a/backend/application/core/objectives/prompts.py
+++ b/backend/application/core/objectives/prompts.py
@@ -68,7 +68,13 @@ DECISION PROCESS
 3. Result source: include exactly one `reported_result`. One extraction represents
    one baseline-to-target comparison interval. Identify every changed factor and
    use exact source group labels or values as endpoints. If SOURCE reports a
-   condition series, choose one complete source-supported pair.
+   condition series, choose one complete source-supported pair. Never convert an
+   absent, off, or without condition to numeric 0; retain the exact source phrase
+   as a categorical endpoint with a null unit. The canonical OBJECTIVE outcome may
+   appear under inflected, narrower, or synonymous SOURCE wording; keep the
+   canonical name in `reported_result.outcome` but copy the exact source-local
+   result clause into `result_text`. A complete comparison may bind endpoint
+   phrases stated in separate sentences of the same SOURCE unit.
 4. Never repeat a changed-variable name. Use `isolated_effect` only for one
    distinct changed factor with a complete comparable baseline/target comparison.
    Use `joint_effect` for two or more distinct changed factors. Otherwise use
@@ -80,7 +86,8 @@ HARD RULES
 - Return at most one extraction. Never repeat the input or output reasoning,
   markdown, source ids, or backend ids.
 - `result_text` is the only source text allowed in output and must be a short
-  verbatim substring.
+  verbatim substring: one contiguous span copied from SOURCE. Never synthesize it
+  from separate clauses or copy wording from a boundary example.
 - A result direction describes the objective outcome, never an intermediate
   mechanism. Use `mixed` for an unordered qualitative change.
 - When SOURCE mixes current work with cited literature, extract current work only.
@@ -94,6 +101,11 @@ HARD RULES
 BOUNDARY EXAMPLES
 Context source:
 {"extractions":[{"evidence_role":"condition_context","changed_variables":[],"comparison":null,"reported_result":null,"attribution_scope":"not_attributable","scientific_context":{"material":[],"sample":[],"process":[{"name":"build platform temperature","value":100,"unit":"C"}],"test":[]},"resolution_status":"resolved","confidence":0.9}]}
+
+Categorical endpoint and source-local outcome wording:
+OBJECTIVE OUTCOME: crack formation
+SOURCE: Cracks were abundant without preheating. Application of preheating largely reduces this cracking behavior, though cracks remain after preheating at 400 C.
+OUTPUT: {"extractions":[{"evidence_role":"direct_result","changed_variables":[{"name":"preheating","baseline_value":"without preheating","target_value":"preheating at 400 C","unit":null}],"comparison":{"baseline_label":"without preheating","target_label":"preheating at 400 C","axis_names":["preheating"],"comparable":true,"incomparability_reasons":[]},"reported_result":{"outcome":"crack formation","value":null,"unit":null,"direction":"decrease","result_text":"Application of preheating largely reduces this cracking behavior"},"attribution_scope":"isolated_effect","scientific_context":{"material":[],"sample":[],"process":[],"test":[]},"resolution_status":"resolved","confidence":0.9}]}
 
 Joint result source:
 {"extractions":[{"evidence_role":"direct_result","changed_variables":[{"name":"laser power","baseline_value":100,"target_value":200,"unit":"W"},{"name":"scan speed","baseline_value":500,"target_value":900,"unit":"mm/s"}],"comparison":{"baseline_label":"A","target_label":"B","axis_names":["laser power","scan speed"],"comparable":true,"incomparability_reasons":[]},"reported_result":{"outcome":"relative density","value":98.0,"unit":"%","direction":"increase","result_text":"relative density increased to 98.0%"},"attribution_scope":"joint_effect","scientific_context":{"material":[],"sample":[],"process":[],"test":[]},"resolution_status":"resolved","confidence":0.9}]}
@@ -247,10 +259,20 @@ def build_paper_skim_prompt(payload: dict[str, Any]) -> tuple[str, str]:
         "6. Use evidence density, confidence, and warnings to expose incomplete or "
         "ambiguous input rather than filling gaps.\n\n"
         "HARD RULES\n"
-        "- Return only the schema object and use at most a few high-signal values.\n"
+        "- Return only the schema object. Rank every list from most central and "
+        "explicitly supported to least central so bounded consumers retain the "
+        "strongest values.\n"
         "- Do not extract final measurements, sample-level results, or source ids.\n"
         "- Do not infer scientific content from filenames or generic section names.\n"
-        "- Return empty arrays rather than guessing unsupported axes or objectives."
+        "- Return empty arrays rather than guessing unsupported axes or objectives.\n\n"
+        "OUTPUT CONTRACT\n"
+        "- Return up to 8 `candidate_materials`, each at most 80 characters.\n"
+        "- Return up to 4 `candidate_processes`, each at most 80 characters.\n"
+        "- Return up to 8 `candidate_properties`, each at most 80 characters.\n"
+        "- Return up to 8 `changed_variables`, each at most 80 characters.\n"
+        "- Return up to 3 `possible_objectives`, each at most 320 characters.\n"
+        "- Return up to 2 `warnings`, each at most 240 characters.\n"
+        "- Keep each value concise; do not combine distinct list values into one item."
     )
     return _RESEARCH_OBJECTIVE_SYSTEM_PROMPT, user_prompt
 

--- a/backend/application/core/objectives/property_matching.py
+++ b/backend/application/core/objectives/property_matching.py
@@ -138,6 +138,19 @@ _PROCESS_SYMBOL_AXIS_HINTS = {
 }
 
 _EXPLICIT_AXIS_SYNONYMS = {
+    "base plate preheating temperature": (
+        "base plate preheating",
+        "baseplate preheating",
+        "baseplate preheating temperature",
+        "build platform preheating temperature",
+        "preheating",
+        "preheating temperature",
+    ),
+    "crack formation": (
+        "cracking",
+        "cracking behavior",
+        "microcrack formation",
+    ),
     "scan strategy": ("scanning strategy",),
     "scanning strategy": ("scan strategy",),
 }

--- a/backend/application/core/objectives/research_objective_service.py
+++ b/backend/application/core/objectives/research_objective_service.py
@@ -999,8 +999,10 @@ class ResearchObjectiveService:
                     max(frame_count - frame_position, 0),
                 )
                 continue
+            objective_context = objective
             source_candidates = self._build_route_source_candidates(
                 frame=frame,
+                objective_context=objective_context,
                 blocks=blocks_by_document_id.get(frame.document_id, []),
                 tables=tables_by_document_id.get(frame.document_id, []),
                 document_tree=document_trees_by_document_id.get(frame.document_id),
@@ -1023,7 +1025,6 @@ class ResearchObjectiveService:
                 (candidate["source_kind"], candidate["source_ref"]): candidate
                 for candidate in source_candidates
             }
-            objective_context = objective_by_id.get(frame.objective_id)
             for candidate in source_candidates:
                 if candidate.get("frame_status") == "excluded":
                     route_key = (
@@ -1619,7 +1620,10 @@ class ResearchObjectiveService:
         join_plan = dict(updated.get("join_plan") or {})
         join_plan["evidence_role"] = evidence_role
         updated["join_plan"] = join_plan
-        if evidence_role == "irrelevant":
+        if evidence_role == "direct_support":
+            updated["role"] = "current_experimental_evidence"
+            updated["extractable"] = True
+        elif evidence_role == "irrelevant":
             updated["role"] = "low_value_or_irrelevant"
             updated["extractable"] = False
         elif evidence_role == "mediator_context":
@@ -4151,7 +4155,10 @@ class ResearchObjectiveService:
                     "decreasing",
                     "lower",
                     "less",
+                    "reduce",
                     "reduced",
+                    "reduces",
+                    "reducing",
                     "reduction",
                     "smaller",
                 ),
@@ -4886,6 +4893,7 @@ class ResearchObjectiveService:
         self,
         *,
         frame: PaperAnalysisFrame,
+        objective_context: ResearchObjective,
         blocks: list[Any],
         tables: list[Any],
         document_tree: SourceDocumentTree | None = None,
@@ -4921,6 +4929,7 @@ class ResearchObjectiveService:
         if document_tree is not None:
             text_candidates = self._build_tree_route_text_candidates(
                 frame=frame,
+                objective_context=objective_context,
                 blocks=blocks,
                 document_tree=document_tree,
             )
@@ -4931,6 +4940,7 @@ class ResearchObjectiveService:
             )
             text_candidates = self._build_ranked_route_text_candidates(
                 frame=frame,
+                objective_context=objective_context,
                 blocks=blocks,
                 limit=text_candidate_limit,
             )
@@ -5309,6 +5319,7 @@ class ResearchObjectiveService:
         self,
         *,
         frame: PaperAnalysisFrame,
+        objective_context: ResearchObjective,
         blocks: list[Any],
         limit: int,
     ) -> list[dict[str, Any]]:
@@ -5333,6 +5344,7 @@ class ResearchObjectiveService:
                 continue
             score = self._route_text_candidate_score(
                 frame=frame,
+                objective_context=objective_context,
                 block_type=block_type,
                 section_label=section_label,
                 text=text,
@@ -5363,6 +5375,7 @@ class ResearchObjectiveService:
         self,
         *,
         frame: PaperAnalysisFrame,
+        objective_context: ResearchObjective,
         blocks: list[Any],
         document_tree: SourceDocumentTree,
     ) -> list[dict[str, Any]]:
@@ -5406,6 +5419,7 @@ class ResearchObjectiveService:
                 continue
             score = self._route_text_candidate_score(
                 frame=frame,
+                objective_context=objective_context,
                 block_type=block_type,
                 section_label=section_label,
                 text=text,
@@ -5428,6 +5442,7 @@ class ResearchObjectiveService:
             )
         scored_candidates = self._bounded_tree_route_text_candidates(
             frame=frame,
+            objective_context=objective_context,
             scored_candidates=scored_candidates,
         )
         return [
@@ -5445,6 +5460,7 @@ class ResearchObjectiveService:
         self,
         *,
         frame: PaperAnalysisFrame,
+        objective_context: ResearchObjective,
         scored_candidates: list[tuple[int, int, dict[str, Any]]],
     ) -> list[tuple[int, int, dict[str, Any]]]:
         if len(scored_candidates) <= _ROUTE_TEXT_CANDIDATE_LIMIT:
@@ -5461,7 +5477,7 @@ class ResearchObjectiveService:
             item
             for item in sorted(scored_candidates)
             if self._route_text_candidate_is_direct_result(
-                frame=frame,
+                objective_context=objective_context,
                 candidate=item[2],
             )
         ]
@@ -5532,7 +5548,7 @@ class ResearchObjectiveService:
     def _route_text_candidate_is_direct_result(
         self,
         *,
-        frame: PaperAnalysisFrame,
+        objective_context: ResearchObjective,
         candidate: Mapping[str, Any],
     ) -> bool:
         text = str(candidate.get("text") or "")
@@ -5540,15 +5556,37 @@ class ResearchObjectiveService:
             return False
         mentions_variable = any(
             property_matching.source_text_mentions_axis(text, axis)
-            for axis in frame.changed_variables
+            for axis in objective_context.variables
         )
         mentions_outcome = any(
             property_matching.source_text_mentions_axis(text, axis)
-            for axis in frame.measured_property_scope
+            for axis in objective_context.outcomes
         )
         if not mentions_outcome:
             return False
         text_haystack = text.casefold()
+        if not mentions_variable:
+            text_tokens = property_matching.axis_tokens(text_haystack)
+            outcome_tokens = set().union(
+                *(
+                    property_matching.axis_tokens(
+                        property_matching.axis_key(axis)
+                    )
+                    for axis in objective_context.outcomes
+                )
+            )
+            mentions_variable = any(
+                any(
+                    len(token) >= 4
+                    and token not in {"base", "plate"}
+                    and token not in outcome_tokens
+                    and token in text_tokens
+                    for token in property_matching.axis_tokens(
+                        property_matching.axis_key(axis)
+                    )
+                )
+                for axis in objective_context.variables
+            )
         has_result_comparison = any(
             phrase in text_haystack
             for phrase in (
@@ -5556,13 +5594,20 @@ class ResearchObjectiveService:
                 "compared to",
                 "comparing",
                 "decreased",
+                "diminish",
                 "exhibited",
                 "higher than",
                 "increased",
                 "lower than",
+                "not significantly influence",
                 "observed",
+                "prevent",
+                "prohibit",
+                "reduc",
                 "resulted in",
                 "resulted into",
+                "significant effect",
+                "unchanged",
             )
         )
         return has_result_comparison and (
@@ -5653,6 +5698,7 @@ class ResearchObjectiveService:
         self,
         *,
         frame: PaperAnalysisFrame,
+        objective_context: ResearchObjective,
         block_type: str,
         section_label: str,
         text: str,
@@ -5661,14 +5707,23 @@ class ResearchObjectiveService:
         if "references" in self._objective_column_key(section_label):
             return 0
         score = 0
-        for term in frame.material_match:
+        for term in (*objective_context.material_scope, *frame.material_match):
             term_text = str(term or "").strip().casefold()
             if term_text and term_text in text_haystack:
                 score += 1
-        for term in (*frame.changed_variables, *frame.measured_property_scope):
-            term_text = str(term or "").strip().casefold()
-            if term_text and term_text in text_haystack:
+        objective_axis_keys = {
+            property_matching.axis_key(term)
+            for term in (*objective_context.variables, *objective_context.outcomes)
+        }
+        for term in (*objective_context.variables, *objective_context.outcomes):
+            if property_matching.source_text_mentions_axis(text, term):
                 score += 4
+        for term in (*frame.changed_variables, *frame.measured_property_scope):
+            if (
+                property_matching.axis_key(term) not in objective_axis_keys
+                and property_matching.source_text_mentions_axis(text, term)
+            ):
+                score += 1
         for term in frame.test_environment_scope:
             term_text = str(term or "").strip().casefold()
             if term_text and term_text in text_haystack:

--- a/backend/application/core/objectives/schemas.py
+++ b/backend/application/core/objectives/schemas.py
@@ -73,6 +73,14 @@ _PAPER_SKIM_DOC_ROLES = {
     "uncertain",
 }
 _PAPER_SKIM_EVIDENCE_DENSITIES = {"high", "medium", "low", "unknown"}
+PAPER_SKIM_OUTPUT_LIMITS = {
+    "candidate_materials": (8, 80),
+    "candidate_processes": (4, 80),
+    "candidate_properties": (8, 80),
+    "changed_variables": (8, 80),
+    "possible_objectives": (3, 320),
+    "warnings": (2, 240),
+}
 _OBJECTIVE_FRAME_RELEVANCE = {"high", "medium", "low", "irrelevant", "uncertain"}
 _OBJECTIVE_FRAME_PAPER_ROLES = {
     "primary_experiment",
@@ -497,25 +505,58 @@ class StructuredPaperSkim(_StrictModel):
     doc_role: Literal["experimental", "review", "modeling", "mixed", "uncertain"] = (
         "uncertain"
     )
-    candidate_materials: list[Annotated[str, Field(max_length=80)]] = Field(
-        default_factory=list, max_length=2
+    candidate_materials: list[
+        Annotated[
+            str,
+            Field(max_length=PAPER_SKIM_OUTPUT_LIMITS["candidate_materials"][1]),
+        ]
+    ] = Field(
+        default_factory=list,
+        max_length=PAPER_SKIM_OUTPUT_LIMITS["candidate_materials"][0],
     )
-    candidate_processes: list[Annotated[str, Field(max_length=80)]] = Field(
-        default_factory=list, max_length=2
+    candidate_processes: list[
+        Annotated[
+            str,
+            Field(max_length=PAPER_SKIM_OUTPUT_LIMITS["candidate_processes"][1]),
+        ]
+    ] = Field(
+        default_factory=list,
+        max_length=PAPER_SKIM_OUTPUT_LIMITS["candidate_processes"][0],
     )
-    candidate_properties: list[Annotated[str, Field(max_length=80)]] = Field(
-        default_factory=list, max_length=8
+    candidate_properties: list[
+        Annotated[
+            str,
+            Field(max_length=PAPER_SKIM_OUTPUT_LIMITS["candidate_properties"][1]),
+        ]
+    ] = Field(
+        default_factory=list,
+        max_length=PAPER_SKIM_OUTPUT_LIMITS["candidate_properties"][0],
     )
-    changed_variables: list[Annotated[str, Field(max_length=80)]] = Field(
-        default_factory=list, max_length=8
+    changed_variables: list[
+        Annotated[
+            str,
+            Field(max_length=PAPER_SKIM_OUTPUT_LIMITS["changed_variables"][1]),
+        ]
+    ] = Field(
+        default_factory=list,
+        max_length=PAPER_SKIM_OUTPUT_LIMITS["changed_variables"][0],
     )
-    possible_objectives: list[Annotated[str, Field(max_length=180)]] = Field(
-        default_factory=list, max_length=3
+    possible_objectives: list[
+        Annotated[
+            str,
+            Field(max_length=PAPER_SKIM_OUTPUT_LIMITS["possible_objectives"][1]),
+        ]
+    ] = Field(
+        default_factory=list,
+        max_length=PAPER_SKIM_OUTPUT_LIMITS["possible_objectives"][0],
     )
     evidence_density: Literal["high", "medium", "low", "unknown"] = "unknown"
     confidence: float = 0.0
-    warnings: list[Annotated[str, Field(max_length=80)]] = Field(
-        default_factory=list, max_length=2
+    warnings: list[
+        Annotated[str, Field(max_length=PAPER_SKIM_OUTPUT_LIMITS["warnings"][1])]
+    ] = Field(
+        default_factory=list,
+        max_length=PAPER_SKIM_OUTPUT_LIMITS["warnings"][0],
     )
 
     @field_validator(

--- a/backend/tests/unit/application/test_objective_evidence_extraction.py
+++ b/backend/tests/unit/application/test_objective_evidence_extraction.py
@@ -738,6 +738,94 @@ def test_llm_objective_evidence_completes_grounded_categorical_endpoints(tmp_pat
     }
 
 
+def test_llm_objective_evidence_accepts_verbatim_preheating_crack_comparison(
+    tmp_path,
+):
+    service = _build_research_objective_service(
+        collection_service=build_test_collection_service(tmp_path / "collections"),
+    )
+    objective = _research_objective(
+        {
+            "objective_id": "obj-preheating-cracks",
+            "question": (
+                "How does base plate preheating temperature affect crack formation?"
+            ),
+            "variables": ["base plate preheating temperature"],
+            "outcomes": ["crack formation"],
+        }
+    )
+    route = EvidenceCandidate.from_mapping(
+        {
+            "objective_id": objective.objective_id,
+            "document_id": "paper-preheating",
+            "source_kind": "text_window",
+            "source_ref": "block-crack-result",
+            "role": "current_experimental_evidence",
+            "extractable": True,
+            "confidence": 0.9,
+        }
+    )
+
+    records = service._objective_evidence_records_from_extracted(
+        route=route,
+        source={
+            "source_kind": "text_window",
+            "source_ref": "block-crack-result",
+            "text": (
+                "Al7075 microcracks can abundantly form after SLM processing "
+                "without preheating. Although the application of preheating "
+                "largely reduces this cracking behavior, it fails to completely "
+                "prevent microcrack formation after preheating at 400 C."
+            ),
+        },
+        objective_context=objective,
+        extracted_record={
+            "evidence_role": "direct_result",
+            "changed_variables": [
+                {
+                    "name": "base plate preheating temperature",
+                    "baseline_value": "without preheating",
+                    "target_value": "preheating at 400 C",
+                    "unit": None,
+                }
+            ],
+            "comparison": {
+                "baseline_label": "without preheating",
+                "target_label": "preheating at 400 C",
+                "axis_names": ["base plate preheating temperature"],
+                "comparable": True,
+                "incomparability_reasons": [],
+            },
+            "reported_result": {
+                "outcome": "crack formation",
+                "value": None,
+                "unit": None,
+                "direction": "decrease",
+                "result_text": (
+                    "application of preheating largely reduces this cracking behavior"
+                ),
+            },
+            "attribution_scope": "isolated_effect",
+            "scientific_context": {
+                "material": [{"name": "material", "value": "Al7075"}],
+            },
+            "resolution_status": "resolved",
+            "confidence": 0.9,
+        },
+    )
+
+    assert len(records) == 1
+    assert records[0]["changed_variables"] == [
+        {
+            "name": "base plate preheating temperature",
+            "baseline_value": "without preheating",
+            "target_value": "preheating at 400 C",
+            "unit": None,
+        }
+    ]
+    assert records[0]["reported_result"]["direction"] == "decrease"
+
+
 def test_llm_objective_evidence_drops_unsupported_qualitative_direction(tmp_path):
     service = _build_research_objective_service(
         collection_service=build_test_collection_service(tmp_path / "collections"),

--- a/backend/tests/unit/application/test_objective_evidence_routing.py
+++ b/backend/tests/unit/application/test_objective_evidence_routing.py
@@ -40,6 +40,24 @@ def test_research_objective_service_forces_extractable_objective_route_roles(
     )
 
 
+def test_research_objective_service_forces_direct_support_route_role(tmp_path):
+    service = _build_research_objective_service(
+        collection_service=build_test_collection_service(tmp_path / "collections"),
+    )
+
+    record = service._apply_route_evidence_role(
+        record={
+            "role": "low_value_or_irrelevant",
+            "extractable": False,
+        },
+        evidence_role="direct_support",
+    )
+
+    assert record["role"] == "current_experimental_evidence"
+    assert record["extractable"] is True
+    assert record["join_plan"] == {"evidence_role": "direct_support"}
+
+
 def test_research_objective_service_treats_energy_density_only_table_as_condition(
     tmp_path,
 ):
@@ -585,6 +603,7 @@ def test_research_objective_service_ranks_result_text_candidates(
 
     candidates = service._build_route_source_candidates(
         frame=frame,
+        objective_context=objective_context,
         blocks=blocks,
         tables=[],
     )
@@ -1488,6 +1507,91 @@ def test_research_objective_tree_routing_keeps_late_document_nodes(tmp_path):
     )
 
 
+def test_research_objective_tree_routing_uses_confirmed_objective_axes(tmp_path):
+    service = _build_research_objective_service(
+        collection_service=build_test_collection_service(tmp_path / "collections"),
+    )
+    objective = _research_objective(
+        {
+            "objective_id": "obj-preheat-cracking",
+            "question": (
+                "How does base plate preheating temperature affect crack formation?"
+            ),
+            "variables": ["base plate preheating temperature"],
+            "outcomes": ["crack formation"],
+            "confirmation_status": "confirmed",
+        }
+    )
+    frame = PaperAnalysisFrame.from_mapping(
+        {
+            "objective_id": "obj-preheat-cracking",
+            "document_id": "paper-1",
+            "relevance": "high",
+            "paper_role": "primary_experiment",
+            "changed_variables": ["laser power"],
+            "measured_property_scope": ["porosity"],
+        }
+    )
+    child_ids = tuple(f"node-{index}" for index in range(30))
+    nodes: dict[str, SourceDocumentNode] = {
+        "root": SourceDocumentNode(
+            node_id="root",
+            document_id="paper-1",
+            parent_id=None,
+            child_ids=child_ids,
+            node_type="document",
+            order=0,
+        )
+    }
+    for index, node_id in enumerate(child_ids):
+        source_ref = f"noise-{index}"
+        text = (
+            "Laser power affected porosity and showed a measured result for "
+            f"condition {index}."
+        )
+        if index == 7:
+            source_ref = "preheating-crack-result"
+            text = (
+                "Although the application of preheating largely reduces this "
+                "cracking behavior, it fails to completely prevent microcrack "
+                "formation after preheating at 400 C."
+            )
+        nodes[node_id] = SourceDocumentNode(
+            node_id=node_id,
+            document_id="paper-1",
+            parent_id="root",
+            child_ids=(),
+            node_type="paragraph",
+            order=100 + index,
+            text=text,
+            heading_path=("Results",),
+            source_ref_kind="block",
+            source_ref_id=source_ref,
+        )
+    document_tree = SourceDocumentTree(
+        document_id="paper-1",
+        collection_id="col-test",
+        root_node_id="root",
+        nodes=nodes,
+    )
+    extractor = _ObjectiveExtractor()
+
+    service._build_objective_evidence_routes(
+        collection_id="col-test",
+        extractor=extractor,
+        objectives=(objective,),
+        objective_paper_frames=(frame,),
+        blocks_by_document_id={"paper-1": []},
+        tables_by_document_id={"paper-1": []},
+        document_trees_by_document_id={"paper-1": document_tree},
+    )
+
+    assert "preheating-crack-result" in {
+        payload["current_source"]["source_ref"]
+        for payload in extractor.route_payloads
+    }
+
+
 def test_research_objective_tree_routing_keeps_direct_result_among_scope_text(
     tmp_path,
 ):
@@ -1503,6 +1607,14 @@ def test_research_objective_tree_routing_keeps_direct_result_among_scope_text(
             "material_match": ["316L stainless steel"],
             "changed_variables": ["preheating build platform temperature"],
             "measured_property_scope": ["microstructure"],
+        }
+    )
+    objective_context = _research_objective(
+        {
+            "objective_id": "obj-preheat",
+            "material_scope": ["316L stainless steel"],
+            "variables": ["preheating build platform temperature"],
+            "outcomes": ["microstructure"],
         }
     )
     child_ids = tuple(f"node-{index}" for index in range(17))
@@ -1549,6 +1661,7 @@ def test_research_objective_tree_routing_keeps_direct_result_among_scope_text(
 
     candidates = service._build_tree_route_text_candidates(
         frame=frame,
+        objective_context=objective_context,
         blocks=[],
         document_tree=document_tree,
     )
@@ -1557,6 +1670,60 @@ def test_research_objective_tree_routing_keeps_direct_result_among_scope_text(
     assert "direct-result" in {
         candidate["source_ref"] for candidate in candidates
     }
+
+
+def test_research_objective_tree_routing_recognizes_preheating_crack_results(
+    tmp_path,
+):
+    service = _build_research_objective_service(
+        collection_service=build_test_collection_service(tmp_path / "collections"),
+    )
+    frame = PaperAnalysisFrame.from_mapping(
+        {
+            "objective_id": "obj-preheat-cracking",
+            "document_id": "paper-1",
+            "relevance": "high",
+            "paper_role": "primary_experiment",
+            "changed_variables": ["base plate preheating temperature"],
+            "measured_property_scope": ["crack formation"],
+        }
+    )
+    objective_context = _research_objective(
+        {
+            "objective_id": "obj-preheat-cracking",
+            "variables": ["base plate preheating temperature"],
+            "outcomes": ["crack formation"],
+        }
+    )
+
+    direct_results = (
+        (
+            "Although the application of preheating largely reduces this cracking "
+            "behavior, it fails to completely prevent microcrack formation after "
+            "preheating at 400 C."
+        ),
+        (
+            "Preheating up to 400 C does not have a significant effect on "
+            "Hastelloy X crack formation."
+        ),
+    )
+
+    assert all(
+        service._route_text_candidate_is_direct_result(
+            objective_context=objective_context,
+            candidate={"text": text},
+        )
+        for text in direct_results
+    )
+    assert not service._route_text_candidate_is_direct_result(
+        objective_context=objective_context,
+        candidate={
+            "text": (
+                "Crack formation was characterized for all four materials in "
+                "the experimental program."
+            )
+        },
+    )
 
 
 def test_research_objective_tree_routing_excludes_non_block_caption_refs(tmp_path):
@@ -1571,6 +1738,13 @@ def test_research_objective_tree_routing_excludes_non_block_caption_refs(tmp_pat
             "paper_role": "primary_experiment",
             "changed_variables": ["energy density"],
             "measured_property_scope": ["relative density"],
+        }
+    )
+    objective_context = _research_objective(
+        {
+            "objective_id": "obj-density",
+            "variables": ["energy density"],
+            "outcomes": ["relative density"],
         }
     )
     document_tree = SourceDocumentTree(
@@ -1605,6 +1779,7 @@ def test_research_objective_tree_routing_excludes_non_block_caption_refs(tmp_pat
 
     candidates = service._build_tree_route_text_candidates(
         frame=frame,
+        objective_context=objective_context,
         blocks=[],
         document_tree=document_tree,
     )
@@ -1626,6 +1801,13 @@ def test_research_objective_tree_routing_keeps_multiple_comparative_results(
             "paper_role": "primary_experiment",
             "changed_variables": ["preheating build platform temperature"],
             "measured_property_scope": ["microstructure"],
+        }
+    )
+    objective_context = _research_objective(
+        {
+            "objective_id": "obj-preheat",
+            "variables": ["preheating build platform temperature"],
+            "outcomes": ["microstructure"],
         }
     )
     generic_candidates = [
@@ -1675,6 +1857,7 @@ def test_research_objective_tree_routing_keeps_multiple_comparative_results(
 
     selected = service._bounded_tree_route_text_candidates(
         frame=frame,
+        objective_context=objective_context,
         scored_candidates=[*generic_candidates, *comparative_candidates],
     )
 
@@ -1704,6 +1887,19 @@ def test_research_objective_service_keeps_numeric_mechanism_text_candidates(
             ],
             "test_environment_scope": ["preheating"],
             "relevant_sections": ["Abstract"],
+        }
+    )
+    objective_context = _research_objective(
+        {
+            "objective_id": "obj-preheating",
+            "material_scope": ["316L stainless steel"],
+            "variables": ["build platform temperature"],
+            "outcomes": [
+                "yield strength",
+                "ultimate tensile strength",
+                "elongation",
+                "porosity",
+            ],
         }
     )
     blocks = [
@@ -1744,6 +1940,7 @@ def test_research_objective_service_keeps_numeric_mechanism_text_candidates(
 
     candidates = service._build_route_source_candidates(
         frame=frame,
+        objective_context=objective_context,
         blocks=blocks,
         tables=[],
     )

--- a/backend/tests/unit/application/test_objective_property_matching.py
+++ b/backend/tests/unit/application/test_objective_property_matching.py
@@ -53,6 +53,14 @@ def test_axis_matching_preserves_explicit_synonyms_and_source_aliases() -> None:
         "scan strategy",
         "scanning strategy",
     )
+    assert property_matching.axis_values_match(
+        "preheating",
+        "base plate preheating temperature",
+    )
+    assert property_matching.axis_values_match(
+        "cracking",
+        "crack formation",
+    )
     assert property_matching.source_text_mentions_axis("E p", "pitting potential")
 
 

--- a/backend/tests/unit/services/test_domain_model_extractors.py
+++ b/backend/tests/unit/services/test_domain_model_extractors.py
@@ -443,8 +443,8 @@ def test_paper_skim_contract_bounds_model_output():
     schema = StructuredPaperSkim.model_json_schema()["properties"]
 
     expected_limits = {
-        "candidate_materials": 2,
-        "candidate_processes": 2,
+        "candidate_materials": 8,
+        "candidate_processes": 4,
         "candidate_properties": 8,
         "changed_variables": 8,
         "possible_objectives": 3,
@@ -458,23 +458,24 @@ def test_paper_skim_contract_bounds_model_output():
         "candidate_processes",
         "candidate_properties",
         "changed_variables",
-        "warnings",
     ):
         assert schema[field]["items"]["maxLength"] == 80
-    assert schema["possible_objectives"]["items"]["maxLength"] == 180
+    assert schema["possible_objectives"]["items"]["maxLength"] == 320
+    assert schema["warnings"]["items"]["maxLength"] == 240
 
 
 @pytest.mark.parametrize(
     ("field", "value"),
     [
-        ("candidate_materials", ["material-1", "material-2", "material-3"]),
-        ("candidate_processes", ["process-1", "process-2", "process-3"]),
+        ("candidate_materials", [f"material-{index}" for index in range(9)]),
+        ("candidate_processes", [f"process-{index}" for index in range(5)]),
         ("candidate_properties", [f"property-{index}" for index in range(9)]),
         ("changed_variables", [f"variable-{index}" for index in range(9)]),
         ("possible_objectives", [f"objective-{index}" for index in range(4)]),
         ("warnings", ["warning-1", "warning-2", "warning-3"]),
         ("candidate_properties", ["p" * 81]),
-        ("possible_objectives", ["o" * 181]),
+        ("possible_objectives", ["o" * 321]),
+        ("warnings", ["w" * 241]),
     ],
 )
 def test_paper_skim_contract_rejects_oversized_values(field, value):
@@ -496,6 +497,9 @@ def test_paper_skim_prompt_defines_structured_research_map_contract():
     assert "`candidate_properties` contains measured outcomes" in user_prompt
     assert "Create a `possible_objectives` question only when" in user_prompt
     assert "Return empty arrays rather than guessing" in user_prompt
+    assert "up to 8 `candidate_materials`" in user_prompt
+    assert "up to 3 `possible_objectives`, each at most 320 characters" in user_prompt
+    assert "up to 2 `warnings`, each at most 240 characters" in user_prompt
 
 
 def test_research_objective_discovery_prompt_requires_focused_concise_objectives():
@@ -1162,6 +1166,98 @@ def test_domain_model_extractors_validates_paper_skim_response():
     assert skim.doc_role == "experimental"
     assert skim.candidate_materials == ["316L stainless steel"]
     assert client.chat.completions.calls[0]["max_completion_tokens"] == 1024
+
+
+def test_paper_skim_preserves_real_multi_material_scope():
+    client = _FakeOpenAIClient(
+        json.dumps(
+            {
+                "doc_role": "experimental",
+                "candidate_materials": [
+                    "Al7075",
+                    "Hastelloy X",
+                    "H13 tool steel",
+                    "CoCr",
+                ],
+                "candidate_processes": ["selective laser melting"],
+                "candidate_properties": [
+                    "part density",
+                    "crack formation",
+                    "internal stresses",
+                    "microstructure",
+                    "mechanical properties",
+                ],
+                "changed_variables": ["base plate preheating temperature"],
+                "possible_objectives": [
+                    "How does base plate preheating temperature affect part density, "
+                    "crack formation, internal stresses, microstructure, and mechanical "
+                    "properties across Al7075, Hastelloy X, H13 tool steel, and CoCr?"
+                ],
+                "evidence_density": "high",
+                "confidence": 0.92,
+                "warnings": [
+                    "Material names are taken from the study overview and should be "
+                    "verified against the material-specific experiment sections."
+                ],
+            }
+        )
+    )
+    extractor = _objective_extractor(client)
+
+    skim = extractor.extract_paper_skim(
+        {
+            "document_id": "paper-1",
+            "title": "Application of base plate preheating during selective laser melting",
+            "text_preview": "Base plate preheating was applied to four materials.",
+        }
+    )
+
+    assert skim.candidate_materials == [
+        "Al7075",
+        "Hastelloy X",
+        "H13 tool steel",
+        "CoCr",
+    ]
+    assert len(skim.possible_objectives[0]) <= 320
+    assert len(skim.warnings[0]) <= 240
+
+
+def test_paper_skim_bounds_recoverable_model_verbosity_before_validation():
+    client = _FakeOpenAIClient(
+        json.dumps(
+            {
+                "doc_role": "experimental",
+                "candidate_materials": [f"material-{index}" for index in range(10)],
+                "candidate_processes": ["selective laser melting"],
+                "candidate_properties": ["density"],
+                "changed_variables": ["preheating temperature"],
+                "possible_objectives": [
+                    "How does preheating temperature affect density under the reported "
+                    + "material and process conditions " * 20
+                    + "?"
+                ],
+                "evidence_density": "medium",
+                "confidence": 0.8,
+                "warnings": ["bounded warning " * 30],
+            }
+        )
+    )
+    extractor = _objective_extractor(client)
+
+    skim = extractor.extract_paper_skim(
+        {
+            "document_id": "paper-1",
+            "title": "Multi-material preheating study",
+            "text_preview": "Preheating was evaluated across several materials.",
+        }
+    )
+
+    assert skim.candidate_materials == [f"material-{index}" for index in range(8)]
+    assert len(skim.possible_objectives) == 1
+    assert len(skim.possible_objectives[0]) <= 320
+    assert skim.possible_objectives[0].endswith("?")
+    assert len(skim.warnings[0]) <= 240
+    assert len(client.chat.completions.calls) == 1
 
 
 def test_domain_model_extractors_validates_research_objective_response():
@@ -1976,7 +2072,7 @@ def test_domain_model_extractors_rejects_unknown_top_level_evidence_fields():
     assert len(client.chat.completions.calls) == 2
 
 
-def test_domain_model_extractors_treats_prompt_only_evidence_echo_as_empty():
+def test_domain_model_extractors_rejects_prompt_only_evidence_echo():
     response = json.dumps(
         {
             "OBJECTIVE": "How does energy density affect relative density?",
@@ -1989,26 +2085,31 @@ def test_domain_model_extractors_treats_prompt_only_evidence_echo_as_empty():
             "SOURCE": "Relative density reached 99.5%.",
         }
     )
-    extractor = _objective_extractor(_FakeOpenAIClient(response))
+    client = _FakeOpenAIClient(response)
+    extractor = _objective_extractor(client)
 
-    parsed = extractor.extract_objective_evidence(
-        {
-            "objective": {
-                "question": "How does energy density affect relative density?"
-            },
-            "evidence_route": {
-                "source_kind": "text_window",
-                "source_ref": "block-1",
-            },
-            "source": {
-                "source_kind": "text_window",
-                "source_ref": "block-1",
-                "text": "Relative density reached 99.5%.",
-            },
-        }
-    )
+    with pytest.raises(ValueError, match="echoed input fields"):
+        extractor.extract_objective_evidence(
+            {
+                "objective": {
+                    "question": "How does energy density affect relative density?"
+                },
+                "evidence_route": {
+                    "source_kind": "text_window",
+                    "source_ref": "block-1",
+                },
+                "source": {
+                    "source_kind": "text_window",
+                    "source_ref": "block-1",
+                    "text": "Relative density reached 99.5%.",
+                },
+            }
+        )
 
-    assert parsed.extractions == []
+    assert len(client.chat.completions.calls) == 2
+    assert "only echoed the input fields" in client.chat.completions.calls[1][
+        "messages"
+    ][-1]["content"]
 
 
 def test_structured_objective_evidence_rejects_effect_without_variable_change():
@@ -2115,6 +2216,7 @@ def test_objective_evidence_prompt_limits_text_routes_to_one_extraction():
     assert "must not be copied" not in prompt
     assert "Identify every changed" in system_prompt
     assert "exact source group labels" in system_prompt
+    assert "absent, off, or without condition to numeric 0" in system_prompt
     assert "one baseline-to-target comparison interval" in system_prompt
     assert "Never repeat a changed-variable name" in system_prompt
     assert "choose one complete source-supported pair" in system_prompt
@@ -2407,7 +2509,14 @@ def test_domain_model_extractors_routes_objective_units_through_bounded_json_tex
     assert client.beta.chat.completions.calls == []
     text_call = client.chat.completions.calls[0]
     assert text_call["max_completion_tokens"] == 2048
-    assert text_call["response_format"] == {"type": "json_object"}
+    assert text_call["response_format"]["type"] == "json_schema"
+    assert text_call["response_format"]["json_schema"]["name"] == (
+        "structured_evidence_extractions"
+    )
+    assert text_call["response_format"]["json_schema"]["strict"] is True
+    assert text_call["response_format"]["json_schema"]["schema"] == (
+        StructuredEvidenceExtractions.model_json_schema()
+    )
     assert "JSON schema:" not in text_call["messages"][1]["content"]
     assert extractor.consume_last_trace()["extraction_mode"] == "json_text"
 


### PR DESCRIPTION
## 概要

修复同一论文在不同模型运行中可能出现的目标选源漂移、直接证据被跳过，以及提示字段复述被误判为空证据的问题。

## 修改

- 约束 PaperSkim 输出，并保留集合级目标发现所需的变量与结果轴。
- 以已确认 ResearchObjective 作为 Evidence 路由的权威研究轴。
- 强制后端识别的 direct_support 来源进入结构化抽取。
- Evidence 抽取使用严格 json_schema；提示字段复述会重试并明确失败。
- 补充目标校验、属性匹配、路由和抽取回归测试。

## 验证

- 修改文件对应单元测试：196 passed
- 目标路由、抽取、分析和任务回归套件：72 + 123 + 155 passed
- Python compileall：通过
- Ruff E9,F63,F7,F82：通过
- git diff --check：通过
- 使用同一真实 PDF 创建全新 collection，完成 upload -> Build -> PaperSkim -> Objective -> confirm -> Analysis -> Evidence -> Finding；Evidence 和 Finding 各产出 1 条。

## 影响

不改变 HTTP API、持久化格式或部署配置。没有新增兼容层或公共抽象。