### PR TITLE
chore(release): prepare v0.11.16

### DIFF
--- a/backend/application/core/objectives/README.md
+++ b/backend/application/core/objectives/README.md
@@ -36,7 +36,10 @@ Objective analysis.
   splits before execution. Provider length termination or model-declared output
   saturation enters the same recursive Source-unit subdivision path as a failed
   multi-unit batch, preserving stable Source-unit ids until only a terminal
-  singleton can become `extraction_failed`.
+  singleton can become `extraction_failed`. A relationship with no varied
+  factor is retained as an unresolved outcome signal when its outcome and
+  Source lineage are valid; the backend does not invent a missing factor or
+  discard valid sibling relationships.
   Successful siblings are retained. Duplicate studies are consolidated and
   unresolved study signals are reconciled only after every terminal batch has
   finished. The resulting one `PaperSkim` per document retains every distinct
@@ -172,7 +175,10 @@ paper authority. `coverage_complete` therefore means that every eligible
 Source unit was processed by a contract-valid first-stage extraction; it does
 not prove that the model found every scientifically relevant study,
 relationship, variable, or outcome. Model-call count grows with document length
-and with failed-batch subdivision.
+and with failed-batch subdivision. Permanent singleton failures are included in
+the Objective node summary and warnings. The collection build finishes as
+`partial_success` while candidates derived from successful Source units remain
+readable.
 
 Objective paper framing is also source-batched. Explicitly excluded documents
 are rejected by the backend without entering the model. The framing prior

--- a/backend/application/core/objectives/research_objective_service.py
+++ b/backend/application/core/objectives/research_objective_service.py
@@ -343,7 +343,7 @@ class ResearchObjectiveService:
         progress_callback: ProgressCallback | None = None,
         *,
         build_id: str,
-    ) -> tuple[ResearchObjective, ...]:
+    ) -> ObjectiveFactSet:
         source_inputs = self._load_objective_source_inputs(
             collection_id,
             build_id=build_id,
@@ -397,7 +397,7 @@ class ResearchObjectiveService:
             len(paper_skims),
             len(research_objectives),
         )
-        return research_objectives
+        return candidate_facts
 
     def generate_objective_analysis_artifacts(
         self,

--- a/backend/application/core/objectives/schemas.py
+++ b/backend/application/core/objectives/schemas.py
@@ -345,6 +345,94 @@ class StructuredPaperSkim(_StrictModel):
         max_length=PAPER_SKIM_WARNING_LIMIT[0],
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def _downgrade_relationships_without_factors(cls, value: object) -> object:
+        if not isinstance(value, Mapping):
+            return value
+        studies = value.get("studies")
+        unresolved_signals = value.get("unresolved_signals")
+        if not isinstance(studies, list):
+            return value
+        if unresolved_signals is not None and not isinstance(
+            unresolved_signals, list
+        ):
+            return value
+
+        retained_studies: list[object] = []
+        downgraded_signals: list[dict[str, object]] = []
+        changed = False
+        for study in studies:
+            if not isinstance(study, Mapping):
+                retained_studies.append(study)
+                continue
+            relationships = study.get("relationships")
+            if not isinstance(relationships, list):
+                retained_studies.append(study)
+                continue
+
+            retained_relationships: list[object] = []
+            study_changed = False
+            for relationship in relationships:
+                if not isinstance(relationship, Mapping):
+                    retained_relationships.append(relationship)
+                    continue
+                varied_factors = relationship.get("varied_factors")
+                if not isinstance(varied_factors, list) or any(
+                    str(item).strip() for item in varied_factors
+                ):
+                    retained_relationships.append(relationship)
+                    continue
+                outcome = str(relationship.get("outcome") or "").strip()
+                source_unit_ids = relationship.get("source_unit_ids")
+                if (
+                    not outcome
+                    or not isinstance(source_unit_ids, list)
+                    or not any(str(item).strip() for item in source_unit_ids)
+                ):
+                    retained_relationships.append(relationship)
+                    continue
+
+                signal = {
+                    "signal_type": "outcome",
+                    "label": outcome,
+                    "source_unit_ids": list(source_unit_ids),
+                    "confidence": relationship.get(
+                        "confidence", study.get("confidence")
+                    ),
+                }
+                for field_name in (
+                    "experiment_label",
+                    "design_type",
+                    "claim_scope",
+                    "material_scope",
+                    "process_context",
+                    "sample_context",
+                    "test_context",
+                    "comparator",
+                    "fixed_conditions",
+                ):
+                    if field_name in study:
+                        signal[field_name] = study[field_name]
+                downgraded_signals.append(signal)
+                study_changed = True
+                changed = True
+
+            if retained_relationships or not study_changed:
+                retained_study = dict(study)
+                retained_study["relationships"] = retained_relationships
+                retained_studies.append(retained_study)
+
+        if not changed:
+            return value
+        normalized = dict(value)
+        normalized["studies"] = retained_studies
+        normalized["unresolved_signals"] = [
+            *(unresolved_signals or []),
+            *downgraded_signals,
+        ]
+        return normalized
+
     @field_validator(
         "studies",
         "unresolved_signals",

--- a/backend/application/pipeline/collection_build/README.md
+++ b/backend/application/pipeline/collection_build/README.md
@@ -16,6 +16,13 @@ newer build; failed or older concurrent builds remain diagnostic history.
 Public task and artifact responses remain projections of these relational rows,
 not file-backed JSON documents.
 
+An Objective candidate node can succeed with incomplete PaperSkim coverage.
+It records the processed and permanently failed Source-unit counts in its output
+summary and exposes a node warning. A nonzero permanent failure count finalizes
+the task as `partial_success`, while successful candidate Objectives remain part
+of the activated build. A build with complete PaperSkim coverage remains
+`completed`.
+
 The pipeline layer does not parse documents or extract facts directly. Each
 node delegates to the owning implementation module for one concrete step.
 

--- a/backend/application/pipeline/collection_build/nodes.py
+++ b/backend/application/pipeline/collection_build/nodes.py
@@ -8,6 +8,7 @@ from application.pipeline.collection_build.context import CollectionBuildContext
 from application.source.reference_extraction_service import (
     SourceReferenceExtractionService,
 )
+from domain.core import PaperSourceUnitCoverageStatus
 from infra.source.runtime.artifact_bundle import SourceArtifactBundle
 
 
@@ -125,9 +126,32 @@ def build_document_profiles(
 def discover_and_replace_objective_candidates(
     context: CollectionBuildContext,
     _config: CollectionBuildPipelineConfig,
-) -> None:
-    context.research_objective_service.discover_and_replace_objective_candidates(
+) -> dict[str, Any]:
+    facts = context.research_objective_service.discover_and_replace_objective_candidates(
         context.collection_id,
         progress_callback=context.objective_progress_callback,
         build_id=context.build_id,
     )
+    coverage = tuple(
+        item
+        for paper_skim in facts.paper_skims
+        for item in paper_skim.source_unit_coverage
+    )
+    failed_count = sum(
+        item.status == PaperSourceUnitCoverageStatus.EXTRACTION_FAILED
+        for item in coverage
+    )
+    warnings = []
+    if failed_count:
+        unit = "unit" if failed_count == 1 else "units"
+        warnings.append(
+            f"{failed_count} PaperSkim Source {unit} failed extraction permanently; "
+            "candidate objectives were built from the remaining coverage."
+        )
+    return {
+        "objective_candidate_count": len(facts.research_objectives),
+        "paper_skim_count": len(facts.paper_skims),
+        "source_unit_count": len(coverage),
+        "extraction_failed_source_unit_count": failed_count,
+        "warnings": warnings,
+    }

--- a/backend/application/pipeline/collection_build/service.py
+++ b/backend/application/pipeline/collection_build/service.py
@@ -281,6 +281,11 @@ class CollectionBuildPipelineService:
             return "failed"
         if pipeline_run.errors:
             return "partial_success"
+        failed_source_unit_count = pipeline_run.node(
+            OBJECTIVE_CANDIDATES
+        ).output_summary.get("extraction_failed_source_unit_count", 0)
+        if isinstance(failed_source_unit_count, int) and failed_source_unit_count > 0:
+            return "partial_success"
         return "completed"
 
     def _build_objective_progress_callback(self, task_id: str, collection_id: str):

--- a/backend/main.py
+++ b/backend/main.py
@@ -303,7 +303,7 @@ def create_app(
 
     app = FastAPI(
         title="TsingAI-Lens API",
-        version="0.11.15",
+        version="0.11.16",
         docs_url=f"{PUBLIC_API_PREFIX}/docs",
         redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
         openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsingai-lens"
-version = "0.11.15"
+version = "0.11.16"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/backend/tests/integration/services/test_task_runner.py
+++ b/backend/tests/integration/services/test_task_runner.py
@@ -42,6 +42,7 @@ from infra.source.runtime.source_evidence import (
 from tests.support.paper_fact_repository import MemoryPaperFactRepository
 from tests.support.objective_repository import MemoryObjectiveRepository
 from tests.support.comparison_repository import MemoryComparisonRepository
+from tests.support.objective_extractor import FakeObjectiveExtractor
 
 
 class DummyWorkflowOutput:
@@ -349,6 +350,73 @@ def test_build_pipeline_service_builds_collection_artifacts(monkeypatch, tmp_pat
     )
     assert objective_facts.research_objectives_ready is True
     assert objective_facts.paper_skims
+
+
+def test_build_pipeline_service_keeps_objectives_and_reports_partial_skim_coverage(
+    monkeypatch,
+    tmp_path,
+):
+    import application.pipeline.collection_build.service as task_runner_module
+
+    class PartiallyFailingObjectiveExtractor(FakeObjectiveExtractor):
+        def extract_paper_skim(self, payload):  # noqa: ANN001
+            if any(
+                unit.get("source_unit_id") == "source-unit-000002"
+                for unit in payload.get("source_units") or ()
+            ):
+                raise RuntimeError("invalid relationship in Source unit")
+            return super().extract_paper_skim(payload)
+
+    collection_service = build_test_collection_service(tmp_path / "collections")
+    build_repository = MemoryBuildRepository()
+    task_service = TaskService(build_repository)
+    runner, artifact_registry = _build_runner(
+        tmp_path,
+        collection_service,
+        build_repository,
+    )
+    runner.research_objective_service._objective_extractor = (
+        PartiallyFailingObjectiveExtractor()
+    )
+
+    collection = collection_service.create_collection("Partial PaperSkim Collection")
+    paths = collection_service.get_paths(collection["collection_id"])
+    collection_service.add_file(
+        collection["collection_id"],
+        "paper.txt",
+        b"Experimental Section\nMix and anneal.",
+    )
+
+    async def fake_build_source_artifacts(**kwargs):  # noqa: ANN003, ARG001
+        return [
+            DummyWorkflowOutput(result=_write_source_artifact_outputs(paths.output_dir))
+        ]
+
+    monkeypatch.setattr(
+        task_runner_module, "build_source_artifacts", fake_build_source_artifacts
+    )
+
+    task = task_service.create_task(collection["collection_id"], "build")
+    result = asyncio.run(runner.run_task(task["task_id"], collection["collection_id"]))
+
+    assert result["status"] == "partial_success"
+    assert result["errors"] == []
+    assert result["warnings"] == [
+        "objective_candidates: 1 PaperSkim Source unit failed extraction "
+        "permanently; candidate objectives were built from the remaining coverage."
+    ]
+    pipeline_run = task_service.read_pipeline_run(task["task_id"])
+    objective_node = pipeline_run.node("objective_candidates")
+    assert objective_node.status == "succeeded"
+    assert objective_node.output_summary["extraction_failed_source_unit_count"] == 1
+
+    objective_facts = runner.research_objective_service.objective_repository.read(
+        collection["collection_id"],
+        build_id=artifact_registry.repository.read_build(task["task_id"]).build_id,
+    )
+    assert objective_facts.research_objectives_ready is True
+    assert objective_facts.research_objectives
+    assert any(not skim.coverage_complete for skim in objective_facts.paper_skims)
 
 
 def test_build_pipeline_service_marks_empty_collection_failed(monkeypatch, tmp_path):

--- a/backend/tests/unit/application/test_collection_build_pipeline_runner.py
+++ b/backend/tests/unit/application/test_collection_build_pipeline_runner.py
@@ -14,6 +14,7 @@ from application.pipeline.collection_build.definitions import (
     CollectionBuildNodeDefinition,
     DOCUMENT_PROFILES,
     OBJECTIVE_CANDIDATES,
+    SOURCE_ARTIFACTS,
     dependency_graph_for_mode,
 )
 from application.pipeline.collection_build.runner import CollectionBuildPipelineRunner
@@ -220,6 +221,73 @@ def test_collection_build_pipeline_runner_persists_provider_usage_per_node():
         "paper_framing": "paper_framing.v1"
     }
     assert result.stats.prompt_versions == {"paper_framing": "paper_framing.v1"}
+
+
+def test_objective_candidate_node_reports_permanent_source_unit_failures():
+    paper_skim = SimpleNamespace(
+        source_unit_coverage=(
+            SimpleNamespace(status="relationship_emitted"),
+            SimpleNamespace(status="extraction_failed"),
+        )
+    )
+    facts = SimpleNamespace(
+        research_objectives=(object(),),
+        paper_skims=(paper_skim,),
+    )
+    context = build_context(MemoryTaskService())
+    context.research_objective_service = SimpleNamespace(
+        discover_and_replace_objective_candidates=lambda *args, **kwargs: facts
+    )
+
+    result = nodes.discover_and_replace_objective_candidates(context, build_config())
+
+    assert result["objective_candidate_count"] == 1
+    assert result["paper_skim_count"] == 1
+    assert result["source_unit_count"] == 2
+    assert result["extraction_failed_source_unit_count"] == 1
+    assert result["warnings"] == [
+        "1 PaperSkim Source unit failed extraction permanently; candidate "
+        "objectives were built from the remaining coverage."
+    ]
+
+
+def test_collection_build_final_status_is_partial_when_paper_skim_coverage_failed():
+    pipeline_run = PipelineRun.create(
+        pipeline_name="collection_build",
+        mode="standard",
+        run_id="task_1",
+        scope_type="collection",
+        scope_id="col_1",
+        node_dependencies={
+            SOURCE_ARTIFACTS: (),
+            OBJECTIVE_CANDIDATES: (SOURCE_ARTIFACTS,),
+        },
+        created_at="2026-08-11T01:00:00+00:00",
+        output_build_id="build_1",
+    )
+    pipeline_run = pipeline_run.with_node(
+        pipeline_run.node(SOURCE_ARTIFACTS).succeed(
+            "2026-08-11T01:00:01+00:00"
+        )
+    )
+    pipeline_run = pipeline_run.with_node(
+        pipeline_run.node(OBJECTIVE_CANDIDATES).succeed(
+            "2026-08-11T01:00:02+00:00",
+            output_summary={"extraction_failed_source_unit_count": 1},
+        )
+    )
+    service = CollectionBuildPipelineService(
+        collection_service=SimpleNamespace(),
+        task_service=SimpleNamespace(),
+        artifact_registry_service=SimpleNamespace(),
+        source_artifact_repository=SimpleNamespace(),
+        document_profile_service=SimpleNamespace(),
+        research_objective_service=SimpleNamespace(),
+    )
+
+    assert service._resolve_final_status(SimpleNamespace(), pipeline_run) == (
+        "partial_success"
+    )
 
 
 def test_collection_build_pipeline_runner_keeps_usage_from_failed_node():

--- a/backend/tests/unit/services/test_domain_model_extractors.py
+++ b/backend/tests/unit/services/test_domain_model_extractors.py
@@ -970,6 +970,73 @@ def test_domain_model_extractors_validates_paper_skim_response():
     assert client.chat.completions.calls[0]["max_completion_tokens"] == 4096
 
 
+def test_paper_skim_downgrades_empty_factor_relationship_without_losing_siblings():
+    response = {
+        "doc_role": "experimental",
+        "studies": [
+            {
+                "experiment_label": "LPBF parameter study",
+                "design_type": "experimental",
+                "claim_scope": "current_work",
+                "material_scope": ["316L stainless steel"],
+                "process_context": ["LPBF"],
+                "relationships": [
+                    {
+                        "varied_factors": ["laser power"],
+                        "outcome": "porosity",
+                        "source_unit_ids": ["window-source-1"],
+                        "confidence": 0.91,
+                    },
+                    {
+                        "varied_factors": [],
+                        "outcome": "microhardness",
+                        "source_unit_ids": ["window-source-2"],
+                        "confidence": 0.84,
+                    },
+                ],
+                "confidence": 0.9,
+            }
+        ],
+        "unresolved_signals": [],
+        "evidence_density": "high",
+        "confidence": 0.9,
+        "warnings": [],
+    }
+    client = _FakeOpenAIClient(json.dumps(response))
+    extractor = _objective_extractor(client)
+
+    skim = extractor.extract_paper_skim(
+        {
+            "document_id": "paper-1",
+            "source_units": [
+                {
+                    "source_unit_id": "window-source-1",
+                    "source_kind": "block",
+                    "source_ref": "block-1",
+                    "content": "Laser power was varied and porosity was measured.",
+                },
+                {
+                    "source_unit_id": "window-source-2",
+                    "source_kind": "block",
+                    "source_ref": "block-2",
+                    "content": "Microhardness was also reported.",
+                },
+            ],
+        }
+    )
+
+    assert len(client.chat.completions.calls) == 1
+    assert len(skim.studies) == 1
+    assert [item.outcome for item in skim.studies[0].relationships] == ["porosity"]
+    assert len(skim.unresolved_signals) == 1
+    unresolved = skim.unresolved_signals[0]
+    assert unresolved.signal_type == "outcome"
+    assert unresolved.label == "microhardness"
+    assert unresolved.material_scope == ["316L stainless steel"]
+    assert unresolved.process_context == ["LPBF"]
+    assert unresolved.source_unit_ids == ["window-source-2"]
+
+
 def test_structured_paper_skim_rejects_duplicate_study_identities():
     study = {
         "experiment_label": "LPBF parameter study",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -6513,7 +6513,7 @@ wheels = [
 
 [[package]]
 name = "tsingai-lens"
-version = "0.11.15"
+version = "0.11.16"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.11.15",
+	"version": "0.11.16",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## Summary

- preserve valid PaperSkim relationships when a sibling relationship has no varied factors
- report permanent Source-unit extraction failures as `partial_success` instead of `completed`
- align backend and frontend version surfaces on `0.11.16`

## Verification

- backend: 1008 passed, 10 skipped; the 8 configuration-only failures passed when rerun with `LENS_DATABASE_URL` set (11/11 in the affected files)
- focused Objective/pipeline suite: 160 passed
- frontend unit tests: 133 passed
- frontend production build: passed
- docs governance: passed (31 governed docs, 63 Markdown files)
- `uv lock --check`: passed
- `git diff --check`: passed

## Deployment

- no database migration is required
- no dependency, compose, workflow, or public API schema changes
- stable tag `v0.11.16` will publish versioned backend/frontend images and update `latest` after merge

Refs #310
Refs #323