### PR TITLE
fix: preserve axisless Evidence as descriptive results

### DIFF
--- a/backend/application/core/objectives/README.md
+++ b/backend/application/core/objectives/README.md
@@ -255,7 +255,11 @@ removes such a parameter from `changed_variables` and `comparison.axis_names`.
 When that removal leaves exactly one changed variable from a `joint_effect`
 draft, the backend derives `isolated_effect`; endpoint completeness, comparison
 parity, comparability, and Source grounding remain strict validation
-requirements. Because `comparison.axis_names` repeats the changed-variable
+requirements. When every named variable is fixed, the backend removes the
+comparison and retains the reported result only as `descriptive_only`; normal
+Source-grounding validation still follows, and the backend does not claim an
+experimental effect from unchanged conditions. Because
+`comparison.axis_names` repeats the changed-variable
 identity, the adapter restores a missing or empty axis list only when every
 changed variable has a unique non-empty name and complete, distinct endpoints.
 Incomplete variables still enter bounded repair; the backend does not infer an

--- a/backend/application/core/objectives/extraction.py
+++ b/backend/application/core/objectives/extraction.py
@@ -1225,6 +1225,29 @@ class ObjectiveExtractor:
                     )
                     normalized_extraction["comparison"] = normalized_comparison
                     changed = True
+            comparison = normalized_extraction.get("comparison")
+            comparison_has_no_axes = (
+                isinstance(comparison, Mapping)
+                and isinstance(comparison.get("axis_names"), list)
+                and not any(
+                    str(axis).strip() for axis in comparison["axis_names"]
+                )
+            )
+            if not changed_variables and (
+                fixed_names or comparison_has_no_axes
+            ):
+                normalized_extraction["comparison"] = None
+                if extraction.get("attribution_scope") in {
+                    "isolated_effect",
+                    "joint_effect",
+                    "association_only",
+                }:
+                    normalized_extraction["attribution_scope"] = (
+                        "descriptive_only"
+                        if extraction.get("reported_result") is not None
+                        else "not_attributable"
+                    )
+                changed = True
             if (
                 extraction.get("attribution_scope") == "joint_effect"
                 and len(changed_variables) == 1

--- a/backend/main.py
+++ b/backend/main.py
@@ -303,7 +303,7 @@ def create_app(
 
     app = FastAPI(
         title="TsingAI-Lens API",
-        version="0.11.17",
+        version="0.11.18",
         docs_url=f"{PUBLIC_API_PREFIX}/docs",
         redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
         openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsingai-lens"
-version = "0.11.17"
+version = "0.11.18"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/backend/tests/unit/services/test_domain_model_extractors.py
+++ b/backend/tests/unit/services/test_domain_model_extractors.py
@@ -3388,6 +3388,85 @@ def test_objective_evidence_recovers_empty_comparison_axes_from_changed_variable
     assert len(client.chat.completions.calls) == 1
 
 
+@pytest.mark.parametrize(
+    ("changed_variables", "axis_names"),
+    (
+        (
+            [
+                {
+                    "name": "scan speed",
+                    "baseline_value": 800,
+                    "target_value": 800,
+                    "unit": "mm/s",
+                }
+            ],
+            ["scan speed"],
+        ),
+        ([], []),
+    ),
+    ids=("all-variables-are-fixed", "model-returned-no-axis"),
+)
+def test_objective_evidence_downgrades_axisless_result_to_descriptive_result(
+    changed_variables,
+    axis_names,
+):
+    response = json.dumps(
+        {
+            "extractions": [
+                {
+                    "evidence_role": "direct_result",
+                    "changed_variables": changed_variables,
+                    "comparison": {
+                        "baseline_label": "sample A",
+                        "target_label": "sample B",
+                        "axis_names": axis_names,
+                        "comparable": True,
+                    },
+                    "reported_result": {
+                        "outcome": "porosity",
+                        "value": 1.2,
+                        "unit": "%",
+                        "direction": "unknown",
+                        "result_text": "The measured porosity was 1.2%.",
+                    },
+                    "attribution_scope": "isolated_effect",
+                    "scientific_context": {},
+                    "resolution_status": "resolved",
+                    "confidence": 0.8,
+                }
+            ]
+        }
+    )
+    client = _FakeOpenAIClient(response)
+    extractor = ObjectiveExtractor(
+        client=client,
+        model="fake-model",
+        extraction_mode="json_text",
+    )
+
+    parsed = extractor.extract_objective_evidence(
+        {
+            "objective": {"question": "How does scan speed affect porosity?"},
+            "evidence_route": {
+                "source_kind": "text_window",
+                "source_ref": "block-1",
+            },
+            "source": {
+                "source_kind": "text_window",
+                "source_ref": "block-1",
+                "text": "At 800 mm/s, the measured porosity was 1.2%.",
+            },
+        }
+    )
+
+    extraction = parsed.extractions[0]
+    assert extraction.changed_variables == []
+    assert extraction.comparison is None
+    assert extraction.attribution_scope == "descriptive_only"
+    assert extraction.reported_result is not None
+    assert len(client.chat.completions.calls) == 1
+
+
 @pytest.mark.parametrize("baseline_value", (None, "", [], {}))
 def test_objective_evidence_does_not_invent_axes_for_incomplete_variables(
     baseline_value,

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -6513,7 +6513,7 @@ wheels = [
 
 [[package]]
 name = "tsingai-lens"
-version = "0.11.17"
+version = "0.11.18"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.11.17",
+	"version": "0.11.18",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## Summary

- preserve valid reported Evidence when fixed variables leave no comparison axis
- downgrade axisless effect claims to descriptive results before normal Source grounding
- align backend and frontend version surfaces at `0.11.18`

## Verification

- 925 backend unit tests passed against the isolated PostgreSQL test database
- 133 frontend unit tests passed
- frontend diagnostics reported 0 errors and 0 warnings
- frontend production build completed
- backend lockfile and documentation governance checks passed

## Release

- target tag: `v0.11.18`
- compare from: `v0.11.17`
- stable tag publication remains gated on the release PR and image workflow

Refs #316
