### PR TITLE
docs(objectives): clarify paper skim source link

### DIFF
--- a/backend/domain/core/research_objective.py
+++ b/backend/domain/core/research_objective.py
@@ -115,6 +115,7 @@ _SLUG_NON_WORD_PATTERN = re.compile(r"[^a-z0-9]+")
 
 @dataclass(frozen=True)
 class PaperSkim:
+    # stable link to the source document
     document_id: str
     title: str | None
     source_filename: str | None


### PR DESCRIPTION
## Why

`PaperSkim` 的领域说明没有明确其来源定位字段，阅读模型时容易误解其与原始文档的关联。

## What

- 补充 `PaperSkim` 文档说明，明确其保留稳定的来源定位信息。

## Impact

- 仅改善领域模型可读性，不改变运行时行为或 API 合同。

## Tests

- `uv run pytest tests/unit/domains/test_research_objective_domain.py -q`（22 passed）
