### PR TITLE
chore(release): prepare v0.11.19

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ comparison, not generic paper chat.
 - Evidence before fluent summary.
 - Comparison before isolated paper chat.
 - Traceability before opaque generation.
+- The complete real-world or scientific scenario is the primary reference for
+  every non-trivial behavior. Code structure must follow that scenario rather
+  than inventing a convenient synthetic workflow.
+- Derive domain objects, responsibilities, ordering, states, and failure paths
+  from what real actors do and observe before choosing APIs, prompts, pipeline
+  nodes, persistence shapes, or abstractions.
 - Prefer direct changes to the owning implementation and direct caller updates.
 - Avoid adding layers unless the human explicitly approves them.
 - Keep one authoritative doc path for each contract surface.
@@ -51,6 +57,95 @@ comparison, not generic paper chat.
 - Non-negotiables:
   do not reframe Lens v1 as a generic paper chat product without explicit
   approval.
+
+### Core Logic Reference: Real-World Chain
+
+- Goal:
+  make the implementation a faithful executable model of a coherent real-world
+  process, not a sequence created by existing code, storage, or model APIs.
+- Required reference before implementation:
+  describe one concrete end-to-end scenario with the real actor, trigger,
+  intended decision or outcome, real objects and evidence, ordered actions and
+  state transitions, prerequisites, invariants, uncertainty, alternate and
+  failure paths, and the feedback that starts the next cycle.
+- Mapping rule:
+  map each domain model, service responsibility, pipeline stage, status, and
+  result to a specific part of that scenario. Infrastructure-only concerns may
+  support the chain but may not redefine its domain order or meaning.
+- Research application:
+  for research-facing behavior, use a complete realistic research scenario at
+  the affected scope. While materials science is the proving vertical, the
+  reference actor is a practicing materials researcher working with real
+  materials, processes, measurements, evidence, uncertainty, and follow-up
+  decisions, not an LLM exchanging JSON with backend services.
+- Evidence:
+  an implementation explanation and test can trace the scenario from its real
+  trigger through every affected decision to its observable outcome and next
+  use, including incomplete and failed paths.
+- Failure cost:
+  code-driven workflows, artificial domain objects, reversed prerequisites,
+  meaningless states, or locally correct steps that cannot form a credible
+  end-to-end real process.
+- Non-negotiables:
+  do not accept an implementation whose behavior is justified only by current
+  modules, prompts, schemas, database tables, API payloads, or test fixtures.
+  When code and the real process disagree, surface the mismatch and correct the
+  model or obtain explicit approval for the deviation.
+
+### Worked Example: Derive Logic from Reality
+
+This example demonstrates how to apply the real-world-chain rule. It is not a
+mandatory product pipeline.
+
+Consider a materials researcher determining whether an LPBF process parameter
+affects one alloy's microstructure and deciding what experiment to perform
+next. The complete real-world chain is:
+
+1. Define the actual decision, material scope, target outcome, constraints, and
+   acceptable evidence.
+2. Collect candidate papers. Relevance means a paper should be inspected; it
+   does not mean that the paper already supplies proven evidence.
+3. Reconstruct each real experiment: material and feedstock, process, varied
+   and fixed parameters, samples, post-processing, characterization or test
+   methods, controls, measurements, and uncertainty.
+4. Account for evidence distributed across Methods, tables, captions, and
+   Results, and bind every extracted fact to its Source.
+5. Validate source-local facts before normalizing terminology, units,
+   materials, or process names.
+6. Assemble within-paper relationships only after variables, conditions,
+   controls, and outcomes are supported. Do not turn jointly varied factors
+   into isolated effects.
+7. Compare papers only when material state, process context, methods, test
+   conditions, and outcomes align; otherwise preserve the non-comparability.
+8. Synthesize agreement, contradiction, independent support, limitations, and
+   uncertainty.
+9. Let the expert decide whether the question is answered or whether an
+   evidence gap supports a new hypothesis.
+10. Specify a follow-up experiment with variables, levels, controls, fixed
+    conditions, characterization, repetitions, acceptance criteria,
+    feasibility, and safety.
+11. Treat new experimental results as evidence, compare them with the
+    hypothesis and literature, and begin the next decision cycle.
+
+Implementation consequences:
+
+- Domain models represent real objects, decisions, evidence, and states.
+- Services and nodes follow real responsibilities and prerequisites.
+- Each LLM prompt performs one real judgment or extraction step.
+- Persistence and runtime machinery support the chain but do not define it.
+- Retries, JSON repair, token limits, and provider failures are technical
+  concerns, not scientific states.
+- End-to-end verification follows the initial decision through the result used
+  by the next decision.
+
+Incorrect derivations include:
+
+- treating a relevant paper or Source as proven Evidence;
+- asking an LLM to invent missing Methods data from Results;
+- marking a scientific step complete because valid JSON was returned;
+- ordering nodes for prompt or database convenience against real
+  prerequisites; and
+- adding domain fields only because an API or table needs them.
 
 ### Docs / Enablement
 
@@ -93,7 +188,8 @@ comparison, not generic paper chat.
   `document_profiles -> paper facts family -> comparison_rows /
   evidence_cards -> protocol branch`.
 - Materials science is the first proving vertical, not the permanent product
-  boundary.
+  boundary. It is the concrete real-world reference used to challenge whether
+  research-facing logic forms a credible complete chain.
 - Protocol output is conditional downstream value, not the default Lens v1
   center.
 - Root `docs/` holds shared governance, architecture, contracts, decisions,
@@ -157,8 +253,11 @@ comparison, not generic paper chat.
 
 9. Verify what you touch.
    Why: this repo spans FastAPI, SvelteKit, and governed docs.
-   How: run the smallest relevant checks for the changed surface.
-   Check: the final report names what ran, or says `not run` with the reason.
+   How: run the smallest relevant checks for the changed surface and exercise
+   the affected behavior through one complete concrete real-world scenario.
+   Check: the final report names what ran, the scenario used, how its real steps
+   map to the implementation, and any known deviation; or says `not run` with
+   the reason. Isolated unit success alone does not establish chain correctness.
 
 10. Follow local module AGENTS for module work.
     Why: backend and frontend each have stricter local constraints than the
@@ -233,6 +332,10 @@ comparison, not generic paper chat.
 - Changes must preserve clear ownership and avoid undocumented coupling.
 - Product-facing behavior must stay aligned with the Lens v1 evidence/comparison
   contract unless explicitly re-scoped.
+- Every non-trivial behavior must be explainable as part of a complete real
+  process. Its domain objects, ordering, state transitions, decisions, and
+  failure handling must preserve that process rather than mirror technical
+  call order.
 - Do not leave dead code, obsolete exports, stale links, or redundant branches
   introduced by the task.
 - Final reports must state whether any new abstraction was added, whether it is

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -20,6 +20,12 @@ approval gates, and verification rules.
 
 - Keep backend ownership explicit across `controllers/`, `application/`,
   `domain/`, and `infra/`.
+- Before changing domain or workflow logic, model the complete real scenario at
+  the affected scope and derive backend responsibilities, dependencies, states,
+  and outputs from it.
+- Keep technical execution concepts separate from domain concepts. Retries,
+  tokens, transport payloads, and persistence mechanics must not masquerade as
+  the real process the backend represents.
 - Preserve `/api/*` and `/api/v1/*` behavior unless the human explicitly
   approves a contract change.
 - Keep protocol as a conditional downstream branch, not the primary product
@@ -46,6 +52,47 @@ approval gates, and verification rules.
   prefer correctness and explicit ownership over convenience abstractions.
 - Non-negotiables:
   no breaking contract change without explicit approval.
+
+### Reality-Mapped Backend Logic
+
+Use the root worked example as the reference pattern: first reconstruct the
+complete real scenario, then derive backend models, responsibilities,
+dependencies, states, prompts, and verification from it.
+
+- Goal:
+  make backend behavior an explicit implementation of the root
+  `Core Logic Reference: Real-World Chain` rather than an accidental sequence
+  of service calls.
+- Domain mapping:
+  every domain model represents a real object, observation, decision, or state;
+  every field has a real meaning; every state transition corresponds to an
+  event or decision in the reference scenario.
+- Responsibility mapping:
+  each application service or pipeline node owns one coherent real-world
+  responsibility or one clearly technical execution responsibility. Split code
+  when one component combines unrelated real responsibilities; do not split a
+  single real decision merely to match storage, prompt, or framework boundaries.
+- Dependency mapping:
+  node and service dependencies express real prerequisites. Configuration may
+  select a valid scenario or execution mode, but it may not create an ordering
+  that contradicts the real process.
+- Model mapping:
+  an LLM prompt performs one identifiable judgment or extraction step from the
+  scenario and receives only information legitimately available at that point.
+  Deterministic code owns identity, provenance, invariants, and state changes.
+- State mapping:
+  preserve the distinction between real domain outcomes and technical runtime
+  outcomes. A domain absence, uncertainty, conflict, or abstention is not a
+  timeout, parse failure, retry, or provider error.
+- Verification:
+  test the complete affected scenario from real input through intermediate
+  states to the user- or downstream-visible result, including at least one
+  alternate or failure path. Unit and schema tests supplement but do not replace
+  this chain test.
+- Non-negotiables:
+  do not justify behavior solely because an existing class, endpoint, prompt,
+  table, or node already works that way. If it cannot be mapped coherently to
+  the real scenario, it is misplaced, incomplete, or incorrectly modeled.
 
 ### Data and Runtime State
 
@@ -85,6 +132,9 @@ approval gates, and verification rules.
 - The backend should keep the Lens v1 backbone order
   `document_profiles -> paper facts family -> comparison_rows /
   evidence_cards -> protocol branch`.
+- Treat that backbone as a product boundary, not as proof that a particular
+  domain flow is correct. Each concrete implementation still derives its inner
+  logic and ordering from the complete real scenario it represents.
 - Collection-facing behavior should stay explicit through
   `controllers/source/*`, `controllers/core/*`, `controllers/derived/*`, and
   `controllers/goal/*`.
@@ -120,8 +170,8 @@ approval gates, and verification rules.
    presence.
    How: preserve real semantics for document profiles, evidence cards,
    comparison rows, and protocol artifacts.
-   Check: names, readiness states, and payload fields still match the owning
-   docs.
+   Check: names, readiness states, payload fields, ownership, and transitions
+   match both the owning docs and the real object or decision they represent.
 
 5. Do not add compatibility layers by default.
    Why: backend cleanup slows down when old interfaces linger behind wrappers.
@@ -146,15 +196,19 @@ approval gates, and verification rules.
    Why: backend checks can be expensive, but untouched surfaces should not
    block focused work.
    How: run the smallest relevant backend verification for the changed surface.
-   Check: the final report names the actual command run, or says `not run` with
-   a real blocker.
+   Also run the affected behavior through its complete real-world scenario at
+   the smallest useful scope.
+   Check: the final report names the command, scenario, intermediate states,
+   final outcome, and alternate or failure path, or says `not run` with a real
+   blocker.
 
 9. Keep error semantics explicit.
    Why: collection workflows need diagnosable failures and recoverable client
    behavior.
    How: return meaningful status and structured failure information at trust
-   boundaries.
-   Check: changed failure paths stay interpretable in tests, code, or docs.
+   boundaries. Keep domain outcomes distinct from technical execution failures.
+   Check: changed failure paths stay interpretable in tests, code, or docs and
+   map to a real event or decision in the reference scenario.
 
 10. Avoid hidden persistence coupling.
     Why: persistence changes can silently break artifact readers and task flows.
@@ -222,6 +276,11 @@ approval gates, and verification rules.
 - Backend diffs must preserve ownership clarity and contract readability.
 - Docs, schemas, and tests should move with real backend behavior when the task
   changes them.
+- Non-trivial backend behavior must map coherently from a complete real scenario
+  to domain concepts, responsibilities, dependencies, states, and outputs.
+- A green parser, HTTP response, pipeline status, or mocked test is useful
+  operational evidence but is insufficient proof that the real chain is modeled
+  correctly.
 - Final reports must state whether any new abstraction was added, whether it is
   temporary or permanent, and what cleanup was performed.
 

--- a/backend/application/core/objectives/README.md
+++ b/backend/application/core/objectives/README.md
@@ -66,7 +66,16 @@ Objective analysis.
   steel grade spellings have one deterministic material identity. A relationship
   with missing material scope may join a known-material group only when exactly
   one scientifically compatible group exists; it cannot bridge conflicting
-  materials. Process,
+  materials. The resulting Objective retains one unambiguous material anchor;
+  an ambiguous or absent shared scope stays empty and is explained in its
+  reason. Objective confidence is the minimum available non-zero confidence
+  from its source studies and relationships. It remains zero only when no
+  source provides confidence, which is also recorded in the reason. A broad
+  label with one measurement interpretation is refined deterministically, while
+  a generic multi-measurement property family such as `mechanical properties`
+  receives a rejection disposition until a specific outcome is available.
+  Established research outcomes such as fatigue strength or microstructure stay
+  intact rather than being replaced with an invented sub-measurement. Process,
   sample, test, comparator, design, and fixed-condition differences remain on
   each `PaperStudy`; they do not fragment a candidate Objective because later
   Evidence and Comparison own scientific comparability. For a multi-document

--- a/backend/application/core/objectives/objective_candidate_service.py
+++ b/backend/application/core/objectives/objective_candidate_service.py
@@ -494,16 +494,56 @@ class ObjectiveCandidateService:
             for relationship_id in relationship_ids
         )
         variables = relationships[0].varied_factors
-        outcome = relationships[0].outcome
+        source_outcome = relationships[0].outcome
+        outcome_expansions = property_matching.broad_outcome_expansions(
+            source_outcome
+        )
+        normalized_outcome = property_matching.normalize_property_label(
+            source_outcome
+        )
+        if (
+            len(outcome_expansions) > 1
+            and normalized_outcome is not None
+            and normalized_outcome.rsplit(" ", 1)[-1] in {"property", "properties"}
+        ):
+            return (
+                None,
+                f"Outcome '{source_outcome}' requires a specific measurable outcome "
+                "before it can seed a research objective.",
+            )
+        outcome = (
+            outcome_expansions[0]
+            if len(outcome_expansions) == 1
+            else source_outcome
+        )
+        confidence = self._objective_confidence(studies, relationships)
+        material_scope = self._shared_study_values(studies, "material_scope")
+        material_scope_was_missing = any(
+            not self._known_material_keys(study.material_scope) for study in studies
+        )
+        reason_parts = [
+            "Supported by one backend-compatible relationship group.",
+            (
+                "Confidence is the minimum available non-zero source confidence."
+                if confidence > 0
+                else "No source supplied a non-zero confidence."
+            ),
+        ]
+        if not material_scope:
+            reason_parts.append(
+                "No unambiguous shared material scope was available."
+            )
+        elif material_scope_was_missing:
+            reason_parts.append(
+                "Material scope was retained from the unambiguous non-conflicting "
+                "source anchor."
+            )
         objective_payload = {
             "collection_id": collection_id,
             "question": self._objective_question(variables, outcome),
             "variables": list(variables),
             "outcomes": [outcome],
-            "material_scope": self._shared_study_values(
-                studies,
-                "material_scope",
-            ),
+            "material_scope": material_scope,
             "mechanisms": [],
             "constraints": self._shared_study_constraints(
                 studies,
@@ -515,11 +555,8 @@ class ObjectiveCandidateService:
             ),
             "seed_document_ids": seed_document_ids,
             "source_relationship_ids": list(relationship_ids),
-            "confidence": min(
-                min(study.confidence for study in studies),
-                min(relationship.confidence for relationship in relationships),
-            ),
-            "reason": "Supported by one backend-compatible relationship group.",
+            "confidence": confidence,
+            "reason": " ".join(reason_parts),
         }
         try:
             return ResearchObjective.from_mapping(objective_payload), None
@@ -579,7 +616,24 @@ class ObjectiveCandidateService:
             tuple(getattr(study, field_name))
             for study in studies
         ]
-        if not values_by_study or any(not values for values in values_by_study):
+        material_scope_was_missing = False
+        if field_name == "material_scope":
+            values_by_study = [
+                tuple(
+                    value
+                    for value in values
+                    if self._known_material_scalar(value) is not None
+                )
+                for values in values_by_study
+            ]
+            material_scope_was_missing = any(
+                not values for values in values_by_study
+            )
+            values_by_study = [values for values in values_by_study if values]
+        if not values_by_study or (
+            field_name != "material_scope"
+            and any(not values for values in values_by_study)
+        ):
             return []
 
         def values_match(left: str, right: str) -> bool:
@@ -591,7 +645,7 @@ class ObjectiveCandidateService:
             )
 
         first, *remaining = values_by_study
-        return self._unique_axis_values(
+        shared_values = self._unique_axis_values(
             value
             for value in first
             if all(
@@ -602,6 +656,28 @@ class ObjectiveCandidateService:
                 for values in remaining
             )
         )
+        if field_name == "material_scope" and material_scope_was_missing:
+            shared_materials = {
+                self._known_material_scalar(value) for value in shared_values
+            }
+            if len(shared_materials) != 1:
+                return []
+        return shared_values
+
+    @staticmethod
+    def _objective_confidence(
+        studies: tuple[PaperStudy, ...],
+        relationships: tuple[PaperStudyRelationship, ...],
+    ) -> float:
+        available = tuple(
+            confidence
+            for confidence in (
+                *(study.confidence for study in studies),
+                *(relationship.confidence for relationship in relationships),
+            )
+            if confidence > 0
+        )
+        return min(available, default=0.0)
 
     def _shared_study_constraints(
         self,

--- a/backend/application/core/objectives/property_matching.py
+++ b/backend/application/core/objectives/property_matching.py
@@ -217,7 +217,7 @@ def normalize_property_label(value: Any) -> str | None:
     return _PROPERTY_LABEL_ALIASES.get(normalized, normalized)
 
 
-def _expand_broad_outcome(value: Any) -> tuple[str, ...]:
+def broad_outcome_expansions(value: Any) -> tuple[str, ...]:
     normalized = normalize_property_label(value)
     if not normalized:
         return ()
@@ -231,7 +231,7 @@ def objective_outcomes(objective: ResearchObjective) -> tuple[str, ...]:
         normalized = normalize_property_label(axis)
         if normalized:
             _append_unique_axis(axes, seen, normalized)
-            for expanded in _expand_broad_outcome(normalized):
+            for expanded in broad_outcome_expansions(normalized):
                 _append_unique_axis(axes, seen, expanded)
         else:
             _append_unique_axis(axes, seen, axis)
@@ -250,7 +250,7 @@ def property_matches_target_axes(
         return True
     return any(
         property_label_matches_target(expanded_axis, target_axes=target_axes)
-        for expanded_axis in _expand_broad_outcome(normalized)
+        for expanded_axis in broad_outcome_expansions(normalized)
     )
 
 
@@ -308,7 +308,7 @@ def objective_method_families(
         normalized = normalize_property_label(axis)
         if not normalized:
             continue
-        for property_name in (normalized, *_expand_broad_outcome(normalized)):
+        for property_name in (normalized, *broad_outcome_expansions(normalized)):
             family = _method_family_for_property(property_name)
             if family is not None:
                 families.append(family)
@@ -359,7 +359,7 @@ def source_text_mentions_axis(text: str, axis: str) -> bool:
         return True
     return any(
         _source_text_mentions_single_axis(text, expanded_axis)
-        for expanded_axis in _expand_broad_outcome(axis)
+        for expanded_axis in broad_outcome_expansions(axis)
     )
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -303,7 +303,7 @@ def create_app(
 
     app = FastAPI(
         title="TsingAI-Lens API",
-        version="0.11.18",
+        version="0.11.19",
         docs_url=f"{PUBLIC_API_PREFIX}/docs",
         redoc_url=f"{PUBLIC_API_PREFIX}/redoc",
         openapi_url=f"{PUBLIC_API_PREFIX}/openapi.json",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsingai-lens"
-version = "0.11.18"
+version = "0.11.19"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/backend/tests/unit/application/test_objective_candidate_service.py
+++ b/backend/tests/unit/application/test_objective_candidate_service.py
@@ -164,13 +164,155 @@ def test_missing_material_and_one_known_anchor_build_cross_paper_objective():
 
     assert len(facts.research_objectives) == 1
     objective = facts.research_objectives[0]
-    assert objective.material_scope == ()
+    assert objective.material_scope == ("316L stainless steel",)
     assert set(objective.seed_document_ids) == {"paper-known", "paper-missing"}
     assert set(objective.source_relationship_ids) == {
         "relationship-known",
         "relationship-missing",
     }
     assert {item.status.value for item in facts.study_dispositions} == {"promoted"}
+
+
+def test_missing_material_does_not_inherit_an_ambiguous_multi_material_scope():
+    skims = (
+        _paper_skim(
+            document_id="paper-multi-material",
+            relationship_id="relationship-known",
+            material_scope=("316L stainless steel", "Ti-6Al-4V"),
+        ),
+        _paper_skim(
+            document_id="paper-missing",
+            relationship_id="relationship-missing",
+            material_scope=(),
+        ),
+    )
+
+    facts = ObjectiveCandidateService().discover_candidate_facts(
+        "collection-test",
+        paper_skims=skims,
+        extractor=_GroupingExtractor(),
+    )
+
+    assert len(facts.research_objectives) == 1
+    objective = facts.research_objectives[0]
+    assert objective.material_scope == ()
+    assert objective.reason is not None
+    assert (
+        "No unambiguous shared material scope was available" in objective.reason
+    )
+
+
+def test_missing_confidence_does_not_erase_supported_objective_confidence():
+    skims = (
+        _paper_skim(
+            document_id="paper-study-confidence-missing",
+            relationship_id="relationship-known",
+            study_confidence=0.0,
+            relationship_confidence=0.86,
+        ),
+        _paper_skim(
+            document_id="paper-relationship-confidence-missing",
+            relationship_id="relationship-missing",
+            study_confidence=0.82,
+            relationship_confidence=0.0,
+        ),
+    )
+
+    facts = ObjectiveCandidateService().discover_candidate_facts(
+        "collection-test",
+        paper_skims=skims,
+        extractor=_GroupingExtractor(),
+    )
+
+    assert len(facts.research_objectives) == 1
+    assert facts.research_objectives[0].confidence == pytest.approx(0.82)
+
+
+def test_all_missing_confidence_remains_zero_with_an_explicit_reason():
+    skims = (
+        _paper_skim(
+            document_id="paper-a",
+            relationship_id="relationship-a",
+            study_confidence=0.0,
+            relationship_confidence=0.0,
+        ),
+        _paper_skim(
+            document_id="paper-b",
+            relationship_id="relationship-b",
+            study_confidence=0.0,
+            relationship_confidence=0.0,
+        ),
+    )
+
+    facts = ObjectiveCandidateService().discover_candidate_facts(
+        "collection-test",
+        paper_skims=skims,
+        extractor=_GroupingExtractor(),
+    )
+
+    assert len(facts.research_objectives) == 1
+    objective = facts.research_objectives[0]
+    assert objective.confidence == 0.0
+    assert objective.reason is not None
+    assert "No source supplied a non-zero confidence" in objective.reason
+
+
+def test_broad_outcome_group_is_rejected_until_the_outcome_is_specific():
+    skims = (
+        _paper_skim(
+            document_id="paper-a",
+            relationship_id="relationship-a",
+            outcome="mechanical properties",
+        ),
+        _paper_skim(
+            document_id="paper-b",
+            relationship_id="relationship-b",
+            outcome="mechanical properties",
+        ),
+    )
+
+    facts = ObjectiveCandidateService().discover_candidate_facts(
+        "collection-test",
+        paper_skims=skims,
+        extractor=_GroupingExtractor(),
+    )
+
+    assert facts.research_objectives == ()
+    assert {item.status.value for item in facts.study_dispositions} == {"rejected"}
+    assert all(
+        "requires a specific measurable outcome" in (item.reason or "")
+        for item in facts.study_dispositions
+    )
+
+
+def test_single_measurement_broad_outcome_is_refined_for_the_candidate():
+    skims = (
+        _paper_skim(
+            document_id="paper-a",
+            relationship_id="relationship-a",
+            outcome="densification",
+        ),
+        _paper_skim(
+            document_id="paper-b",
+            relationship_id="relationship-b",
+            outcome="densification",
+        ),
+    )
+
+    facts = ObjectiveCandidateService().discover_candidate_facts(
+        "collection-test",
+        paper_skims=skims,
+        extractor=_GroupingExtractor(),
+    )
+
+    assert len(facts.research_objectives) == 1
+    objective = facts.research_objectives[0]
+    assert objective.question == "How does laser power affect relative density?"
+    assert objective.outcomes == ("relative density",)
+    assert set(objective.source_relationship_ids) == {
+        "relationship-a",
+        "relationship-b",
+    }
 
 
 def test_material_grade_word_order_does_not_fragment_relationship_groups():
@@ -1174,6 +1316,8 @@ def _paper_skim(
     design_type: str = "experimental",
     claim_scope: str = "current_work",
     comparator: str | None = "low versus high setting",
+    study_confidence: float = 0.92,
+    relationship_confidence: float = 0.9,
     extra_relationships: tuple[dict[str, Any], ...] = (),
 ) -> PaperSkim:
     return PaperSkim.from_mapping(
@@ -1203,11 +1347,11 @@ def _paper_skim(
                                     "source_ref": f"{document_id}-results",
                                 }
                             ],
-                            "confidence": 0.9,
+                            "confidence": relationship_confidence,
                         },
                         *extra_relationships,
                     ],
-                    "confidence": 0.92,
+                    "confidence": study_confidence,
                 }
             ],
             "evidence_density": "high",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -6513,7 +6513,7 @@ wheels = [
 
 [[package]]
 name = "tsingai-lens"
-version = "0.11.18"
+version = "0.11.19"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.11.18",
+	"version": "0.11.19",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/collections/[id]/objectives/+page.svelte
+++ b/frontend/src/routes/collections/[id]/objectives/+page.svelte
@@ -6,12 +6,15 @@
 	import {
 		confirmObjective,
 		fetchCollectionObjectives,
+		fetchObjectiveAnalysis,
 		runObjectiveAnalysis,
+		type ObjectiveAnalysisState,
 		type ObjectiveList,
 		type ObjectiveSummary
 	} from '../../../_shared/researchView';
 
 	let objectiveList: ObjectiveList | null = null;
+	let analysisStates: Record<string, ObjectiveAnalysisState | null> = {};
 	let loading = false;
 	let actionObjectiveId = '';
 	let error = '';
@@ -35,12 +38,70 @@
 		error = '';
 		try {
 			objectiveList = await fetchCollectionObjectives(collectionId);
+			await refreshActiveAnalysisStates();
 		} catch (err) {
 			objectiveList = null;
+			analysisStates = {};
 			error = errorMessage(err);
 		} finally {
 			loading = false;
 		}
+	}
+
+	async function refreshActiveAnalysisStates() {
+		const currentList = objectiveList;
+		if (!currentList) return;
+		const activeObjectives = currentList.objectives.filter(
+			(objective) =>
+				objective.active_analysis_version !== null &&
+				objective.active_analysis_version !== objective.published_analysis_version
+		);
+		if (!activeObjectives.length) {
+			analysisStates = {};
+			return;
+		}
+
+		const states = await Promise.all(
+			activeObjectives.map(async (objective) => {
+				try {
+					const snapshot = await fetchObjectiveAnalysis(collectionId, objective.objective_id);
+					return [objective.objective_id, snapshot.active_analysis] as const;
+				} catch {
+					return [objective.objective_id, null] as const;
+				}
+			})
+		);
+		analysisStates = Object.fromEntries(states);
+	}
+
+	function analysisStatus(objective: ObjectiveSummary) {
+		return analysisStates[objective.objective_id]?.status ?? null;
+	}
+
+	function statusLabel(objective: ObjectiveSummary) {
+		const active = analysisStates[objective.objective_id];
+		if (active?.status === 'queued') return '等待分析';
+		if (active?.status === 'running') {
+			return active.total_document_count > 0
+				? `分析中 · ${active.processed_document_count}/${active.total_document_count}`
+				: '分析中';
+		}
+		if (active?.status === 'failed') return '分析失败';
+		if (objective.published_analysis_version !== null) {
+			return `结果 v${objective.published_analysis_version}`;
+		}
+		if (objective.active_analysis_version !== null) return '分析已启动';
+		return objective.confirmation_status === 'confirmed' ? '已确认' : '待确认';
+	}
+
+	function canStartAnalysis(objective: ObjectiveSummary) {
+		return objective.active_analysis_version === null || analysisStatus(objective) === 'failed';
+	}
+
+	function actionLabel(objective: ObjectiveSummary) {
+		if (actionObjectiveId === objective.objective_id) return '正在启动...';
+		if (analysisStatus(objective) === 'failed') return '重试分析';
+		return objective.confirmation_status === 'candidate' ? '确认并分析' : '开始分析';
 	}
 
 	function objectiveHref(objectiveId: string) {
@@ -104,12 +165,11 @@
 							<h3>{objective.question}</h3>
 							<p>{objective.requested_comparator || '尚未设置比较意图'}</p>
 						</div>
-						<span class:published={objective.published_analysis_version !== null}>
-							{objective.published_analysis_version !== null
-								? `结果 v${objective.published_analysis_version}`
-								: objective.confirmation_status === 'confirmed'
-									? '已确认'
-									: '待确认'}
+						<span
+							class:published={objective.published_analysis_version !== null}
+							class:failed={analysisStatus(objective) === 'failed'}
+						>
+							{statusLabel(objective)}
 						</span>
 					</div>
 					<dl>
@@ -139,14 +199,14 @@
 						</div>
 					</dl>
 					<div class="actions">
-						{#if objective.published_analysis_version === null}
+						{#if canStartAnalysis(objective)}
 							<button
 								class="btn btn--primary btn--small"
 								type="button"
 								disabled={Boolean(actionObjectiveId)}
 								on:click={() => startAnalysis(objective)}
 							>
-								{actionObjectiveId === objective.objective_id ? '正在启动...' : '确认并分析'}
+								{actionLabel(objective)}
 							</button>
 						{/if}
 						<a class="btn btn--ghost btn--small" href={objectiveHref(objective.objective_id)}>
@@ -245,6 +305,10 @@
 	.heading > span.published {
 		border-color: #3a7d5d;
 		color: #256346;
+	}
+	.heading > span.failed {
+		border-color: var(--danger, #b42318);
+		color: var(--danger, #b42318);
 	}
 	dl {
 		margin: 0;

--- a/frontend/src/routes/collections/[id]/objectives/objectives-page.svelte.spec.ts
+++ b/frontend/src/routes/collections/[id]/objectives/objectives-page.svelte.spec.ts
@@ -202,9 +202,7 @@ describe('collections/[id]/objectives/+page.svelte', () => {
 		await expect
 			.element(browserPage.getByRole('button', { name: '确认并分析' }))
 			.not.toBeInTheDocument();
-		await expect
-			.element(browserPage.getByRole('link', { name: '查看状态' }))
-			.toBeInTheDocument();
+		await expect.element(browserPage.getByRole('link', { name: '查看状态' })).toBeInTheDocument();
 	});
 
 	it('shows the published version without a second result lookup', async () => {

--- a/frontend/src/routes/collections/[id]/objectives/objectives-page.svelte.spec.ts
+++ b/frontend/src/routes/collections/[id]/objectives/objectives-page.svelte.spec.ts
@@ -76,6 +76,29 @@ function objective(overrides: Record<string, unknown> = {}) {
 	};
 }
 
+function analysisState(status: 'queued' | 'running' | 'succeeded' | 'failed') {
+	return {
+		collection_id: 'col_123',
+		objective_id: 'obj_heat_strength',
+		analysis_version: 1,
+		source_build_id: 'build-1',
+		pipeline_version: 'objective-analysis-v1',
+		model_name: null,
+		prompt_versions: {},
+		status,
+		phase: status === 'running' ? 'evidence_extraction' : status,
+		processed_document_count: status === 'running' ? 2 : 0,
+		total_document_count: 6,
+		current_document_id: status === 'running' ? 'paper-2' : null,
+		progress_message: status === 'running' ? 'Extracting evidence.' : null,
+		error_code: null,
+		error_message: null,
+		created_at: null,
+		started_at: null,
+		completed_at: null
+	};
+}
+
 describe('collections/[id]/objectives/+page.svelte', () => {
 	beforeEach(() => {
 		setPage({
@@ -142,6 +165,46 @@ describe('collections/[id]/objectives/+page.svelte', () => {
 			});
 			expect(goto).toHaveBeenCalledWith('/collections/col_123/objectives/obj_heat_strength');
 		});
+	});
+
+	it('shows active analysis progress instead of offering confirmation again', async () => {
+		fetchMock.mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+			const current = request(input, init);
+			if (current.path.endsWith('/objectives') && current.method === 'GET') {
+				return jsonResponse({
+					collection_id: 'col_123',
+					objectives: [
+						objective({
+							confirmation_status: 'confirmed',
+							active_analysis_version: 1
+						})
+					]
+				});
+			}
+			if (current.path.endsWith('/obj_heat_strength/analysis') && current.method === 'GET') {
+				return jsonResponse({
+					collection_id: 'col_123',
+					objective: objective({
+						confirmation_status: 'confirmed',
+						active_analysis_version: 1
+					}),
+					active_analysis: analysisState('running'),
+					published_analysis: null,
+					warnings: []
+				});
+			}
+			throw new Error(`unexpected request: ${current.method} ${current.path}`);
+		});
+
+		render(Page);
+
+		await expect.element(browserPage.getByText('分析中 · 2/6')).toBeInTheDocument();
+		await expect
+			.element(browserPage.getByRole('button', { name: '确认并分析' }))
+			.not.toBeInTheDocument();
+		await expect
+			.element(browserPage.getByRole('link', { name: '查看状态' }))
+			.toBeInTheDocument();
 	});
 
 	it('shows the published version without a second result lookup', async () => {


### PR DESCRIPTION
## Summary

- preserve concrete material scope and supported confidence in cross-paper Objective candidates
- refine single-measurement broad outcomes and reject ambiguous property-family candidates
- show queued, running, and failed Objective analysis state without offering duplicate starts
- require non-trivial implementation logic to map to a complete real scientific or operational chain
- align backend and frontend version surfaces at `0.11.19`

## Verification

- 930 backend unit tests passed
- 134 frontend unit tests passed
- frontend diagnostics reported 0 errors and 0 warnings
- frontend production build completed
- Alembic reports the single head `20260814_0030`
- backend lockfile and documentation governance checks passed
- release candidate worktree is clean and contains no whitespace errors

## Release gates

- target tag: `v0.11.19`
- compare from: `v0.11.18`
- stable tag publication remains gated on merge and the release image workflow
- the candidate six-paper model replay is not yet rerun because `localhost:8008/v1/models` currently returns HTTP 502
- #330 remains an explicit known scientific-quality gap: valid cross-section Evidence can still be classified as `extraction_failed` by single-Source grounding
- deployment defaults remain unchanged

Closes #322
Refs #305
Refs #259
Refs #330
