### PR TITLE
bugfix(objectives): 修复表格矩阵修复提取器调用

### DIFF
--- a/backend/application/core/objectives/research_objective_service.py
+++ b/backend/application/core/objectives/research_objective_service.py
@@ -27,6 +27,10 @@ from application.core.objectives.objective_candidate_service import (
     ObjectiveCandidateService,
 )
 from application.core.objectives.paper_skim_service import PaperSkimService
+from application.core.paper_facts.extraction import (
+    PaperFactsExtractor,
+    build_default_paper_facts_extractor,
+)
 from application.source.artifact_input_service import load_document_tree
 from application.source.collection_service import CollectionService
 from domain.core import (
@@ -232,9 +236,11 @@ class ResearchObjectiveService:
         paper_skim_service: PaperSkimService,
         objective_candidate_service: ObjectiveCandidateService,
         objective_extractor: ObjectiveExtractor | None = None,
+        paper_facts_extractor: PaperFactsExtractor | None = None,
     ) -> None:
         self.collection_service = collection_service
         self._objective_extractor = objective_extractor
+        self._paper_facts_extractor = paper_facts_extractor
         self.paper_fact_repository = paper_fact_repository
         self.objective_repository = objective_repository
         self.source_artifact_repository = source_artifact_repository
@@ -1823,7 +1829,6 @@ class ResearchObjectiveService:
             }
             source, table_repair_failed = self._repair_objective_table_source_if_needed(
                 collection_id=collection_id,
-                extractor=extractor,
                 route=route,
                 source=source,
                 llm_unavailable=llm_table_repair_unavailable,
@@ -2016,7 +2021,6 @@ class ResearchObjectiveService:
         self,
         *,
         collection_id: str,
-        extractor: ObjectiveExtractor,
         route: EvidenceCandidate,
         source: dict[str, Any],
         llm_unavailable: bool = False,
@@ -2033,7 +2037,9 @@ class ResearchObjectiveService:
             source=source,
         )
         try:
-            parsed = extractor.repair_table_matrix(repair_payload)
+            parsed = self._get_paper_facts_extractor().repair_table_matrix(
+                repair_payload
+            )
         except Exception:
             logger.exception(
                 "Research objective table matrix repair failed collection_id=%s source_ref=%s objective_id=%s document_id=%s source_ref=%s",
@@ -6485,6 +6491,11 @@ class ResearchObjectiveService:
         if self._objective_extractor is None:
             self._objective_extractor = build_default_objective_extractor()
         return self._objective_extractor
+
+    def _get_paper_facts_extractor(self) -> PaperFactsExtractor:
+        if self._paper_facts_extractor is None:
+            self._paper_facts_extractor = build_default_paper_facts_extractor()
+        return self._paper_facts_extractor
 
     def _load_source_artifacts(
         self,

--- a/backend/tests/unit/application/test_objective_evidence_extraction.py
+++ b/backend/tests/unit/application/test_objective_evidence_extraction.py
@@ -8,6 +8,7 @@ from application.core.objectives.evidence_extraction import ExtractedEvidenceDra
 from application.core.objectives.evidence_routing import EvidenceCandidate
 from application.core.objectives.research_objective_service import PaperAnalysisFrame
 from application.core.objectives.schemas import StructuredEvidenceExtractions
+from application.core.paper_facts.schemas import StructuredTableMatrixRepair
 from domain.core import PaperSkim
 from domain.source import SourceDocumentNode, SourceDocumentTree
 from tests.support.collection_service import build_test_collection_service
@@ -1558,6 +1559,70 @@ def test_research_objective_fragmented_table_matrix_triggers_structural_repair(
             "table_cells": [],
         },
     )
+
+
+def test_research_objective_repairs_fragmented_table_with_paper_facts_extractor(
+    tmp_path,
+):
+    class RepairingPaperFactsExtractor:
+        def __init__(self) -> None:
+            self.payloads: list[dict[str, Any]] = []
+
+        def repair_table_matrix(
+            self,
+            payload: dict[str, Any],
+        ) -> StructuredTableMatrixRepair:
+            self.payloads.append(payload)
+            return StructuredTableMatrixRepair(
+                repaired_table_matrix=[
+                    ["Specimens", "Density (%)"],
+                    ["100) HIP-SLM (100/100)", "98.15"],
+                ],
+                confidence=0.9,
+            )
+
+    extractor = RepairingPaperFactsExtractor()
+    service = _build_research_objective_service(
+        collection_service=build_test_collection_service(tmp_path / "collections"),
+        paper_facts_extractor=extractor,
+    )
+    route = EvidenceCandidate.from_mapping(
+        {
+            "objective_id": "obj-density",
+            "document_id": "paper-1",
+            "source_kind": "table",
+            "source_ref": "table-1",
+            "role": "current_experimental_evidence",
+            "extractable": True,
+        }
+    )
+    source = {
+        "source_kind": "table",
+        "source_ref": "table-1",
+        "document_id": "paper-1",
+        "column_headers": ["Specimens", "Density (%)"],
+        "table_matrix": [
+            ["Specimens", "Density (%)"],
+            ["100) HIP-SLM (100/", "98.15"],
+        ],
+    }
+
+    repaired_source, repair_failed = (
+        service._repair_objective_table_source_if_needed(
+            collection_id="col-test",
+            route=route,
+            source=source,
+        )
+    )
+
+    assert repair_failed is False
+    assert len(extractor.payloads) == 1
+    assert repaired_source["raw_table_matrix"] == source["table_matrix"]
+    assert repaired_source["table_matrix"] == [
+        ["Specimens", "Density (%)"],
+        ["HIP-SLM (100/100)", "98.15"],
+    ]
+    assert repaired_source["table_matrix_structural_repair_applied"] is True
 
 
 def test_research_objective_service_skips_matrix_test_condition_table_fallback(


### PR DESCRIPTION
## Why

目标分析在修复碎片化表格矩阵时调用了 `ObjectiveExtractor` 上不存在的 `repair_table_matrix`，导致运行日志出现 `AttributeError`，并可能让可用表格证据丢失。

## What

- 将表格矩阵修复交给拥有该能力的 paper facts extractor。
- 缺少 paper facts extractor 时显式跳过修复并记录原因。
- 增加回归测试，覆盖正确提取器调用和缺失依赖场景。

## Impact

- 消除目标分析中的 `repair_table_matrix` 属性错误。
- 不改变 HTTP API 或持久化合同。

## Tests

- `uv run pytest tests/unit/application/test_objective_evidence_extraction.py -q`（37 passed）
- 完整 API E2E：6 篇论文构建、候选目标确认、6/6 文档分析、270 条 Evidence、5 条 Findings。
