### PR TITLE
fix: recover missing Evidence comparison axes

### DIFF
--- a/backend/application/core/objectives/README.md
+++ b/backend/application/core/objectives/README.md
@@ -255,12 +255,17 @@ removes such a parameter from `changed_variables` and `comparison.axis_names`.
 When that removal leaves exactly one changed variable from a `joint_effect`
 draft, the backend derives `isolated_effect`; endpoint completeness, comparison
 parity, comparability, and Source grounding remain strict validation
-requirements. A non-empty model result that survives schema validation but
-fails Source grounding receives deterministic field-path errors for unsupported
-variable names, endpoints, units, outcomes, values, result text, or table-row
-bindings. The service permits one additional repair call with the same Objective,
-route, Source, invalid item, and field errors. The model may correct only values
-explicitly present in that Source or abstain; the backend never deletes or
+requirements. Because `comparison.axis_names` repeats the changed-variable
+identity, the adapter restores a missing or empty axis list only when every
+changed variable has a unique non-empty name and complete, distinct endpoints.
+Incomplete variables still enter bounded repair; the backend does not infer an
+axis from domain knowledge. A non-empty model result that survives schema
+validation but fails Source grounding receives deterministic field-path errors
+for unsupported variable names, endpoints, units, outcomes, values, result text,
+or table-row bindings. The service permits one additional repair call with the
+same Objective, route, Source, invalid item, and field errors. The model may
+correct only values explicitly present in that Source or abstain; the backend
+never deletes or
 substitutes scientific values merely to make the item pass. A repaired item goes
 through the complete contract and Source-grounding checks again. A failed repair
 or abstention becomes explicit failed Evidence with the final field-level reason

--- a/backend/application/core/objectives/extraction.py
+++ b/backend/application/core/objectives/extraction.py
@@ -1046,7 +1046,7 @@ class ObjectiveExtractor:
                     raise RuntimeError(
                         "structured extraction returned empty response content"
                     )
-                payload = self._normalize_fixed_objective_evidence_conditions(
+                payload = self._normalize_objective_evidence_payload(
                     load_json_payload(extract_json_object(raw_content))
                 )
                 try:
@@ -1110,7 +1110,7 @@ class ObjectiveExtractor:
         raise RuntimeError("structured extraction failed after repairs") from last_error
 
     @staticmethod
-    def _normalize_fixed_objective_evidence_conditions(payload: Any) -> Any:
+    def _normalize_objective_evidence_payload(payload: Any) -> Any:
         def identical_nonempty_scalar(left: Any, right: Any) -> bool:
             if isinstance(left, bool) or isinstance(right, bool):
                 return type(left) is type(right) and left == right
@@ -1119,6 +1119,36 @@ class ObjectiveExtractor:
             if isinstance(left, str) and isinstance(right, str):
                 return bool(left.strip()) and left == right
             return False
+
+        def complete_changed_variable_names(
+            variables: list[Any],
+        ) -> tuple[str, ...]:
+            def is_complete_scalar(value: Any) -> bool:
+                if isinstance(value, str):
+                    return bool(value.strip())
+                return isinstance(value, (int, float, bool))
+
+            names: list[str] = []
+            seen: set[str] = set()
+            for variable in variables:
+                if not isinstance(variable, Mapping):
+                    return ()
+                name = str(variable.get("name") or "").strip()
+                baseline = variable.get("baseline_value")
+                target = variable.get("target_value")
+                if (
+                    not name
+                    or not is_complete_scalar(baseline)
+                    or not is_complete_scalar(target)
+                    or identical_nonempty_scalar(baseline, target)
+                ):
+                    return ()
+                canonical_name = name.casefold()
+                if canonical_name in seen:
+                    return ()
+                seen.add(canonical_name)
+                names.append(name)
+            return tuple(names)
 
         if not isinstance(payload, Mapping):
             return payload
@@ -1155,11 +1185,9 @@ class ObjectiveExtractor:
                 fixed_names.add(variable_name)
                 changed = True
 
-            if not fixed_names:
-                normalized_extractions.append(extraction)
-                continue
             normalized_extraction = dict(extraction)
-            normalized_extraction["changed_variables"] = changed_variables
+            if fixed_names:
+                normalized_extraction["changed_variables"] = changed_variables
             remaining_variable_names = {
                 str(variable.get("name") or "").strip().casefold()
                 for variable in changed_variables
@@ -1178,6 +1206,25 @@ class ObjectiveExtractor:
                     or str(axis).strip().casefold() in remaining_variable_names
                 ]
                 normalized_extraction["comparison"] = normalized_comparison
+            comparison = normalized_extraction.get("comparison")
+            if isinstance(comparison, Mapping):
+                axis_names = comparison.get("axis_names")
+                missing_axis_names = axis_names is None or (
+                    isinstance(axis_names, list)
+                    and not any(str(axis).strip() for axis in axis_names)
+                )
+                recovered_axis_names = (
+                    complete_changed_variable_names(changed_variables)
+                    if missing_axis_names
+                    else ()
+                )
+                if recovered_axis_names:
+                    normalized_comparison = dict(comparison)
+                    normalized_comparison["axis_names"] = list(
+                        recovered_axis_names
+                    )
+                    normalized_extraction["comparison"] = normalized_comparison
+                    changed = True
             if (
                 extraction.get("attribution_scope") == "joint_effect"
                 and len(changed_variables) == 1

--- a/backend/main.py
+++ b/backend/main.py
@@ -303,7 +303,7 @@ def create_app(
 
     app = FastAPI(
         title="TsingAI-Lens API",
-        version="0.11.16",
+        version="0.11.17",
         docs_url=f"{PUBLIC_API_PREFIX}/docs",
         redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
         openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsingai-lens"
-version = "0.11.16"
+version = "0.11.17"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/backend/tests/unit/services/test_domain_model_extractors.py
+++ b/backend/tests/unit/services/test_domain_model_extractors.py
@@ -3320,6 +3320,99 @@ def test_objective_evidence_normalizes_fixed_endpoint_and_joint_scope_without_re
     assert len(client.chat.completions.calls) == 1
 
 
+def test_objective_evidence_recovers_empty_comparison_axes_from_changed_variables():
+    response = json.dumps(
+        {
+            "extractions": [
+                {
+                    "evidence_role": "direct_result",
+                    "changed_variables": [
+                        {
+                            "name": "laser power",
+                            "baseline_value": 100,
+                            "target_value": 140,
+                            "unit": "W",
+                        }
+                    ],
+                    "comparison": {
+                        "baseline_label": "100 W",
+                        "target_label": "140 W",
+                        "axis_names": [],
+                        "comparable": True,
+                    },
+                    "reported_result": {
+                        "outcome": "relative density",
+                        "value": 98.05,
+                        "unit": "%",
+                        "direction": "increase",
+                        "result_text": "the average density was found to be 98.05%",
+                    },
+                    "attribution_scope": "isolated_effect",
+                    "scientific_context": {},
+                    "resolution_status": "resolved",
+                    "confidence": 0.9,
+                }
+            ]
+        }
+    )
+    client = _FakeOpenAIClient(response)
+    extractor = ObjectiveExtractor(
+        client=client,
+        model="fake-model",
+        extraction_mode="json_text",
+    )
+
+    parsed = extractor.extract_objective_evidence(
+        {
+            "objective": {
+                "question": "How does laser power affect relative density?"
+            },
+            "evidence_route": {
+                "source_kind": "text_window",
+                "source_ref": "block-1",
+            },
+            "source": {
+                "source_kind": "text_window",
+                "source_ref": "block-1",
+                "text": (
+                    "At laser powers of 100 W and 140 W, the average density "
+                    "was found to be 98.05%."
+                ),
+            },
+        }
+    )
+
+    comparison = parsed.extractions[0].comparison
+    assert comparison is not None
+    assert comparison.axis_names == ["laser power"]
+    assert len(client.chat.completions.calls) == 1
+
+
+@pytest.mark.parametrize("baseline_value", (None, "", [], {}))
+def test_objective_evidence_does_not_invent_axes_for_incomplete_variables(
+    baseline_value,
+):
+    payload = {
+        "extractions": [
+            {
+                "changed_variables": [
+                    {
+                        "name": "laser power",
+                        "baseline_value": baseline_value,
+                        "target_value": 140,
+                    }
+                ],
+                "comparison": {"axis_names": []},
+                "attribution_scope": "isolated_effect",
+            }
+        ]
+    }
+
+    normalized = ObjectiveExtractor._normalize_objective_evidence_payload(payload)
+
+    assert normalized == payload
+
+
 @pytest.mark.parametrize(
     ("variable_name", "endpoint"),
     (
@@ -3349,7 +3442,7 @@ def test_objective_evidence_does_not_normalize_invalid_fixed_endpoints(
         ]
     }
 
-    normalized = ObjectiveExtractor._normalize_fixed_objective_evidence_conditions(
+    normalized = ObjectiveExtractor._normalize_objective_evidence_payload(
         payload
     )
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -6513,7 +6513,7 @@ wheels = [
 
 [[package]]
 name = "tsingai-lens"
-version = "0.11.16"
+version = "0.11.17"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.11.16",
+	"version": "0.11.17",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## Summary
- recover an empty Evidence comparison axis from complete changed-variable endpoints
- keep incomplete or ambiguous variable drafts on the existing repair/rejection path
- prepare the immutable v0.11.17 release version surfaces

## Why
A model response can contain a valid changed variable while leaving `comparison.axis_names` empty. The previous whole-response validation rejected that Evidence and prevented Objective analysis from completing.

## Verification
- backend extractor tests: 101 passed
- full backend suite from the fix checkpoint: 1010 passed, 10 skipped; 8 environment-only database failures reran as 11 passed with a temporary database URL
- real merged-qwen extractor call: recovered `axis_names=["laser power"]`
- frontend check: 0 errors and 0 warnings
- frontend unit tests: 133 passed
- frontend production build: passed
- docs governance and lockfile checks: passed

## Compatibility
- no HTTP API changes
- no database migration
- no deployment configuration changes

Refs #316